### PR TITLE
Feature: Set focus to embedded window when application got focus

### DIFF
--- a/Source/NETworkManager.Utilities/NativeMethods.cs
+++ b/Source/NETworkManager.Utilities/NativeMethods.cs
@@ -43,6 +43,9 @@ namespace NETworkManager.Utilities
         #endregion
 
         #region Pinvoke/Win32 Methods
+        [DllImport("user32.dll")]
+        public static extern IntPtr GetForegroundWindow();
+
         [DllImport("user32.dll", SetLastError = true)]
         public static extern long SetParent(IntPtr hWndChild, IntPtr hWndParent);
 
@@ -72,6 +75,9 @@ namespace NETworkManager.Utilities
 
         [DllImport("user32.dll")]
         public static extern bool ShowWindow(IntPtr hWnd, WindowShowStyle nCmdShow);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern bool SetForegroundWindow(IntPtr hWnd);
         #endregion
     }
 }

--- a/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml
+++ b/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml
@@ -11,7 +11,7 @@
         xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
         xmlns:wpfHelpers="clr-namespace:NETworkManager.Utilities.WPF;assembly=NETworkManager.Utilities.WPF"
         mc:Ignorable="d"
-        Style="{DynamicResource DefaultWindow}" MinWidth="800" Width="1024" Height="768" MinHeight="600" TitleAlignment="Left"
+        Style="{DynamicResource DefaultWindow}" MinWidth="800" Width="1024" Height="768" MinHeight="600" TitleAlignment="Left" Activated="MetroWindow_Activated"
         d:DataContext="{d:DesignInstance controls:DragablzTabHostWindow}">
     <mah:MetroWindow.WindowButtonCommands>
         <mah:WindowButtonCommands Template="{DynamicResource MahApps.Templates.WindowButtonCommands.Win10}" />

--- a/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
+++ b/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
@@ -10,6 +10,7 @@ using NETworkManager.Models.RemoteDesktop;
 using MahApps.Metro.Controls.Dialogs;
 using NETworkManager.Localization.Translators;
 using NETworkManager.Models;
+using System.Threading.Tasks;
 
 namespace NETworkManager.Controls
 {
@@ -278,15 +279,35 @@ namespace NETworkManager.Controls
         #endregion
         #endregion
 
+        private async void FocusEmbeddedWindow()
+        {
+            // Delay the focus to prevent blocking the ui
+            do
+            {
+                await Task.Delay(250);
+            } while (Mouse.LeftButton == MouseButtonState.Pressed);
+
+            // Switch by name
+            switch (ApplicationName)
+            {
+                case ApplicationName.PowerShell:
+                    ((PowerShellControl)((DragablzTabItem)TabsContainer?.SelectedItem)?.View)?.FocusEmbeddedWindow();
+                    break;
+                case ApplicationName.PuTTY:
+                    ((PuTTYControl)((DragablzTabItem)TabsContainer?.SelectedItem)?.View)?.FocusEmbeddedWindow();
+                    break;
+            }
+        }
+
         #region Events
         private void SettingsManager_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-        }
-        #endregion
 
+        }
         private void MetroWindow_Activated(object sender, EventArgs e)
         {
-            
+            FocusEmbeddedWindow();
         }
+        #endregion
     }
 }

--- a/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
+++ b/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
@@ -10,7 +10,6 @@ using NETworkManager.Models.RemoteDesktop;
 using MahApps.Metro.Controls.Dialogs;
 using NETworkManager.Localization.Translators;
 using NETworkManager.Models;
-using System.Threading.Tasks;
 
 namespace NETworkManager.Controls
 {
@@ -284,5 +283,10 @@ namespace NETworkManager.Controls
         {
         }
         #endregion
+
+        private void MetroWindow_Activated(object sender, EventArgs e)
+        {
+            
+        }
     }
 }

--- a/Source/NETworkManager/Controls/PowerShellControl.xaml.cs
+++ b/Source/NETworkManager/Controls/PowerShellControl.xaml.cs
@@ -157,7 +157,7 @@ namespace NETworkManager.Controls
                             if (IntPtr.Zero != _appWin)
                                 break;
 
-                            await Task.Delay(50);
+                            await Task.Delay(100);
                         }
                     }
 

--- a/Source/NETworkManager/Controls/PowerShellControl.xaml.cs
+++ b/Source/NETworkManager/Controls/PowerShellControl.xaml.cs
@@ -170,7 +170,9 @@ namespace NETworkManager.Controls
                         
                         IsConnected = true;
 
-                        // Resize embedded application & refresh       
+                        // Resize embedded application & refresh
+                        // Requires a short delay because it's not applied immediately
+                        await Task.Delay(250);
                         ResizeEmbeddedWindow();
                     }
                 }
@@ -202,6 +204,12 @@ namespace NETworkManager.Controls
         {
             // This happens when the user exit the process
             IsConnected = false;
+        }
+
+        public void FocusEmbeddedWindow()
+        {
+            if (IsConnected)
+                NativeMethods.SetForegroundWindow(_process.MainWindowHandle);
         }
 
         public void ResizeEmbeddedWindow()

--- a/Source/NETworkManager/Controls/PowerShellControl.xaml.cs
+++ b/Source/NETworkManager/Controls/PowerShellControl.xaml.cs
@@ -37,8 +37,6 @@ namespace NETworkManager.Controls
         private Process _process;
         private IntPtr _appWin;
 
-        private readonly DispatcherTimer _resizeTimer = new DispatcherTimer();
-
         private bool _isConnected;
         public bool IsConnected
         {
@@ -77,9 +75,6 @@ namespace NETworkManager.Controls
             _dialogCoordinator = DialogCoordinator.Instance;
 
             _sessionInfo = info;
-
-            _resizeTimer.Tick += ResizeTimer_Tick;
-            _resizeTimer.Interval = new TimeSpan(0, 0, 0, 0, 500);
 
             Dispatcher.ShutdownStarted += Dispatcher_ShutdownStarted;
         }
@@ -217,7 +212,7 @@ namespace NETworkManager.Controls
 
         public void Disconnect()
         {
-            if (_process != null && !_process.HasExited)
+            if (IsConnected)
                 _process.Kill();
         }
 
@@ -240,15 +235,8 @@ namespace NETworkManager.Controls
         #region Events
         private void WindowGrid_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            if (_process != null)
+            if (IsConnected)
                 ResizeEmbeddedWindow();
-        }
-
-        private void ResizeTimer_Tick(object sender, EventArgs e)
-        {
-            _resizeTimer.Stop();
-
-            ResizeEmbeddedWindow();
         }
         #endregion
     }

--- a/Source/NETworkManager/Controls/PuTTYControl.xaml.cs
+++ b/Source/NETworkManager/Controls/PuTTYControl.xaml.cs
@@ -38,8 +38,6 @@ namespace NETworkManager.Controls
         private Process _process;
         private IntPtr _appWin;
 
