### PR TITLE
Fix: App crash if selected group is null when switching profiles

### DIFF
--- a/Source/NETworkManager/ViewModels/ProfilesViewModel.cs
+++ b/Source/NETworkManager/ViewModels/ProfilesViewModel.cs
@@ -278,8 +278,8 @@ namespace NETworkManager.ViewModels
             {
                 Groups?.Refresh();
 
-                // Set group again after refresh or first if null
-                SelectedGroup = Groups.SourceCollection.Cast<GroupInfo>().FirstOrDefault(x => x.Name == _selectedGroup.Name) ?? Groups.SourceCollection.Cast<GroupInfo>().OrderBy(x => x.Name).FirstOrDefault();
+                // Set group again after refresh or first if null (_selectedGroup can be null in some cases)
+                SelectedGroup = Groups.SourceCollection.Cast<GroupInfo>().FirstOrDefault(x => x.Name == _selectedGroup?.Name) ?? Groups.SourceCollection.Cast<GroupInfo>().OrderBy(x => x.Name).FirstOrDefault();
             }));
 
             _profileInfoOnRefresh = null;

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -56,6 +56,7 @@ permalink: /Changelog/next-release
 - Settings > Profiles
   - App crash fixed when a profile file is deleted and an encrypted but locked profile file is selected [#1512](https://github.com/BornToBeRoot/NETworkManager/pull/1512){:target="\_blank"}
   - Reselect group/profile on refresh (e.g. if profiles page is opened again) [#1516](https://github.com/BornToBeRoot/NETworkManager/pull/1516){:target="\_blank"}
+  - App crash fixed when no group is selected and the profile file changes [#1610](https://github.com/BornToBeRoot/NETworkManager/pull/1610){:target="\_blank"}
 
 ## Other
 - Code cleanup [#1515](https://github.com/BornToBeRoot/NETworkManager/pull/1515){:target="\_blank"} [#1599](https://github.com/BornToBeRoot/NETworkManager/pull/1600){:target="\_blank"} [#1600](https://github.com/BornToBeRoot/NETworkManager/pull/1599){:target="\_blank"}


### PR DESCRIPTION
**Please provide some details about this pull request:**
- App crash if selected group is null when switching profiles
-
-


---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or ressource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).