### PR TITLE
IPv4 address regex for extract fixed

### DIFF
--- a/Source/NETworkManager.Utilities/RegexHelper.cs
+++ b/Source/NETworkManager.Utilities/RegexHelper.cs
@@ -8,7 +8,7 @@ namespace NETworkManager.Utilities
         /// <summary>
         /// Match an IPv4-Address like 192.168.178.1
         /// </summary>
-        private const string IPv4AddressValues = @"(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])";
+        private const string IPv4AddressValues = @"((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)";
 
         /// <summary>
         /// Match exactly an IPv4-Address like 192.168.178.1 

--- a/docs/04_Changelog.md
+++ b/docs/04_Changelog.md
@@ -8,6 +8,7 @@ permalink: /Changelog
 
 <!--
 ## What's new?
+- Dashbaord - Regex for IPv4 fixed  [#841](https://github.com/BornToBeRoot/NETworkManager/issues/841){:target="_blank"}
 - Network Interface - Remove IPv4 address added [#212](https://github.com/BornToBeRoot/NETworkManager/issues/212){:target="_blank"}
 - IP Scanner - Custom commands fixed [2e53b292f1dca7808fed509aa9ac39e009a3030f](https://github.com/BornToBeRoot/NETworkManager/commit/2e53b292f1dca7808fed509aa9ac39e009a3030f){:target="_blank"}
 -->


### PR DESCRIPTION
Fixes #841

**Please provide some details about this pull request:**
- IPv4 regex replaced
-
-


---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/master/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/master/Contributors.md) list or don't want to.
- [x] The code or ressource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/master/LICENSE).