-        private readonly DispatcherTimer _resizeTimer = new DispatcherTimer();
-
         private bool _isConnected;
         public bool IsConnected
         {
@@ -78,9 +76,6 @@ namespace NETworkManager.Controls
             _dialogCoordinator = DialogCoordinator.Instance;
 
             _sessionInfo = info;
-
-            _resizeTimer.Tick += ResizeTimer_Tick;
-            _resizeTimer.Interval = new TimeSpan(0, 0, 0, 0, 500);
 
             Dispatcher.ShutdownStarted += Dispatcher_ShutdownStarted;
         }
@@ -160,7 +155,7 @@ namespace NETworkManager.Controls
                             if (IntPtr.Zero != _appWin)
                                 break;
 
-                            await Task.Delay(50);
+                            await Task.Delay(100);
                         }
                     }
 
@@ -168,7 +163,7 @@ namespace NETworkManager.Controls
                     {
                         while (!_process.HasExited && _process.MainWindowTitle.IndexOf(" - PuTTY", StringComparison.Ordinal) == -1)
                         {
-                            await Task.Delay(50);
+                            await Task.Delay(100);
 
                             _process.Refresh();
                         }
@@ -189,7 +184,7 @@ namespace NETworkManager.Controls
 
                             // Resize embedded application & refresh
                             // Requires a short delay because it'S not applied immediately
-                            await Task.Delay(500);
+                            await Task.Delay(250);
                                                         
                             ResizeEmbeddedWindow();
                         }
@@ -225,6 +220,12 @@ namespace NETworkManager.Controls
             IsConnected = false;
         }
 
+        public void FocusEmbeddedWindow()
+        {
+            if (IsConnected)
+                NativeMethods.SetForegroundWindow(_process.MainWindowHandle);
+        }
+
         public void ResizeEmbeddedWindow()
         {
             if (IsConnected)
@@ -233,7 +234,7 @@ namespace NETworkManager.Controls
 
         public void Disconnect()
         {
-            if (_process != null && !_process.HasExited)
+            if (IsConnected)
                 _process.Kill();
         }
 
@@ -262,15 +263,8 @@ namespace NETworkManager.Controls
         #region Events
         private void WindowGrid_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            if (_process != null)
+            if (IsConnected)
                 ResizeEmbeddedWindow();
-        }
-
-        private void ResizeTimer_Tick(object sender, EventArgs e)
-        {
-            _resizeTimer.Stop();
-
-            ResizeEmbeddedWindow();
         }
         #endregion
     }

--- a/Source/NETworkManager/Controls/PuTTYControl.xaml.cs
+++ b/Source/NETworkManager/Controls/PuTTYControl.xaml.cs
@@ -183,7 +183,7 @@ namespace NETworkManager.Controls
                             IsConnected = true;
 
                             // Resize embedded application & refresh
-                            // Requires a short delay because it'S not applied immediately
+                            // Requires a short delay because it's not applied immediately
                             await Task.Delay(250);
                                                         
                             ResizeEmbeddedWindow();

--- a/Source/NETworkManager/Controls/RemoteDesktopControl.xaml.cs
+++ b/Source/NETworkManager/Controls/RemoteDesktopControl.xaml.cs
@@ -456,7 +456,7 @@ namespace NETworkManager.Controls
 
             do // Prevent to many requests
             {
-                await Task.Delay(500);
+                await Task.Delay(250);
 
             } while (Mouse.LeftButton == MouseButtonState.Pressed);
 

--- a/Source/NETworkManager/Controls/TightVNCControl.xaml.cs
+++ b/Source/NETworkManager/Controls/TightVNCControl.xaml.cs
@@ -226,6 +226,12 @@ namespace NETworkManager.Controls
             IsConnected = false;
         }
 
+        public void FocusEmbeddedWindow()
+        {
+            if (IsConnected)
+                NativeMethods.SetForegroundWindow(_process.MainWindowHandle);
+        }
+
         private void ResizeEmbeddedWindow()
         {
             if (IsConnected)

--- a/Source/NETworkManager/Controls/TightVNCControl.xaml.cs
+++ b/Source/NETworkManager/Controls/TightVNCControl.xaml.cs
@@ -37,8 +37,6 @@ namespace NETworkManager.Controls
         private Process _process;
         private IntPtr _appWin;
 
-        private readonly DispatcherTimer _resizeTimer = new DispatcherTimer();
-
         private bool _isConnected;
         public bool IsConnected
         {
@@ -77,9 +75,6 @@ namespace NETworkManager.Controls
             _dialogCoordinator = DialogCoordinator.Instance;
 
             _sessionInfo = info;
-
-            _resizeTimer.Tick += ResizeTimer_Tick;
-            _resizeTimer.Interval = new TimeSpan(0, 0, 0, 0, 500);
 
             Dispatcher.ShutdownStarted += Dispatcher_ShutdownStarted;
         }
@@ -239,7 +234,7 @@ namespace NETworkManager.Controls
 
         public void Disconnect()
         {
-            if (_process != null && !_process.HasExited)
+            if (IsConnected)
                 _process.Kill();
         }
 
@@ -262,15 +257,8 @@ namespace NETworkManager.Controls
         #region Events
         private void TigerVNCGrid_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            if (_process != null)
+            if (IsConnected)
                 ResizeEmbeddedWindow();
-        }
-
-        private void ResizeTimer_Tick(object sender, EventArgs e)
-        {
-            _resizeTimer.Stop();
-
-            ResizeEmbeddedWindow();
         }
         #endregion
     }

--- a/Source/NETworkManager/Controls/TightVNCControl.xaml.cs
+++ b/Source/NETworkManager/Controls/TightVNCControl.xaml.cs
@@ -140,18 +140,6 @@ namespace NETworkManager.Controls
 
                         while ((DateTime.Now - startTime).TotalSeconds < 10)
                         {
-                            // Fix for netcore3.1 https://stackoverflow.com/questions/60342879/process-mainwindowhandle-is-non-zero-in-net-framework-but-zero-in-net-core-unl
-                            /*
-                            try
-                            {
-                                _process = Process.GetProcessById(_process.Id);
-                            }
-                            catch
-                            {
-                                break; // Process has exited
-                            }
-                            */
-
                             _process.Refresh();
 
                             if (_process.HasExited)
@@ -192,7 +180,9 @@ namespace NETworkManager.Controls
 
                             IsConnected = true;
 
-                            // Resize embedded application & refresh       
+                            // Resize embedded application & refresh
+                            // Requires a short delay because it's not applied immediately
+                            await Task.Delay(250);
                             ResizeEmbeddedWindow();
                         }
                     }
