### PR TITLE
ConfigGateway - IPv4Gateway NullReferenceException during launch fixed.

### DIFF
--- a/Source/NETworkManager/ViewModels/Applications/NetworkInterfaceViewModel.cs
+++ b/Source/NETworkManager/ViewModels/Applications/NetworkInterfaceViewModel.cs
@@ -144,7 +144,8 @@ namespace NETworkManager.ViewModels.Applications
                         ConfigEnableStaticIPAddress = true;
                         ConfigIPAddress = value.IPv4Address.FirstOrDefault().ToString();
                         ConfigSubnetmaskOrCidr = value.Subnetmask.FirstOrDefault().ToString();
-                        ConfigGateway = value.IPv4Gateway.FirstOrDefault().ToString();
+                        if (value.IPv4Gateway.FirstOrDefault() != null)
+                            ConfigGateway = value.IPv4Gateway.FirstOrDefault().ToString();
                     }
 
                     if (value.DNSAutoconfigurationEnabled)

--- a/Source/NETworkManager/ViewModels/Applications/NetworkInterfaceViewModel.cs
+++ b/Source/NETworkManager/ViewModels/Applications/NetworkInterfaceViewModel.cs
@@ -144,8 +144,7 @@ namespace NETworkManager.ViewModels.Applications
                         ConfigEnableStaticIPAddress = true;
                         ConfigIPAddress = value.IPv4Address.FirstOrDefault().ToString();
                         ConfigSubnetmaskOrCidr = value.Subnetmask.FirstOrDefault().ToString();
-                        if (value.IPv4Gateway.FirstOrDefault() != null)
-                            ConfigGateway = value.IPv4Gateway.FirstOrDefault().ToString();
+                        ConfigGateway = (value.IPv4Gateway == null) ? value.IPv4Gateway.ToString() : string.Empty;
                     }
 
                     if (value.DNSAutoconfigurationEnabled)


### PR DESCRIPTION
When there is no gateway given in network adapter IPv4 settings, application crush during launch without any error message.
![nogateway](https://user-images.githubusercontent.com/33267255/32325579-31c3dd7e-bfd8-11e7-824e-71e1ebbf6af4.JPG)
![nullreferenceexception](https://user-images.githubusercontent.com/33267255/32325580-31e53b18-bfd8-11e7-8aca-6b15f78f10ee.JPG)

 