### PR TITLE
Fix: Don't use hidden files in build

### DIFF
--- a/Source/NETworkManager/NETworkManager.csproj
+++ b/Source/NETworkManager/NETworkManager.csproj
@@ -5,7 +5,7 @@
 		<RuntimeIdentifier>win10-x64</RuntimeIdentifier>
 		<PlatformTarget>x64</PlatformTarget>
 		<SelfContained>false</SelfContained>
-		<!--
+		<!-- Publish a single file can't be used when accessing assembly file path
 		<PublishSingleFile>true</PublishSingleFile>
 		<PublishReadyToRun>true</PublishReadyToRun>
 		-->
@@ -31,7 +31,9 @@
 		<BeautyLibsDir Condition="$(BeautySharedRuntimeMode) == 'True'">../lib</BeautyLibsDir>
 		<BeautyLibsDir Condition="$(BeautySharedRuntimeMode) != 'True'">./lib</BeautyLibsDir>
 		<BeautyExcludes>NETworkManager.Models.dll</BeautyExcludes>
+		<!-- Hidden files are not supported by Compress-Archive (Portable, Archive) and InnoSetup (Installer)
 		<BeautyHiddens>*.deps.json;*.runtimeconfig.json;*.dll.config</BeautyHiddens>
+		-->
 		<DisableBeauty>False</DisableBeauty>
 		<BeautyOnPublishOnly>False</BeautyOnPublishOnly>
 		<BeautyEnableDebugging>False</BeautyEnableDebugging>


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Don't use hidden files because Compress-Archive & InnoSetup can't include them
-
-

Fixes #1916 

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).