@@ -207,10 +197,10 @@ namespace NETworkManager.Controls
                 if (!_closing)
                 {
                     var settings = AppearanceManager.MetroDialog;
-                    settings.AffirmativeButtonText = NETworkManager.Localization.Resources.Strings.OK;
+                    settings.AffirmativeButtonText = Localization.Resources.Strings.OK;
                     ConfigurationManager.Current.FixAirspace = true;
 
-                    await _dialogCoordinator.ShowMessageAsync(this, NETworkManager.Localization.Resources.Strings.Error,
+                    await _dialogCoordinator.ShowMessageAsync(this, Localization.Resources.Strings.Error,
                         ex.Message, MessageDialogStyle.Affirmative, settings);
 
                     ConfigurationManager.Current.FixAirspace = false;
@@ -224,12 +214,6 @@ namespace NETworkManager.Controls
         {
             // This happens when the user exit the process
             IsConnected = false;
-        }
-
-        public void FocusEmbeddedWindow()
-        {
-            if (IsConnected)
-                NativeMethods.SetForegroundWindow(_process.MainWindowHandle);
         }
 
         private void ResizeEmbeddedWindow()

--- a/Source/NETworkManager/Controls/TightVNCControl.xaml.cs
+++ b/Source/NETworkManager/Controls/TightVNCControl.xaml.cs
@@ -167,7 +167,7 @@ namespace NETworkManager.Controls
                             if (IntPtr.Zero != _appWin)
                                 break;
 
-                            await Task.Delay(50);
+                            await Task.Delay(100);
                         }
                     }
 
@@ -175,7 +175,7 @@ namespace NETworkManager.Controls
                     {
                         while (!_process.HasExited && _process.MainWindowTitle.IndexOf(" - TigerVNC", StringComparison.Ordinal) == -1)
                         {
-                            await Task.Delay(50);
+                            await Task.Delay(100);
 
                             _process.Refresh();
                         }

--- a/Source/NETworkManager/MainWindow.xaml
+++ b/Source/NETworkManager/MainWindow.xaml
@@ -12,7 +12,7 @@
         xmlns:resources="clr-namespace:NETworkManager.Properties"
         xmlns:networkManager="clr-namespace:NETworkManager"
         mc:Ignorable="d"
-        Style="{DynamicResource DefaultWindow}" MinWidth="800" Width="1024" Height="768" MinHeight="600" SaveWindowPosition="True" TitleAlignment="Left" Closing="MetroWindowMain_Closing" StateChanged="MetroWindowMain_StateChanged"
+        Style="{DynamicResource DefaultWindow}" MinWidth="800" Width="1024" Height="768" MinHeight="600" Activated="MetroMainWindow_Activated" SaveWindowPosition="True" TitleAlignment="Left" Closing="MetroWindowMain_Closing" StateChanged="MetroWindowMain_StateChanged"
         d:DataContext="{d:DesignInstance networkManager:MainWindow}">
     <!-- MetroDialogStyles.xaml must be adjusted if MinWidth/MinHeight is changed -->
     <Window.Resources>
@@ -103,7 +103,7 @@
                         <TextBlock Text="{x:Static localization:Strings.UnlockProfile}" Style="{StaticResource LinkTextBlock}" Margin="5,0" />
                     </StackPanel>
                 </Button>
-                <ComboBox ItemsSource="{Binding ProfileFiles}" SelectedItem="{Binding SelectedProfileFile, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Background="{DynamicResource MahApps.Brushes.Gray8}" BorderThickness="0" MinWidth="100" HorizontalAlignment="Left" Margin="0,0,10,0">
+                <ComboBox ItemsSource="{Binding ProfileFiles}" SelectedItem="{Binding SelectedProfileFile, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Background="{DynamicResource MahApps.Brushes.Gray8}" IsDropDownOpen="{Binding IsProfileFileDropDownOpened}" BorderThickness="0" MinWidth="100" HorizontalAlignment="Left" Margin="0,0,10,0">
                     <ComboBox.ItemTemplate>
                         <DataTemplate>
                             <Grid>

--- a/Source/NETworkManager/MainWindow.xaml
+++ b/Source/NETworkManager/MainWindow.xaml
@@ -309,11 +309,11 @@
                                     </Style>
                                 </TextBox.Style>
                                 <interactivity:Interaction.Triggers>
-                                    <interactivity:EventTrigger EventName="GotKeyboardFocus">
-                                        <interactivity:InvokeCommandAction Command="{Binding TextBoxSearchGotKeyboardFocusCommand}" />
+                                    <interactivity:EventTrigger EventName="GotFocus">
+                                        <interactivity:InvokeCommandAction Command="{Binding TextBoxSearchGotFocusCommand}" />
                                     </interactivity:EventTrigger>
-                                    <interactivity:EventTrigger EventName="LostKeyboardFocus">
-                                        <interactivity:InvokeCommandAction Command="{Binding TextBoxSearchLostKeyboardFocusCommand}" />
+                                    <interactivity:EventTrigger EventName="LostFocus">
+                                        <interactivity:InvokeCommandAction Command="{Binding TextBoxSearchLostFocusCommand}" />
                                     </interactivity:EventTrigger>
                                 </interactivity:Interaction.Triggers>
                             </TextBox>

--- a/Source/NETworkManager/MainWindow.xaml.cs
+++ b/Source/NETworkManager/MainWindow.xaml.cs
@@ -1441,22 +1441,22 @@ namespace NETworkManager
             IsMouseOverApplicationList = false;
         }
 
-        public ICommand TextBoxSearchGotKeyboardFocusCommand
+        public ICommand TextBoxSearchGotFocusCommand
         {
-            get { return new RelayCommand(p => TextBoxSearchGotKeyboardFocusAction()); }
+            get { return new RelayCommand(p => TextBoxSearchGotFocusAction()); }
         }
 
-        private void TextBoxSearchGotKeyboardFocusAction()
+        private void TextBoxSearchGotFocusAction()
         {
             IsTextBoxSearchFocused = true;
         }
 
-        public ICommand TextBoxSearchLostKeyboardFocusCommand
+        public ICommand TextBoxSearchLostFocusCommand
         {
-            get { return new RelayCommand(p => TextBoxSearchLostKeyboardFocusAction()); }
+            get { return new RelayCommand(p => TextBoxSearchLostFocusAction()); }
         }
 
