### PR TITLE
Fix: Detection of AWS CLI and SSM plugin

### DIFF
--- a/Source/NETworkManager/ViewModels/AWSSessionManagerHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/AWSSessionManagerHostViewModel.cs
@@ -511,13 +511,25 @@ namespace NETworkManager.ViewModels
 
         #region Methods        
         private void CheckInstallationStatus()
-        {
-            // Maybe also check DisplayVersion?
-            RegistryKey awsCLIRegistryKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{01CCB9EC-7FA4-494D-9EEC-395C080CAA7C}", false);
-            IsAWSCLIInstalled = awsCLIRegistryKey != null && awsCLIRegistryKey.GetValue("DisplayName") != null;
+        {            
+            using (RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"))
+            {
+                foreach (string subkeyName in key.GetSubKeyNames())
+                {
+                    using RegistryKey subKey = key.OpenSubKey(subkeyName);
 
-            RegistryKey awsSessionManagerPluginRegistryKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{13DD0F7B-C2A8-4F22-BF55-CD0D719DBA46}", false);
-            IsAWSSessionManagerPluginInstalled = awsSessionManagerPluginRegistryKey != null && awsSessionManagerPluginRegistryKey.GetValue("DisplayName") != null;
+                    var displayName = subKey.GetValue("DisplayName");
+
+                    if (displayName == null)
+                        continue;
+
+                    if (displayName.Equals("AWS Command Line Interface v2"))
+                        IsAWSCLIInstalled = true;
+
+                    if (displayName.Equals( "Session Manager Plugin"))
+                        IsAWSSessionManagerPluginInstalled = true;
+                }
+            }
         }
 
         private void CheckSettings()


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Detection of SSM plugin (They don't use the same GUID...)
-
-


---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).