### PR TITLE
Fix app crash if MAC address is empty, return empty string

### DIFF
--- a/Source/NETworkManager.Converters/PhysicalAddressToStringConverter.cs
+++ b/Source/NETworkManager.Converters/PhysicalAddressToStringConverter.cs
@@ -10,7 +10,12 @@ namespace NETworkManager.Converters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return value == null ? string.Empty : MACAddressHelper.GetDefaultFormat((PhysicalAddress)value);
+            if (!(value is PhysicalAddress physicalAddress))
+                return string.Empty;
+
+            string macAddress = physicalAddress.ToString();
+
+            return string.IsNullOrEmpty(macAddress) ? string.Empty : MACAddressHelper.GetDefaultFormat(macAddress);
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)


### PR DESCRIPTION
Fixes #458

**Please provide some details about this pull request:**
- Since this https://github.com/BornToBeRoot/NETworkManager/issues/375, network interfaces from type 53 are displayed
- Sometimes they don't have a mac address and the app crashes


---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/master/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/master/Contributors.md) list or don't want to.
- [x] The code or ressource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/master/LICENSE).