-        private void TextBoxSearchLostKeyboardFocusAction()
+        private void TextBoxSearchLostFocusAction()
         {
             if (!IsMouseOverApplicationList)
                 IsApplicationListOpen = false;

--- a/Source/NETworkManager/MainWindow.xaml.cs
+++ b/Source/NETworkManager/MainWindow.xaml.cs
@@ -1509,7 +1509,7 @@ namespace NETworkManager
             } while (Mouse.LeftButton == MouseButtonState.Pressed);
 
             /* Don't continue if
-               - Appplication is not set
+               - Application is not set
                - Settings are opened
                - Profile file drop down is opened
                - Application search textbox is opened

--- a/Source/NETworkManager/MainWindow.xaml.cs
+++ b/Source/NETworkManager/MainWindow.xaml.cs
@@ -1500,7 +1500,7 @@ namespace NETworkManager
         }
         #endregion
 
-        private async void RefocusEmbeddedWindow()
+        private async void FocusEmbeddedWindow()
         {
             // Delay the focus to prevent blocking the ui
             do
@@ -1532,12 +1532,7 @@ namespace NETworkManager
 
         private void MetroMainWindow_Activated(object sender, EventArgs e)
         {
-            RefocusEmbeddedWindow();
-        }
-
-        private void ComboBox_DropDownOpened(object sender, EventArgs e)
-        {
-
+            FocusEmbeddedWindow();
         }
     }
 }

--- a/Source/NETworkManager/MainWindow.xaml.cs
+++ b/Source/NETworkManager/MainWindow.xaml.cs
@@ -291,6 +291,20 @@ namespace NETworkManager
             }
         }
 
+        private bool _isProfileFileDropDownOpened;
+        public bool IsProfileFileDropDownOpened
+        {
+            get => _isProfileFileDropDownOpened;
+            set
+            {
+                if (value == _isProfileFileDropDownOpened)
+                    return;
+
+                _isProfileFileDropDownOpened = value;
+                OnPropertyChanged();
+            }
+        }
+
         private bool _isProfileFileLocked;
         public bool IsProfileFileLocked
         {
@@ -367,7 +381,7 @@ namespace NETworkManager
                 var firstRunViewModel = new FirstRunViewModel(async instance =>
                 {
                     await this.HideMetroDialogAsync(customDialog);
-                    
+
                     SettingsManager.Current.FirstRun = false;
 
                     // Set settings based on user choice
@@ -1028,6 +1042,7 @@ namespace NETworkManager
                 var credentialsPasswordViewModel = new CredentialsPasswordViewModel(async instance =>
                 {
                     await this.HideMetroDialogAsync(customDialog);
+                    ConfigurationManager.Current.FixAirspace = false;
 
                     info.Password = instance.Password;
 
@@ -1035,6 +1050,7 @@ namespace NETworkManager
                 }, async instance =>
                 {
                     await this.HideMetroDialogAsync(customDialog);
+                    ConfigurationManager.Current.FixAirspace = false;
 
                     ProfileManager.Unload();
 
@@ -1046,6 +1062,7 @@ namespace NETworkManager
                     DataContext = credentialsPasswordViewModel
                 };
 
+                ConfigurationManager.Current.FixAirspace = true;
                 await this.ShowMetroDialogAsync(customDialog);
             }
             else
@@ -1079,18 +1096,17 @@ namespace NETworkManager
             {
                 var settings = AppearanceManager.MetroDialog;
                 settings.AffirmativeButtonText = Localization.Resources.Strings.Migrate;
-                settings.NegativeButtonText = Localization.Resources.Strings.Cancel;                
+                settings.NegativeButtonText = Localization.Resources.Strings.Cancel;
                 settings.DefaultButtonFocus = MessageDialogResult.Affirmative;
 
                 ConfigurationManager.Current.FixAirspace = true;
 
                 // ToDo: Improve Message
-
                 var result = await this.ShowMessageAsync(Localization.Resources.Strings.ProfileCouldNotBeLoaded, Localization.Resources.Strings.ProfileCouldNotBeLoadedMessage, MessageDialogStyle.AffirmativeAndNegative, settings);
 
                 ConfigurationManager.Current.FixAirspace = false;
 
-                if(result == MessageDialogResult.Affirmative)
+                if (result == MessageDialogResult.Affirmative)
                 {
                     ExternalProcessStarter.RunProcess("powershell.exe", $"-NoLogo -NoProfile -ExecutionPolicy ByPass -File \"{Path.Combine(ConfigurationManager.Current.ExecutionPath, "Resources", "Migrate-Profiles.ps1")}\" -Path \"{ProfileManager.GetProfilesLocation()}\" -NETworkManagerPath \"{ConfigurationManager.Current.ApplicationFullName}\" -NETworkManagerVersion \"{AssemblyManager.Current.Version}\"");
                     CloseApplication();
@@ -1483,5 +1499,42 @@ namespace NETworkManager
             e.Handled = true;
         }
         #endregion
+
+        private async void RefocusEmbeddedWindow()
+        {
+            // Delay the focus to prevent blocking the ui
+            do
+            {
+                await Task.Delay(250);
+            } while (Mouse.LeftButton == MouseButtonState.Pressed);
+
+            /* Don't continue if
+               - Appplication is not set
+               - Settings are opened
+               - Profile file drop down is opened
+               - Application search textbox is opened
+               - Dialog over an embedded window is opened
+            */
+            if (SelectedApplication == null || ShowSettingsView || IsProfileFileDropDownOpened || IsTextBoxSearchFocused || ConfigurationManager.Current.FixAirspace)
+                return;
+
+            // Switch by name
+            switch (SelectedApplication.Name)
+            {
+                case ApplicationName.PuTTY:
+                    _puttyHostView?.FocusEmbeddedWindow();
+                    break;
+            }
+        }
+
+        private void MetroMainWindow_Activated(object sender, EventArgs e)
+        {
+            RefocusEmbeddedWindow();
+        }
+
+        private void ComboBox_DropDownOpened(object sender, EventArgs e)
+        {
+
+        }
     }
 }

--- a/Source/NETworkManager/MainWindow.xaml.cs
+++ b/Source/NETworkManager/MainWindow.xaml.cs
@@ -1521,6 +1521,9 @@ namespace NETworkManager
             // Switch by name
             switch (SelectedApplication.Name)
             {
+                case ApplicationName.PowerShell:
+                    _powerShellHostView?.FocusEmbeddedWindow();
+                    break;
                 case ApplicationName.PuTTY:
                     _puttyHostView?.FocusEmbeddedWindow();
                     break;

--- a/Source/NETworkManager/ViewModels/NetworkConnectionViewModel.cs
+++ b/Source/NETworkManager/ViewModels/NetworkConnectionViewModel.cs
@@ -472,7 +472,7 @@ namespace NETworkManager.ViewModels
                 while (IsChecking)
                 {
                     //Debug.WriteLine("Waiting for cancel..");
-                    await Task.Delay(500);
+                    await Task.Delay(250);
                 }
             }
 

--- a/Source/NETworkManager/ViewModels/PowerShellHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PowerShellHostViewModel.cs
@@ -69,6 +69,20 @@ namespace NETworkManager.ViewModels
                 OnPropertyChanged();
             }
         }
+
+        private bool _headerContextMenuIsOpen;
+        public bool HeaderContextMenuIsOpen
+        {
+            get => _headerContextMenuIsOpen;
+            set
+            {
+                if (value == _headerContextMenuIsOpen)
+                    return;
+
+                _headerContextMenuIsOpen = value;
+                OnPropertyChanged();
+            }
+        }
         #region Profiles
 
         public ICollectionView Profiles { get; }
@@ -104,16 +118,16 @@ namespace NETworkManager.ViewModels
             }
         }
 
