### PR TITLE
Try to fix #1425 by unloading the profile first

### DIFF
--- a/Source/NETworkManager.Profiles/ProfileManager.cs
+++ b/Source/NETworkManager.Profiles/ProfileManager.cs
@@ -446,6 +446,10 @@ namespace NETworkManager.Profiles
             ProfilesChanged = false;
         }
 
+        /// <summary>
+        /// Method to unload the currently loaded profile file.
+        /// </summary>
+        /// <param name="saveLoadedProfiles">Save loaded profile file (default is true)</param>
         public static void Unload(bool saveLoadedProfiles = true)
         {
             if (saveLoadedProfiles && LoadedProfileFile != null && ProfilesChanged)
@@ -456,6 +460,11 @@ namespace NETworkManager.Profiles
             Reset();
         }
 
+        /// <summary>
+        /// Method to switch to another profile file.
+        /// </summary>
+        /// <param name="info">New <see cref="ProfileFileInfo"/> to load.</param>
+        /// <param name="saveLoadedProfiles">Save loaded profile file (defualt is true)</param>
         public static void Switch(ProfileFileInfo info, bool saveLoadedProfiles = true)
         {
             Unload(saveLoadedProfiles);

--- a/Source/NETworkManager.Profiles/ProfileManager.cs
+++ b/Source/NETworkManager.Profiles/ProfileManager.cs
@@ -207,7 +207,7 @@ namespace NETworkManager.Profiles
 
             if (switchProfile)
             {
-                SwitchProfile(newProfileFileInfo, false);
+                Switch(newProfileFileInfo, false);
                 LoadedProfileFileChanged(LoadedProfileFile);
             }
 
@@ -223,7 +223,7 @@ namespace NETworkManager.Profiles
         {
             if (LoadedProfileFile != null && LoadedProfileFile.Equals(profileFileInfo))
             {
-                SwitchProfile(ProfileFiles.FirstOrDefault(x => !x.Equals(profileFileInfo)));
+                Switch(ProfileFiles.FirstOrDefault(x => !x.Equals(profileFileInfo)));
                 LoadedProfileFileChanged(LoadedProfileFile);
             }
 
@@ -271,7 +271,7 @@ namespace NETworkManager.Profiles
             // Switch profile, if it was previously loaded
             if (switchProfile)
             {
-                SwitchProfile(newProfileFileInfo, false);
+                Switch(newProfileFileInfo, false);
                 LoadedProfileFileChanged(LoadedProfileFile);
             }
 
@@ -322,7 +322,7 @@ namespace NETworkManager.Profiles
             // Switch profile, if it was previously loaded
             if (switchProfile)
             {
-                SwitchProfile(newProfileFileInfo, false);
+                Switch(newProfileFileInfo, false);
                 LoadedProfileFileChanged(LoadedProfileFile);
             }
 
@@ -363,7 +363,7 @@ namespace NETworkManager.Profiles
             // Switch profile, if it was previously loaded
             if (switchProfile)
             {
-                SwitchProfile(newProfileFileInfo, false);
+                Switch(newProfileFileInfo, false);
                 LoadedProfileFileChanged(LoadedProfileFile);
             }
 
@@ -446,12 +446,19 @@ namespace NETworkManager.Profiles
             ProfilesChanged = false;
         }
 
-        public static void SwitchProfile(ProfileFileInfo info, bool saveLoadedProfiles = true)
+        public static void Unload(bool saveLoadedProfiles = true)
         {
             if (saveLoadedProfiles && LoadedProfileFile != null && ProfilesChanged)
                 Save();
 
+            LoadedProfileFile = null;
+
             Reset();
+        }
+
+        public static void Switch(ProfileFileInfo info, bool saveLoadedProfiles = true)
+        {
+            Unload(saveLoadedProfiles);
 
             Load(info);
         }

--- a/Source/NETworkManager/MainWindow.xaml.cs
+++ b/Source/NETworkManager/MainWindow.xaml.cs
@@ -1024,6 +1024,8 @@ namespace NETworkManager
                 {
                     await this.HideMetroDialogAsync(customDialog).ConfigureAwait(false);
 
+                    ProfileManager.Unload();
+
                     IsProfileFileLocked = true;
                 });
 
@@ -1044,7 +1046,7 @@ namespace NETworkManager
         {
             try
             {
-                ProfileManager.SwitchProfile(info);
+                ProfileManager.Switch(info);
 
                 IsProfileFileLocked = false;
             }

--- a/Source/NETworkManager/ViewModels/DNSLookupHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/DNSLookupHostViewModel.cs
@@ -345,7 +345,10 @@ namespace NETworkManager.ViewModels
             if (!_isViewActive)
                 return;
 
-            Profiles.Refresh();
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(delegate
+            {
+                Profiles.Refresh();
+            }));
         }
 
         public void OnProfileDialogOpen()

--- a/Source/NETworkManager/ViewModels/IPScannerHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/IPScannerHostViewModel.cs
@@ -350,7 +350,10 @@ namespace NETworkManager.ViewModels
             if (!_isViewActive)
                 return;
 
-            Profiles.Refresh();
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(delegate
+            {
+                Profiles.Refresh();
+            }));
         }
         
         public void OnProfileDialogOpen()

--- a/Source/NETworkManager/ViewModels/NetworkInterfaceViewModel.cs
+++ b/Source/NETworkManager/ViewModels/NetworkInterfaceViewModel.cs
@@ -1155,7 +1155,10 @@ namespace NETworkManager.ViewModels
             if (!_isViewActive)
                 return;
 
-            Profiles.Refresh();
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(delegate
+            {
+                Profiles.Refresh();
+            }));
         }
 
         public void OnProfileDialogOpen()

