### PR TITLE
Fix CryptoStream does not read to EOF

### DIFF
--- a/Source/NETworkManager.Utilities/CryptoHelper.cs
+++ b/Source/NETworkManager.Utilities/CryptoHelper.cs
@@ -81,7 +81,20 @@ namespace NETworkManager.Utilities
             using var cryptoStream = new CryptoStream(memoryStream, decryptor, CryptoStreamMode.Read);
 
             var text = new byte[cipher.Length];
-            cryptoStream.Read(text, 0, text.Length);
+
+            //cryptoStream.Read(text, 0, text.Length);
+            // Fix for issue: https://github.com/dotnet/runtime/issues/61535
+
+            int readBytes = 0;
+            while (readBytes < text.Length)
+            {
+                int n = cryptoStream.Read(text, readBytes, text.Length - readBytes);
+
+                if (n == 0)
+                    break;
+
+                readBytes += n;
+            }
 
             memoryStream.Close();
             cryptoStream.Close();


### PR DESCRIPTION
Fixes #{Replace this with the issue number}

**Please provide some details about this pull request:**
-
-
-


---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/master/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/master/Contributors.md) list or don't want to.
- [x] The code or ressource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/master/LICENSE).