-        private bool _isTextBoxSearchFocused;
-        public bool IsTextBoxSearchFocused
+        private bool _textBoxSearchIsFocused;
+        public bool TextBoxSearchIsFocused
         {
-            get => _isTextBoxSearchFocused;
+            get => _textBoxSearchIsFocused;
             set
             {
-                if (value == _isTextBoxSearchFocused)
+                if (value == _textBoxSearchIsFocused)
                     return;
 
-                _isTextBoxSearchFocused = value;
+                _textBoxSearchIsFocused = value;
                 OnPropertyChanged();
             }
         }
@@ -176,6 +190,21 @@ namespace NETworkManager.ViewModels
                 OnPropertyChanged();
             }
         }
+
+        private bool _profileContextMenuIsOpen;
+        public bool ProfileContextMenuIsOpen
+        {
+            get => _profileContextMenuIsOpen;
+            set
+            {
+
+                if (value == _profileContextMenuIsOpen)
+                    return;
+
+                _profileContextMenuIsOpen = value;
+                OnPropertyChanged();
+            }
+        }
         #endregion
         #endregion
 
@@ -218,8 +247,8 @@ namespace NETworkManager.ViewModels
             // This will select the first entry as selected item...
             SelectedProfile = Profiles.SourceCollection.Cast<ProfileInfo>().Where(x => x.PowerShell_Enabled).OrderBy(x => x.Group).ThenBy(x => x.Name).FirstOrDefault();
 
-            ProfileManager.OnProfilesUpdated += ProfileManager_OnProfilesUpdated;    
-                
+            ProfileManager.OnProfilesUpdated += ProfileManager_OnProfilesUpdated;
+
             _searchDispatcherTimer.Interval = GlobalStaticConfiguration.SearchDispatcherTimerTimeSpan;
             _searchDispatcherTimer.Tick += SearchDispatcherTimer_Tick;
 
@@ -229,7 +258,7 @@ namespace NETworkManager.ViewModels
 
             _isLoading = false;
         }
-               
+
         private void Current_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(SettingsInfo.PowerShell_ApplicationFilePath))
@@ -344,24 +373,24 @@ namespace NETworkManager.ViewModels
             ProfileDialogManager.ShowEditGroupDialog(this, _dialogCoordinator, ProfileManager.GetGroup(group.ToString()));
         }
 
-        public ICommand TextBoxSearchGotKeyboardFocusCommand
+        public ICommand TextBoxSearchGotFocusCommand
         {
-            get { return new RelayCommand(p => TextBoxSearchGotKeyboardFocusAction()); }
+            get { return new RelayCommand(p => TextBoxSearchGotFocusAction()); }
         }
 
-        private void TextBoxSearchGotKeyboardFocusAction()
+        private void TextBoxSearchGotFocusAction()
         {
-            IsTextBoxSearchFocused = true;
+            TextBoxSearchIsFocused = true;
         }
 
-        public ICommand TextBoxSearchLostKeyboardFocusCommand
+        public ICommand TextBoxSearchLostFocusCommand
         {
-            get { return new RelayCommand(p => TextBoxSearchLostKeyboardFocusAction()); }
+            get { return new RelayCommand(p => TextBoxSearchLostFocusAction()); }
         }
 
-        private void TextBoxSearchLostKeyboardFocusAction()
+        private void TextBoxSearchLostFocusAction()
         {
-            IsTextBoxSearchFocused = false;
+            TextBoxSearchIsFocused = false;
         }
 
         public ICommand ClearSearchCommand => new RelayCommand(p => ClearSearchAction());
@@ -425,7 +454,7 @@ namespace NETworkManager.ViewModels
             };
 
             ConfigurationManager.Current.FixAirspace = true;
-            await _dialogCoordinator.ShowMetroDialogAsync(this, customDialog);            
+            await _dialogCoordinator.ShowMetroDialogAsync(this, customDialog);
         }
 
         private void ConnectProfile()
@@ -466,7 +495,7 @@ namespace NETworkManager.ViewModels
         {
             if (string.IsNullOrEmpty(host))
                 return;
-            
+
             SettingsManager.Current.PowerShell_HostHistory = new ObservableCollection<string>(ListHelper.Modify(SettingsManager.Current.PowerShell_HostHistory.ToList(), host, SettingsManager.Current.General_HistoryListEntries));
         }
 
@@ -520,8 +549,15 @@ namespace NETworkManager.ViewModels
 
         public void FocusEmbeddedWindow()
         {
-            if (!IsTextBoxSearchFocused)
-                (SelectedTabItem?.View as PowerShellControl)?.FocusEmbeddedWindow();
+            /* Don't continue if
+               - Search TextBox is focused
+               - Header ContextMenu is opened
+               - Profile ContextMenu is opened
+            */
+            if (TextBoxSearchIsFocused || HeaderContextMenuIsOpen || ProfileContextMenuIsOpen)
+                return;
+
+            (SelectedTabItem?.View as PowerShellControl)?.FocusEmbeddedWindow();
         }
 
         public void OnViewVisible()

--- a/Source/NETworkManager/ViewModels/PuTTYHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PuTTYHostViewModel.cs
@@ -70,6 +70,20 @@ namespace NETworkManager.ViewModels
             }
         }
 
+        private bool _headerContextMenuIsOpen;
+        public bool HeaderContextMenuIsOpen
+        {
+            get => _headerContextMenuIsOpen;
+            set
+            {
+                if (value == _headerContextMenuIsOpen)
+                    return;
+
+                _headerContextMenuIsOpen = value;
+                OnPropertyChanged();
+            }
+        }
+
         #region Profiles
 
         public ICollectionView Profiles { get; }
@@ -105,16 +119,16 @@ namespace NETworkManager.ViewModels
             }
         }
 
-        private bool _isTextBoxSearchFocused;
-        public bool IsTextBoxSearchFocused
+        private bool _textBoxSearchIsFocused;
+        public bool TextBoxSearchIsFocused
         {
-            get => _isTextBoxSearchFocused;
+            get => _textBoxSearchIsFocused;
             set
             {
-                if (value == _isTextBoxSearchFocused)
+                if (value == _textBoxSearchIsFocused)
                     return;
 
-                _isTextBoxSearchFocused = value;
+                _textBoxSearchIsFocused = value;
                 OnPropertyChanged();
             }
         }
@@ -174,6 +188,21 @@ namespace NETworkManager.ViewModels
                 if (_canProfileWidthChange)
                     ResizeProfile(true);
 
+                OnPropertyChanged();
+            }
+        }
+
+        private bool _profileContextMenuIsOpen;
+        public bool ProfileContextMenuIsOpen
+        {
+            get => _profileContextMenuIsOpen;
+            set
+            {
+
+                if (value == _profileContextMenuIsOpen)
+                    return;
+
+                _profileContextMenuIsOpen = value;
                 OnPropertyChanged();
             }
         }
@@ -360,24 +389,24 @@ namespace NETworkManager.ViewModels
             ProfileDialogManager.ShowEditGroupDialog(this, _dialogCoordinator, ProfileManager.GetGroup(group.ToString()));
         }
 