--- a/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
@@ -474,6 +474,7 @@ namespace NETworkManager.ViewModels
         {
             if (!_isViewActive)
                 return;
+                
             Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(delegate
             {
                 Profiles.Refresh();

--- a/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
@@ -474,8 +474,10 @@ namespace NETworkManager.ViewModels
         {
             if (!_isViewActive)
                 return;
-
-            Profiles.Refresh();
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(delegate
+            {
+                Profiles.Refresh();
+            }));
         }
 
         public void OnProfileDialogOpen()

--- a/Source/NETworkManager/ViewModels/PortScannerHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PortScannerHostViewModel.cs
@@ -350,7 +350,10 @@ namespace NETworkManager.ViewModels
             if (!_isViewActive)
                 return;
 
-            Profiles.Refresh();
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(delegate
+            {
+                Profiles.Refresh();
+            }));
         }
 
         public void OnProfileDialogOpen()

--- a/Source/NETworkManager/ViewModels/PowerShellHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PowerShellHostViewModel.cs
@@ -475,7 +475,10 @@ namespace NETworkManager.ViewModels
             if (!_isViewActive)
                 return;
 
-            Profiles.Refresh();
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(delegate
+            {
+                Profiles.Refresh();
+            }));
         }
 
         public void OnProfileDialogOpen()

--- a/Source/NETworkManager/ViewModels/ProfilesViewModel.cs
+++ b/Source/NETworkManager/ViewModels/ProfilesViewModel.cs
@@ -11,6 +11,7 @@ using System.Windows.Threading;
 using NETworkManager.Profiles;
 using NETworkManager.Settings;
 using System.Diagnostics;
+using System.Windows;
 
 namespace NETworkManager.ViewModels
 {

--- a/Source/NETworkManager/ViewModels/ProfilesViewModel.cs
+++ b/Source/NETworkManager/ViewModels/ProfilesViewModel.cs
@@ -270,8 +270,11 @@ namespace NETworkManager.ViewModels
                 SetGroupView();
             }
 
-            Groups?.Refresh();
-            Profiles?.Refresh();
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(delegate
+            {
+                Groups?.Refresh();
+                Profiles?.Refresh();
+            }));
         }
 
         public void OnProfileDialogOpen()

--- a/Source/NETworkManager/ViewModels/PuTTYHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PuTTYHostViewModel.cs
@@ -579,7 +579,10 @@ namespace NETworkManager.ViewModels
             if (!_isViewActive)
                 return;
 
-            Profiles.Refresh();
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(delegate
+            {
+                Profiles.Refresh();
+            }));
         }
 
         public void OnProfileDialogOpen()

--- a/Source/NETworkManager/ViewModels/RemoteDesktopHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/RemoteDesktopHostViewModel.cs
@@ -560,7 +560,10 @@ namespace NETworkManager.ViewModels
             if (!_isViewActive)
                 return;
 
-            Profiles.Refresh();
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(delegate
+            {
+                Profiles.Refresh();
+            }));
         }
 
         public void OnProfileDialogOpen()

--- a/Source/NETworkManager/ViewModels/TigerVNCHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/TigerVNCHostViewModel.cs
@@ -483,7 +483,10 @@ namespace NETworkManager.ViewModels
             if (!_isViewActive)
                 return;
 
-            Profiles.Refresh();
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(delegate
+            {
+                Profiles.Refresh();
+            }));
         }
 
         public void OnProfileDialogOpen()

--- a/Source/NETworkManager/ViewModels/TracerouteHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/TracerouteHostViewModel.cs
@@ -350,7 +350,10 @@ namespace NETworkManager.ViewModels
             if (!_isViewActive)
                 return;
 
-            Profiles.Refresh();
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(delegate
+            {
+                Profiles.Refresh();
+            }));
         }
 
         public void OnProfileDialogOpen()

--- a/Source/NETworkManager/ViewModels/WakeOnLANViewModel.cs
+++ b/Source/NETworkManager/ViewModels/WakeOnLANViewModel.cs
@@ -465,7 +465,10 @@ namespace NETworkManager.ViewModels
             if (!_isViewActive)
                 return;
 
-            Profiles.Refresh();
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(delegate
+            {
+                Profiles.Refresh();
+            }));
         }
 
         public void OnProfileDialogOpen()

--- a/Source/NETworkManager/ViewModels/WebConsoleHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/WebConsoleHostViewModel.cs
@@ -457,7 +457,10 @@ namespace NETworkManager.ViewModels
             if (!_isViewActive)
                 return;
 
-            Profiles.Refresh();
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(delegate
+            {
+                Profiles.Refresh();
+            }));
         }
 
         public void OnProfileDialogOpen()

--- a/Source/NETworkManager/ViewModels/WhoisHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/WhoisHostViewModel.cs
@@ -347,7 +347,10 @@ namespace NETworkManager.ViewModels
             if (!_isViewActive)
                 return;
 
-            Profiles.Refresh();
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(delegate
+            {
+                Profiles.Refresh();
+            }));
         }
 
         public void OnProfileDialogOpen()

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -21,7 +21,7 @@ permalink: /Changelog/next-release
 - Profile migration dialog improved [#1393](https://github.com/BornToBeRoot/NETworkManager/pull/1393){:target="_blank"}
 
 ## Bugfixes
-- 
+- Fixed some rare cases where the profile file was overwritten [#1495](https://github.com/BornToBeRoot/NETworkManager/pull/1425){:target="_blank"}
 
 ## Other
 - Language files updated [#transifex](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Ftransifex-integration){:target="_blank"}


### PR DESCRIPTION
Fixes #1425

**Please provide some details about this pull request:**
- Unload profile file when switching to an encrypted profile file
-
-


---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/master/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/master/Contributors.md) list or don't want to.
- [x] The code or ressource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/master/LICENSE).