### PR TITLE
Use msbuild instead of dotnet for build

### DIFF
--- a/Source/NETworkManager/NETworkManager.csproj
+++ b/Source/NETworkManager/NETworkManager.csproj
@@ -19,6 +19,7 @@
 		<PackageIcon>NETworkManager.ico</PackageIcon>
 		<SatelliteResourceLanguages>en</SatelliteResourceLanguages>
 		<Description>A powerful tool for managing networks and troubleshoot network problems!</Description>
+		<PlatformTarget>x64</PlatformTarget>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Remove="NETworkManager.ico" />
@@ -34,9 +35,7 @@
 	</ItemGroup>
 	<!-- Target 6.0.0 for compatibility https://github.com/dotnet/core/issues/7176 -->
 	<ItemGroup>
-		<FrameworkReference
-		Update="Microsoft.WindowsDesktop.App;Microsoft.WindowsDesktop.App.WPF;Microsoft.WindowsDesktop.App.WindowsForms"
-		TargetingPackVersion="6.0.0" />
+		<FrameworkReference Update="Microsoft.WindowsDesktop.App;Microsoft.WindowsDesktop.App.WPF;Microsoft.WindowsDesktop.App.WindowsForms" TargetingPackVersion="6.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="AirspaceFixer" Version="1.0.5" />

--- a/cleanup.ps1
+++ b/cleanup.ps1
@@ -1,6 +1,8 @@
 foreach($path in Get-ChildItem -Path "$PSScriptRoot\Source\" -Directory)
 {
-    "bin","obj" | ForEach-Object {        
-        Remove-Item "$path\$_" -Recurse -Force
+    "bin","obj" | ForEach-Object {
+        if(Test-Path -Path "$path\$_" -PathType Container) {
+            Remove-Item -Path "$path\$_" -Recurse -Force
+        }
     }
 }

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -44,6 +44,7 @@ permalink: /Changelog/next-release
 - Visibility of the min/max/close button on the pulled out window fixed [#1366](https://github.com/BornToBeRoot/NETworkManager/pull/1366){:target="_blank"}
 - App crash when building with SDK .NET 6.0.2 and running the app on 6.0.0 or 6.0.1 fixed [#1236](https://github.com/BornToBeRoot/NETworkManager/pull/1236){:target="_blank"} [#1381](https://github.com/BornToBeRoot/NETworkManager/issues/1381){:target="_blank"}
 - App crash when renaming a profile file fixed [#1318](https://github.com/BornToBeRoot/NETworkManager/issues/1318){:target="_blank"}
+- Language `zh-CN` and `zh-TW` is missing in dotnet publish. Build script changed from `dotnet` to `msbuild` [#1316](https://github.com/BornToBeRoot/NETworkManager/issues/1316){:target="_blank"}
 - Remote Desktop 
   - Connection via Profile leads to error message "Error Code 4 (Total login limit was reached)" fixed [#1265](https://github.com/BornToBeRoot/NETworkManager/issues/1265){:target="_blank"}
 - PuTTY


### PR DESCRIPTION
Fixes #1316 

**Please provide some details about this pull request:**
- Replace dotnet with msbuild
-
-


---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/master/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/master/Contributors.md) list or don't want to.
- [x] The code or ressource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/master/LICENSE).