### PR TITLE
Fix: App crash when profile file is deleted #1508

### DIFF
--- a/Source/NETworkManager/MainWindow.xaml.cs
+++ b/Source/NETworkManager/MainWindow.xaml.cs
@@ -409,6 +409,7 @@ namespace NETworkManager
             _isProfileLoading = false;
 
             ProfileManager.OnLoadedProfileFileChangedEvent += ProfileManager_OnLoadedProfileFileChangedEvent;
+            ProfileManager.OnSwitchProfileFileViaUIEvent += ProfileManager_OnSwitchProfileFileViaUIEvent;
 
             SelectedProfileFile = ProfileFiles.SourceCollection.Cast<ProfileFileInfo>().FirstOrDefault(x => x.Name == SettingsManager.Current.Profiles_LastSelected);
 
@@ -1026,14 +1027,14 @@ namespace NETworkManager
 
                 var credentialsPasswordViewModel = new CredentialsPasswordViewModel(async instance =>
                 {
-                    await this.HideMetroDialogAsync(customDialog).ConfigureAwait(true);
+                    await this.HideMetroDialogAsync(customDialog);
 
                     info.Password = instance.Password;
 
                     SwitchProfile(info);
                 }, async instance =>
                 {
-                    await this.HideMetroDialogAsync(customDialog).ConfigureAwait(false);
+                    await this.HideMetroDialogAsync(customDialog);
 
                     ProfileManager.Unload();
 
@@ -1045,7 +1046,7 @@ namespace NETworkManager
                     DataContext = credentialsPasswordViewModel
                 };
 
-                await this.ShowMetroDialogAsync(customDialog).ConfigureAwait(false);
+                await this.ShowMetroDialogAsync(customDialog);
             }
             else
             {
@@ -1109,6 +1110,16 @@ namespace NETworkManager
             SelectedProfileFile = ProfileFiles.SourceCollection.Cast<ProfileFileInfo>().FirstOrDefault(x => x.Equals(e.ProfileFileInfo));
 
             _isProfileUpdating = false;
+        }
+
+        /// <summary>
+        /// Switch the profile from code behind via UI to get the password for encrypted files.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void ProfileManager_OnSwitchProfileFileViaUIEvent(object sender, ProfileFileInfoArgs e)
+        {
+            SelectedProfileFile = ProfileFiles.SourceCollection.Cast<ProfileFileInfo>().FirstOrDefault(x => x.Equals(e.ProfileFileInfo));
         }
         #endregion
 

--- a/Source/NETworkManager/ViewModels/ProfilesViewModel.cs
+++ b/Source/NETworkManager/ViewModels/ProfilesViewModel.cs
@@ -177,7 +177,7 @@ namespace NETworkManager.ViewModels
             };
 
             // Select first profile, or the last selected profile
-                SelectedProfile = Profiles.SourceCollection.Cast<ProfileInfo>().OrderBy(x => x.Name).FirstOrDefault();
+            SelectedProfile = Profiles.SourceCollection.Cast<ProfileInfo>().OrderBy(x => x.Name).FirstOrDefault();
 
             SelectedProfiles = new List<ProfileInfo> { SelectedProfile }; // Fix --> Count need to be 1 for EditProfile_CanExecute
         }

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -23,6 +23,8 @@ permalink: /Changelog/next-release
 ## Bugfixes
 - Dashboard / Status Window
   - Handle null exception properly [#1510](https://github.com/BornToBeRoot/NETworkManager/pull/1510){:target="\_blank"}
+- Settings > Profiles
+  - App crash fixed when a profile file is deleted and an encrypted but locked profile file is selected [#1512](https://github.com/BornToBeRoot/NETworkManager/pull/1512){:target="\_blank"}
 
 ## Other
 - Language files updated [#transifex](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Ftransifex-integration){:target="_blank"}


### PR DESCRIPTION
Fixes #1508 

**Please provide some details about this pull request:**
- Fix app crash when deleting a profile file and a encrypted (locked) profile file is selected


---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or ressource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).