-        public ICommand TextBoxSearchGotKeyboardFocusCommand
+        public ICommand TextBoxSearchGotFocusCommand
         {
-            get { return new RelayCommand(p => TextBoxSearchGotKeyboardFocusAction()); }
+            get { return new RelayCommand(p => TextBoxSearchGotFocusAction()); }
         }
 
-        private void TextBoxSearchGotKeyboardFocusAction()
+        private void TextBoxSearchGotFocusAction()
         {
-            IsTextBoxSearchFocused = true;
+            TextBoxSearchIsFocused = true;
         }
 
-        public ICommand TextBoxSearchLostKeyboardFocusCommand
+        public ICommand TextBoxSearchLostFocusCommand
         {
-            get { return new RelayCommand(p => TextBoxSearchLostKeyboardFocusAction()); }
+            get { return new RelayCommand(p => TextBoxSearchLostFocusAction()); }
         }
 
-        private void TextBoxSearchLostKeyboardFocusAction()
+        private void TextBoxSearchLostFocusAction()
         {
-            IsTextBoxSearchFocused = false;
+            TextBoxSearchIsFocused = false;
         }
 
         public ICommand ClearSearchCommand => new RelayCommand(p => ClearSearchAction());
@@ -600,8 +629,15 @@ namespace NETworkManager.ViewModels
 
         public void FocusEmbeddedWindow()
         {
-            if (!IsTextBoxSearchFocused)
-                (SelectedTabItem?.View as PuTTYControl)?.FocusEmbeddedWindow();
+            /* Don't continue if
+               - Search TextBox is focused
+               - Header ContextMenu is opened
+               - Profile ContextMenu is opened
+            */
+            if (TextBoxSearchIsFocused || HeaderContextMenuIsOpen || ProfileContextMenuIsOpen)
+                return;
+
+            (SelectedTabItem?.View as PuTTYControl)?.FocusEmbeddedWindow();
         }
 
         public void OnViewVisible()

--- a/Source/NETworkManager/Views/PowerShellHostView.xaml
+++ b/Source/NETworkManager/Views/PowerShellHostView.xaml
@@ -75,7 +75,7 @@
                             <Border BorderBrush="{DynamicResource MahApps.Brushes.Gray8}" BorderThickness="0,0,1,0">
                                 <Grid Height="32">
                                     <Grid.ContextMenu>
-                                        <ContextMenu>
+                                        <ContextMenu IsOpen="{Binding Data.HeaderContextMenuIsOpen, Source={StaticResource BindingProxy}, Mode=OneWayToSource}">
                                             <MenuItem Header="{x:Static localization:Strings.Reconnect}" Command="{Binding Data.PowerShell_ReconnectCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                                 <MenuItem.Icon>
                                                     <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
@@ -241,11 +241,11 @@
                                     <KeyBinding Command="{Binding ConnectProfileCommand}" Key="Enter" />
                                 </TextBox.InputBindings>
                                 <interactivity:Interaction.Triggers>
-                                    <interactivity:EventTrigger EventName="GotKeyboardFocus">
-                                        <interactivity:InvokeCommandAction Command="{Binding TextBoxSearchGotKeyboardFocusCommand}" />
+                                    <interactivity:EventTrigger EventName="GotFocus">
+                                        <interactivity:InvokeCommandAction Command="{Binding TextBoxSearchGotFocusCommand}" />
                                     </interactivity:EventTrigger>
-                                    <interactivity:EventTrigger EventName="LostKeyboardFocus">
-                                        <interactivity:InvokeCommandAction Command="{Binding TextBoxSearchLostKeyboardFocusCommand}" />
+                                    <interactivity:EventTrigger EventName="LostFocus">
+                                        <interactivity:InvokeCommandAction Command="{Binding TextBoxSearchLostFocusCommand}" />
                                     </interactivity:EventTrigger>
                                 </interactivity:Interaction.Triggers>
                             </TextBox>
@@ -269,7 +269,7 @@
                         </Grid>
                         <ListBox Grid.Row="2" ItemsSource="{Binding Profiles}" Visibility="{Binding IsSearching, Converter={StaticResource BooleanReverseToVisibilityCollapsedConverter}}" DisplayMemberPath="Name" SelectedItem="{Binding SelectedProfile}" Style="{StaticResource ProfileListBox}">
                             <ListBox.Resources>
-                                <ContextMenu x:Key="ListBoxItemContextMenu" Opened="ContextMenu_Opened" MinWidth="150">
+                                <ContextMenu x:Key="ListBoxItemContextMenu" Opened="ContextMenu_Opened" MinWidth="150" IsOpen="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=DataContext.ProfileContextMenuIsOpen, Mode=OneWayToSource}">
                                     <MenuItem Header="{x:Static localization:Strings.Connect}" Command="{Binding ConnectProfileCommand}">
                                         <MenuItem.Icon>
                                             <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">

--- a/Source/NETworkManager/Views/PowerShellHostView.xaml
+++ b/Source/NETworkManager/Views/PowerShellHostView.xaml
@@ -12,6 +12,7 @@
         xmlns:viewModels="clr-namespace:NETworkManager.ViewModels"
         xmlns:localization="clr-namespace:NETworkManager.Localization.Resources;assembly=NETworkManager.Localization"
         xmlns:settings="clr-namespace:NETworkManager.Settings;assembly=NETworkManager.Settings"
+        xmlns:interactivity="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"             
         dialogs:DialogParticipation.Register="{Binding}"
         Loaded="UserControl_Loaded"
@@ -41,7 +42,7 @@
                 <ColumnDefinition MinWidth="{x:Static settings:GlobalStaticConfiguration.Profile_WidthCollapsed}" Width="{Binding ProfileWidth, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" MaxWidth="{x:Static settings:GlobalStaticConfiguration.Profile_MaxWidthExpanded}" />
             </Grid.ColumnDefinitions>
             <airspaceFixer:AirspacePanel Grid.Column="0" Grid.Row="0" FixAirspace="{Binding Source={x:Static settings:ConfigurationManager.Current}, Path=FixAirspace}">
-                <dragablz:TabablzControl ClosingItemCallback="{Binding CloseItemCommand}" ItemsSource="{Binding TabItems}" SelectedIndex="{Binding SelectedTabIndex}" Visibility="{Binding Source={x:Static settings:ConfigurationManager.Current}, Path=FixAirspace, Converter={StaticResource BooleanReverseToVisibilityCollapsedConverter}}">
+                <dragablz:TabablzControl ClosingItemCallback="{Binding CloseItemCommand}" ItemsSource="{Binding TabItems}" SelectedItem="{Binding SelectedTabItem}" Visibility="{Binding Source={x:Static settings:ConfigurationManager.Current}, Path=FixAirspace, Converter={StaticResource BooleanReverseToVisibilityCollapsedConverter}}">
                     <dragablz:TabablzControl.Resources>
                         <wpfHelpers:BindingProxy x:Key="BindingProxy" Data="{Binding}" />
                     </dragablz:TabablzControl.Resources>
