### PR TITLE
Fix: IPv6 is now resolved when selected in the settings

### DIFF
--- a/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
@@ -365,7 +365,7 @@ namespace NETworkManager.ViewModels
             else // Resolve ip address
             {
                 hostname = host;
-                ipAddress = await DnsLookupHelper.ResolveIPAddress(host);
+                ipAddress = await DnsLookupHelper.ResolveIPAddress(host, SettingsManager.Current.PingMonitor_ResolveHostnamePreferIPv4);
             }
 
             if (ipAddress != null)

--- a/Source/NETworkManager/ViewModels/SNMPViewModel.cs
+++ b/Source/NETworkManager/ViewModels/SNMPViewModel.cs
@@ -509,7 +509,7 @@ namespace NETworkManager.ViewModels
             // Try to parse the string into an IP-Address
             if (!IPAddress.TryParse(Host, out var ipAddress))
             {
-                ipAddress = await DnsLookupHelper.ResolveIPAddress(Host);
+                ipAddress = await DnsLookupHelper.ResolveIPAddress(Host, SettingsManager.Current.SNMP_ResolveHostnamePreferIPv4);
             }
 
             if (ipAddress == null)

--- a/Source/NETworkManager/ViewModels/TracerouteViewModel.cs
+++ b/Source/NETworkManager/ViewModels/TracerouteViewModel.cs
@@ -318,7 +318,7 @@ namespace NETworkManager.ViewModels
             // Try to parse the string into an IP-Address
             if (!IPAddress.TryParse(Host, out var ipAddress))
             {
-                ipAddress = await DnsLookupHelper.ResolveIPAddress(Host);
+                ipAddress = await DnsLookupHelper.ResolveIPAddress(Host, SettingsManager.Current.Traceroute_ResolveHostnamePreferIPv4);
             }
 
             if (ipAddress == null)

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -30,9 +30,11 @@ permalink: /Changelog/next-release
   - Handle null exception properly [#1510](https://github.com/BornToBeRoot/NETworkManager/pull/1510){:target="\_blank"}
 - Traceroute
   - Hops were skipped if they did not respond to ping [#1528](https://github.com/BornToBeRoot/NETworkManager/pull/1528){:target="\_blank"}
+- Ping Monitor, Traceroute & SNMP
+  - IPv6 is now resolved when selected in the settings [#1529](https://github.com/BornToBeRoot/NETworkManager/pull/1529){:target="\_blank"}
 - Remote Desktop, PowerShell, PuTTY & TigerVNC
   - "Unlock profile" dialog is now displayed correctly if an embedded window is already open [#1515](https://github.com/BornToBeRoot/NETworkManager/pull/1515){:target="\_blank"}
-PowerShell & TigerVNC
+- PowerShell & TigerVNC
   - Embedded window is now resized correctly after the inital connect [#1515](https://github.com/BornToBeRoot/NETworkManager/pull/1515){:target="\_blank"}
 - Settings > Profiles
   - App crash fixed when a profile file is deleted and an encrypted but locked profile file is selected [#1512](https://github.com/BornToBeRoot/NETworkManager/pull/1512){:target="\_blank"}


### PR DESCRIPTION
Fixes #1527

**Please provide some details about this pull request:**
- IPv6 is now resolved when selected in the settings
-
-


---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or ressource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).