### PR TITLE
Fix: Use UTF8 encoding for PowerShell console

### DIFF
--- a/Source/NETworkManager.Models/AWS/AWSSessionManager.cs
+++ b/Source/NETworkManager.Models/AWS/AWSSessionManager.cs
@@ -2,9 +2,13 @@
 {
     public static partial class AWSSessionManager
     {
+        private static string _encodingCommand = "[console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding";
+        private static string _setLocationCommand = "Set-Location -Path ~";
+        private static string _clearHostCommand = "Clear-Host";
+
         public static string BuildCommandLine(AWSSessionManagerSessionInfo sessionInfo)
         {
-            var commandLine = $"-NoExit -NoLogo -NoProfile -Command \"Set-Location -Path ~; Clear-Host; aws ssm start-session --target {sessionInfo.InstanceID}";
+            var commandLine = $"-NoExit -NoLogo -NoProfile -Command \"{_encodingCommand}; {_setLocationCommand}; {_clearHostCommand}; aws ssm start-session --target {sessionInfo.InstanceID}";
 
             // Add profile
             if (!string.IsNullOrEmpty(sessionInfo.Profile))

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -34,7 +34,8 @@ New Feature
   - [IP Scanner](https://borntoberoot.net/NETworkManager/Documentation/Application/IPScanner){:target="\_blank"}
 
 ## Bugfixes
-
+AWS Session Manager
+  - Use UTF-8 encoding for embedded PowerShell console window [#1832](https://github.com/BornToBeRoot/NETworkManager/pull/1832){:target="\_blank"}
 
 ## Other
 - Language files updated [#transifex](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Ftransifex-integration){:target="\_blank"}


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Use UTF-8 encoding for embedded PowerShell console window
-
-

Fixes #1897

**ToDo:**

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).