@@ -239,6 +240,14 @@
                                 <TextBox.InputBindings>
                                     <KeyBinding Command="{Binding ConnectProfileCommand}" Key="Enter" />
                                 </TextBox.InputBindings>
+                                <interactivity:Interaction.Triggers>
+                                    <interactivity:EventTrigger EventName="GotKeyboardFocus">
+                                        <interactivity:InvokeCommandAction Command="{Binding TextBoxSearchGotKeyboardFocusCommand}" />
+                                    </interactivity:EventTrigger>
+                                    <interactivity:EventTrigger EventName="LostKeyboardFocus">
+                                        <interactivity:InvokeCommandAction Command="{Binding TextBoxSearchLostKeyboardFocusCommand}" />
+                                    </interactivity:EventTrigger>
+                                </interactivity:Interaction.Triggers>
                             </TextBox>
                             <Button Grid.Column="4" Grid.Row="0" Style="{StaticResource CleanButton}" Command="{Binding AddProfileCommand}" ToolTip="{x:Static localization:Strings.AddProfileDots}">
                                 <Rectangle Width="16" Height="16">

--- a/Source/NETworkManager/Views/PowerShellHostView.xaml.cs
+++ b/Source/NETworkManager/Views/PowerShellHostView.xaml.cs
@@ -58,5 +58,10 @@ namespace NETworkManager.Views
         {
             _viewModel.OnViewVisible();
         }
+
+        public void FocusEmbeddedWindow()
+        {
+            _viewModel.FocusEmbeddedWindow();
+        }
     }
 }

--- a/Source/NETworkManager/Views/PowerShellHostView.xaml.cs
+++ b/Source/NETworkManager/Views/PowerShellHostView.xaml.cs
@@ -43,7 +43,7 @@ namespace NETworkManager.Views
             // Wait for the interface to load, before displaying the dialog to connect a new profile... 
             // MahApps will throw an exception... 
             while (!_loaded)
-                await Task.Delay(100);
+                await Task.Delay(250);
 
             if (_viewModel.IsConfigured)
                 _viewModel.AddTab(host);

--- a/Source/NETworkManager/Views/PuTTYHostView.xaml
+++ b/Source/NETworkManager/Views/PuTTYHostView.xaml
@@ -76,7 +76,7 @@
                             <Border BorderBrush="{DynamicResource MahApps.Brushes.Gray8}" BorderThickness="0,0,1,0">
                                 <Grid Height="32">
                                     <Grid.ContextMenu>
-                                        <ContextMenu>
+                                        <ContextMenu IsOpen="{Binding Data.HeaderContextMenuIsOpen, Source={StaticResource BindingProxy}, Mode=OneWayToSource}">
                                             <MenuItem Header="{x:Static localization:Strings.Reconnect}" Command="{Binding Data.PuTTY_ReconnectCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                                 <MenuItem.Icon>
                                                     <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
@@ -251,11 +251,11 @@
                                     <KeyBinding Command="{Binding ConnectProfileCommand}" Key="Enter" />
                                 </TextBox.InputBindings>
                                 <interactivity:Interaction.Triggers>
-                                    <interactivity:EventTrigger EventName="GotKeyboardFocus">
-                                        <interactivity:InvokeCommandAction Command="{Binding TextBoxSearchGotKeyboardFocusCommand}" />
+                                    <interactivity:EventTrigger EventName="GotFocus">
+                                        <interactivity:InvokeCommandAction Command="{Binding TextBoxSearchGotFocusCommand}" />
                                     </interactivity:EventTrigger>
-                                    <interactivity:EventTrigger EventName="LostKeyboardFocus">
-                                        <interactivity:InvokeCommandAction Command="{Binding TextBoxSearchLostKeyboardFocusCommand}" />
+                                    <interactivity:EventTrigger EventName="LostFocus">
+                                        <interactivity:InvokeCommandAction Command="{Binding TextBoxSearchLostFocusCommand}" />
                                     </interactivity:EventTrigger>
                                 </interactivity:Interaction.Triggers>
                             </TextBox>
@@ -279,7 +279,7 @@
                         </Grid>
                         <ListBox Grid.Row="2" ItemsSource="{Binding Profiles}" Visibility="{Binding IsSearching, Converter={StaticResource BooleanReverseToVisibilityCollapsedConverter}}" DisplayMemberPath="Name" SelectedItem="{Binding SelectedProfile}" Style="{StaticResource ProfileListBox}">
                             <ListBox.Resources>
-                                <ContextMenu x:Key="ListBoxItemContextMenu" Opened="ContextMenu_Opened" MinWidth="150">
+                                <ContextMenu x:Key="ListBoxItemContextMenu" Opened="ContextMenu_Opened" MinWidth="150" IsOpen="{Binding RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Path=DataContext.ProfileContextMenuIsOpen, Mode=OneWayToSource}">
                                     <MenuItem Header="{x:Static localization:Strings.Connect}" Command="{Binding ConnectProfileCommand}">
                                         <MenuItem.Icon>
                                             <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">

--- a/Source/NETworkManager/Views/PuTTYHostView.xaml
+++ b/Source/NETworkManager/Views/PuTTYHostView.xaml
@@ -246,7 +246,7 @@
                                     </Rectangle.Style>
                                 </Rectangle>
                             </ToggleButton>
-                            <TextBox x:Name="TextBoxSearch" Grid.Column="2" Grid.Row="0" VerticalAlignment="Center"  Text="{Binding Search, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource SearchTextBox}">
+                            <TextBox x:Name="TextBoxSearch" Grid.Column="2" Grid.Row="0" VerticalAlignment="Center" Text="{Binding Search, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource SearchTextBox}">
                                 <TextBox.InputBindings>
                                     <KeyBinding Command="{Binding ConnectProfileCommand}" Key="Enter" />
                                 </TextBox.InputBindings>

--- a/Source/NETworkManager/Views/PuTTYHostView.xaml
+++ b/Source/NETworkManager/Views/PuTTYHostView.xaml
@@ -13,6 +13,7 @@
         xmlns:controls="clr-namespace:NETworkManager.Controls"
         xmlns:wpfHelpers="clr-namespace:NETworkManager.Utilities.WPF;assembly=NETworkManager.Utilities.WPF"
         xmlns:settings="clr-namespace:NETworkManager.Settings;assembly=NETworkManager.Settings"
+        xmlns:interactivity="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"             
         dialogs:DialogParticipation.Register="{Binding}"
         Loaded="UserControl_Loaded"
@@ -42,7 +43,7 @@
                 <ColumnDefinition MinWidth="{x:Static settings:GlobalStaticConfiguration.Profile_WidthCollapsed}" Width="{Binding ProfileWidth, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" MaxWidth="{x:Static settings:GlobalStaticConfiguration.Profile_MaxWidthExpanded}" />
             </Grid.ColumnDefinitions>
             <airspaceFixer:AirspacePanel Grid.Column="0" Grid.Row="0" FixAirspace="{Binding Source={x:Static settings:ConfigurationManager.Current}, Path=FixAirspace}">
-                <dragablz:TabablzControl ClosingItemCallback="{Binding CloseItemCommand}" ItemsSource="{Binding TabItems}" SelectedIndex="{Binding SelectedTabIndex}" Visibility="{Binding Source={x:Static settings:ConfigurationManager.Current}, Path=FixAirspace, Converter={StaticResource BooleanReverseToVisibilityCollapsedConverter}}">
+                <dragablz:TabablzControl ClosingItemCallback="{Binding CloseItemCommand}" ItemsSource="{Binding TabItems}" SelectedItem="{Binding SelectedTabItem}" Visibility="{Binding Source={x:Static settings:ConfigurationManager.Current}, Path=FixAirspace, Converter={StaticResource BooleanReverseToVisibilityCollapsedConverter}}">
                     <dragablz:TabablzControl.Resources>
                         <wpfHelpers:BindingProxy x:Key="BindingProxy" Data="{Binding}" />
                     </dragablz:TabablzControl.Resources>
@@ -245,10 +246,18 @@
                                     </Rectangle.Style>
                                 </Rectangle>
                             </ToggleButton>
-                            <TextBox x:Name="TextBoxSearch" Grid.Column="2" Grid.Row="0" VerticalAlignment="Center" Text="{Binding Search, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource SearchTextBox}">
+                            <TextBox x:Name="TextBoxSearch" Grid.Column="2" Grid.Row="0" VerticalAlignment="Center"  Text="{Binding Search, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource SearchTextBox}">
                                 <TextBox.InputBindings>
                                     <KeyBinding Command="{Binding ConnectProfileCommand}" Key="Enter" />
                                 </TextBox.InputBindings>
+                                <interactivity:Interaction.Triggers>
+                                    <interactivity:EventTrigger EventName="GotKeyboardFocus">
+                                        <interactivity:InvokeCommandAction Command="{Binding TextBoxSearchGotKeyboardFocusCommand}" />
+                                    </interactivity:EventTrigger>
+                                    <interactivity:EventTrigger EventName="LostKeyboardFocus">
+                                        <interactivity:InvokeCommandAction Command="{Binding TextBoxSearchLostKeyboardFocusCommand}" />
+                                    </interactivity:EventTrigger>
+                                </interactivity:Interaction.Triggers>
                             </TextBox>
                             <Button Grid.Column="4" Grid.Row="0" Style="{StaticResource CleanButton}" Command="{Binding AddProfileCommand}" ToolTip="{x:Static localization:Strings.AddProfileDots}">
                                 <Rectangle Width="16" Height="16">

--- a/Source/NETworkManager/Views/PuTTYHostView.xaml.cs
+++ b/Source/NETworkManager/Views/PuTTYHostView.xaml.cs
@@ -43,7 +43,7 @@ namespace NETworkManager.Views
             // Wait for the interface to load, before displaying the dialog to connect a new profile... 
             // MahApps will throw an exception... 
             while (!_loaded)
-                await Task.Delay(100);
+                await Task.Delay(250);
 
             if (_viewModel.IsConfigured)
                 _viewModel.AddTab(host);
@@ -57,6 +57,11 @@ namespace NETworkManager.Views
         public void OnViewVisible()
         {
             _viewModel.OnViewVisible();
+        }
+
+        public void FocusEmbeddedWindow()
+        {
+            _viewModel.FocusEmbeddedWindow();
         }
     }
 }

--- a/Source/NETworkManager/Views/RemoteDesktopHostView.xaml.cs
+++ b/Source/NETworkManager/Views/RemoteDesktopHostView.xaml.cs
@@ -42,7 +42,7 @@ namespace NETworkManager.Views
             // Wait for the interface to load, before displaying the dialog to connect a new Profile... 
             // MahApps will throw an exception... 
             while (!_loaded)
-                await Task.Delay(100);
+                await Task.Delay(250);
 
             _viewModel.AddTab(host);
         }

--- a/Source/NETworkManager/Views/TigerVNCHostView.xaml.cs
+++ b/Source/NETworkManager/Views/TigerVNCHostView.xaml.cs
@@ -44,7 +44,7 @@ namespace NETworkManager.Views
             // Wait for the interface to load, before displaying the dialog to connect a new profile... 
             // MahApps will throw an exception... 
             while (!_loaded)
-                await Task.Delay(100);
+                await Task.Delay(250);
 
             if (_viewModel.IsConfigured)
                 _viewModel.AddTab(host);

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -18,14 +18,22 @@ permalink: /Changelog/next-release
 
   
 ## Improvements
-
+- PowerShell & PuTTY
+  - Focus embedded window when the application has received the focus [#1515](https://github.com/BornToBeRoot/NETworkManager/pull/1515){:target="\_blank"}
+  - Focus embedded window when application is selected again [#1515](https://github.com/BornToBeRoot/NETworkManager/pull/1515){:target="\_blank"}
+  - Focus embedded window when switching tabs [#1515](https://github.com/BornToBeRoot/NETworkManager/pull/1515){:target="\_blank"}
 
 ## Bugfixes
 - Dashboard / Status Window
   - Handle null exception properly [#1510](https://github.com/BornToBeRoot/NETworkManager/pull/1510){:target="\_blank"}
+- Remote Desktop, PowerShell, PuTTY & TigerVNC
+  - "Unlock profile" dialog is now displayed correctly if an embedded window is already open [#1515](https://github.com/BornToBeRoot/NETworkManager/pull/1515){:target="\_blank"}
+PowerShell & TigerVNC
+  - Embedded window is now resized correctly after the inital connect [#1515](https://github.com/BornToBeRoot/NETworkManager/pull/1515){:target="\_blank"}
 - Settings > Profiles
   - App crash fixed when a profile file is deleted and an encrypted but locked profile file is selected [#1512](https://github.com/BornToBeRoot/NETworkManager/pull/1512){:target="\_blank"}
 
 ## Other
+- Code cleanup [#1515](https://github.com/BornToBeRoot/NETworkManager/pull/1515){:target="\_blank"}
 - Language files updated [#transifex](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Ftransifex-integration){:target="_blank"}
 - Dependencies updated [#dependencies](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Fdependabot){:target="_blank"}


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Set focus to embedded window when main window got focus
- Set focus on tab item change
- Set focus when re-select the app from the main view
- PowerShell - Resize window after first embed fixed
- Fix Dialog "Unlock profile" over an embedded window
- Code cleanup

ToDo List
- [x] Implement & code cleanup for PuTTY
- [x] Implement & code cleanup for PowerShell
- [x] Code cleanup for TigerVNC
- [x] Handle focus / activated event in dragged out window
- [x] Allow right click on profile and tab header (menu is closed when focus is set)

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or ressource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).