### PR TITLE
Feature: PuTTY parameter `-hostkey` added

### DIFF
--- a/Source/NETworkManager.Localization/Resources/StaticStrings.Designer.cs
+++ b/Source/NETworkManager.Localization/Resources/StaticStrings.Designer.cs
@@ -160,6 +160,15 @@ namespace NETworkManager.Localization.Resources {
         }
         
         /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die 71:b8:f2:6e..., 13:59:a7... ähnelt.
+        /// </summary>
+        public static string ExampleHostkey {
+            get {
+                return ResourceManager.GetString("ExampleHostkey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die SERVER-01 ähnelt.
         /// </summary>
         public static string ExampleHostname {
@@ -480,6 +489,15 @@ namespace NETworkManager.Localization.Resources {
         public static string ExamplePuTTYPath {
             get {
                 return ResourceManager.GetString("ExamplePuTTYPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die NETworkManager ähnelt.
+        /// </summary>
+        public static string ExamplePuTTYProfile {
+            get {
+                return ResourceManager.GetString("ExamplePuTTYProfile", resourceCulture);
             }
         }
         

--- a/Source/NETworkManager.Localization/Resources/StaticStrings.resx
+++ b/Source/NETworkManager.Localization/Resources/StaticStrings.resx
@@ -318,4 +318,10 @@
   <data name="ExampleTigerVNCPath" xml:space="preserve">
     <value>C:\Tools\TigerVNC\vncviewer64-1.12.0.exe</value>
   </data>
+  <data name="ExampleHostkey" xml:space="preserve">
+    <value>71:b8:f2:6e..., 13:59:a7...</value>
+  </data>
+  <data name="ExamplePuTTYProfile" xml:space="preserve">
+    <value>NETworkManager</value>
+  </data>
 </root>

--- a/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
+++ b/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
@@ -3921,6 +3921,15 @@ namespace NETworkManager.Localization.Resources {
         }
         
         /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Hostkey ähnelt.
+        /// </summary>
+        public static string Hostkey {
+            get {
+                return ResourceManager.GetString("Hostkey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die Hostname ähnelt.
         /// </summary>
         public static string Hostname {

--- a/Source/NETworkManager.Localization/Resources/Strings.resx
+++ b/Source/NETworkManager.Localization/Resources/Strings.resx
@@ -3326,4 +3326,7 @@ If the option is disabled again, the values are no longer modified. However, the
   <data name="PortState_TimedOut" xml:space="preserve">
     <value>Timed out</value>
   </data>
+  <data name="Hostkey" xml:space="preserve">
+    <value>Hostkey</value>
+  </data>
 </root>

--- a/Source/NETworkManager.Models/PuTTY/PuTTY.cs
+++ b/Source/NETworkManager.Models/PuTTY/PuTTY.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Win32;
+using NETworkManager.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -158,11 +159,20 @@ namespace NETworkManager.Models.PuTTY
 
             // Private key
             if (!string.IsNullOrEmpty(sessionInfo.PrivateKey))
-                command += $" -i {'"'}{sessionInfo.PrivateKey}{'"'}";
+                command += $" -i \"{sessionInfo.PrivateKey}\"";
 
             // Profile
             if (!string.IsNullOrEmpty(sessionInfo.Profile))
-                command += $" -load {'"'}{sessionInfo.Profile}{'"'}";
+                command += $" -load \"{sessionInfo.Profile}\"";
+
+            // Hostkey(s)
+            if (!string.IsNullOrEmpty(sessionInfo.Hostkey))
+            {
+                var hostkeys = StringHelper.RemoveWhitespace(sessionInfo.Hostkey).Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+                foreach (var hostkey in hostkeys)
+                    command += $" -hostkey \"{hostkey}\"";
+            }
 
             // Log
             if (sessionInfo.EnableLog)

--- a/Source/NETworkManager.Models/PuTTY/PuTTYSessionInfo.cs
+++ b/Source/NETworkManager.Models/PuTTY/PuTTYSessionInfo.cs
@@ -41,6 +41,11 @@
         public string Profile { get; set; }
 
         /// <summary>
+        /// PuTTY host key. Multiple keys are separated by a comma.
+        /// </summary>
+        public string Hostkey { get; set; }
+
+        /// <summary>
         /// Enables session log.
         /// </summary>
         public bool EnableLog { get; set; }

--- a/Source/NETworkManager.Profiles/Application/PuTTY.cs
+++ b/Source/NETworkManager.Profiles/Application/PuTTY.cs
@@ -20,6 +20,7 @@ namespace NETworkManager.Profiles.Application
                 Username = profile.PuTTY_OverrideUsername ? profile.PuTTY_Username : (group.PuTTY_OverrideUsername ? group.PuTTY_Username : SettingsManager.Current.PuTTY_Username),
                 PrivateKey = profile.PuTTY_OverridePrivateKeyFile ? profile.PuTTY_PrivateKeyFile : (group.PuTTY_OverridePrivateKeyFile ? group.PuTTY_PrivateKeyFile : SettingsManager.Current.PuTTY_PrivateKeyFile),
                 Profile = profile.PuTTY_OverrideProfile ? profile.PuTTY_Profile : (group.PuTTY_OverrideProfile ? group.PuTTY_Profile : SettingsManager.Current.PuTTY_Profile),
+                Hostkey = profile.PuTTY_OverrideHostkey ? profile.PuTTY_Hostkey : "",
                 EnableLog = profile.PuTTY_OverrideEnableLog ? profile.PuTTY_EnableLog : (group.PuTTY_OverrideEnableLog ? group.PuTTY_EnableLog : SettingsManager.Current.PuTTY_EnableSessionLog),
                 LogMode = profile.PuTTY_OverrideLogMode ? profile.PuTTY_LogMode : (group.PuTTY_OverrideLogMode ? group.PuTTY_LogMode : SettingsManager.Current.PuTTY_LogMode),
                 LogPath = profile.PuTTY_OverrideLogPath ? profile.PuTTY_LogPath : (group.PuTTY_OverrideLogPath ? group.PuTTY_LogPath : Settings.Application.PuTTY.LogPath),

--- a/Source/NETworkManager.Profiles/ProfileInfo.cs
+++ b/Source/NETworkManager.Profiles/ProfileInfo.cs
@@ -154,6 +154,8 @@ namespace NETworkManager.Profiles
         public string PuTTY_PrivateKeyFile { get; set; }
         public bool PuTTY_OverrideProfile { get; set; }
         public string PuTTY_Profile { get; set; }
+        public bool PuTTY_OverrideHostkey { get; set; }
+        public string PuTTY_Hostkey { get; set; }
         public bool PuTTY_OverrideEnableLog { get; set; }
         public bool PuTTY_EnableLog { get; set; }
         public bool PuTTY_OverrideLogMode { get; set; }
@@ -307,7 +309,7 @@ namespace NETworkManager.Profiles
             RemoteDesktop_MenuAndWindowAnimation = profile.RemoteDesktop_MenuAndWindowAnimation;
             RemoteDesktop_OverrideVisualStyles = profile.RemoteDesktop_OverrideVisualStyles;
             RemoteDesktop_VisualStyles = profile.RemoteDesktop_VisualStyles;
-            
+
             // PowerShell
             PowerShell_Enabled = profile.PowerShell_Enabled;
             PowerShell_EnableRemoteConsole = profile.PowerShell_EnableRemoteConsole;
@@ -333,6 +335,8 @@ namespace NETworkManager.Profiles
             PuTTY_PrivateKeyFile = profile.PuTTY_PrivateKeyFile;
             PuTTY_OverrideProfile = profile.PuTTY_OverrideProfile;
             PuTTY_Profile = profile.PuTTY_Profile;
+            PuTTY_OverrideHostkey = profile.PuTTY_OverrideHostkey;
+            PuTTY_Hostkey = profile.PuTTY_Hostkey;
             PuTTY_OverrideEnableLog = profile.PuTTY_OverrideEnableLog;
             PuTTY_EnableLog = profile.PuTTY_EnableLog;
             PuTTY_OverrideLogMode = profile.PuTTY_OverrideLogMode;
@@ -374,6 +378,6 @@ namespace NETworkManager.Profiles
             Whois_Enabled = profile.Whois_Enabled;
             Whois_InheritHost = profile.Whois_InheritHost;
             Whois_Domain = profile.Whois_Domain;
-        }        
+        }
     }
 }

--- a/Source/NETworkManager.Settings/SettingsManager.cs
+++ b/Source/NETworkManager.Settings/SettingsManager.cs
@@ -266,19 +266,19 @@ namespace NETworkManager.Settings
 
                     if (portProfileFound == null)
                     {
-                        _log.Info($"Add PortScanner_PortProfiles \"{portProfile.Name}\"...");
+                        _log.Info($"Add \"{portProfile.Name}\" to \"PortScanner_PortProfiles\"...");
                         Current.PortScanner_PortProfiles.Add(portProfile);
                     }
                     else if (!portProfile.Ports.Equals(portProfileFound.Ports))
                     {
-                        _log.Info($"Update PortScanner_PortProfiles \"{portProfile.Name}\"...");
+                        _log.Info($"Update \"{portProfile.Name}\" in \"PortScanner_PortProfiles\"...");
                         Current.PortScanner_PortProfiles.Remove(portProfileFound);
                         Current.PortScanner_PortProfiles.Add(portProfile);
                     }
                 }
 
                 // Add new DNS lookup profiles
-                _log.Info("Set \"DNSLookup_DNSServers_v2\" to default...");
+                _log.Info("Init \"DNSLookup_DNSServers_v2\" with default DNS servers...");
                 Current.DNSLookup_DNSServers_v2 = new ObservableCollection<DNSServerConnectionInfoProfile>(DNSServer.GetDefaultList());
             }
 

--- a/Source/NETworkManager.Utilities/StringHelper.cs
+++ b/Source/NETworkManager.Utilities/StringHelper.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.RegularExpressions;
+
+namespace NETworkManager.Utilities
+{
+    public static class StringHelper
+    {
+        /// <summary>
+        /// Method to remove whitespaces from a string.
+        /// </summary>
+        /// <param name="input">Text with whitespaces.</param>
+        /// <returns>Text without whitespaces.</returns>
+        public static string RemoveWhitespace(string input)
+        {
+            return Regex.Replace(input, @"\s+", "");
+        }
+    }
+}

--- a/Source/NETworkManager/ProfileDialogManager.cs
+++ b/Source/NETworkManager/ProfileDialogManager.cs
@@ -350,6 +350,8 @@ namespace NETworkManager
                 PuTTY_PrivateKeyFile = instance.PuTTY_PrivateKeyFile,
                 PuTTY_OverrideProfile = instance.PuTTY_OverrideProfile,
                 PuTTY_Profile = instance.PuTTY_Profile?.Trim(),
+                PuTTY_OverrideHostkey = instance.PuTTY_OverrideHostkey,
+                PuTTY_Hostkey = instance.PuTTY_Hostkey?.Trim(),
                 PuTTY_OverrideEnableLog = instance.PuTTY_OverrideEnableLog,
                 PuTTY_EnableLog = instance.PuTTY_EnableLog,
                 PuTTY_OverrideLogMode = instance.PuTTY_OverrideLogMode,

--- a/Source/NETworkManager/ViewModels/ProfileViewModel.cs
+++ b/Source/NETworkManager/ViewModels/ProfileViewModel.cs
@@ -1725,6 +1725,34 @@ namespace NETworkManager.ViewModels
             }
         }
 
+        private bool _puTTY_OverrideHostkey;
+        public bool PuTTY_OverrideHostkey
+        {
+            get => _puTTY_OverrideHostkey;
+            set
+            {
+                if (value == _puTTY_OverrideHostkey)
+                    return;
+
+                _puTTY_OverrideHostkey = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private string _puTTY_Hostkey;
+        public string PuTTY_Hostkey
+        {
+            get => _puTTY_Hostkey;
+            set
+            {
+                if (value == _puTTY_Hostkey)
+                    return;
+
+                _puTTY_Hostkey = value;
+                OnPropertyChanged();
+            }
+        }
+
         private bool _puTTY_OverrideEnableLog;
         public bool PuTTY_OverrideEnableLog
         {
@@ -2188,17 +2216,6 @@ namespace NETworkManager.ViewModels
         }
         #endregion
         #endregion
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="saveCommand"></param>
-        /// <param name="cancelHandler"></param>
-        /// <param name="groups"></param>
-        /// <param name="group"></param>
-        /// <param name="editMode"></param>
-        /// <param name="profile"></param>
-        /// <param name="applicationName"></param>
         public ProfileViewModel(Action<ProfileViewModel> saveCommand, Action<ProfileViewModel> cancelHandler, IReadOnlyCollection<string> groups, string group = null, ProfileEditMode editMode = ProfileEditMode.Add, ProfileInfo profile = null, ApplicationName applicationName = ApplicationName.None)
         {
             // Load the view
@@ -2362,6 +2379,8 @@ namespace NETworkManager.ViewModels
             PuTTY_PrivateKeyFile = profileInfo.PuTTY_PrivateKeyFile;
             PuTTY_OverrideProfile = profileInfo.PuTTY_OverrideProfile;
             PuTTY_Profile = profileInfo.PuTTY_Profile;
+            PuTTY_OverrideHostkey = profileInfo.PuTTY_OverrideHostkey;
+            PuTTY_Hostkey = profileInfo.PuTTY_Hostkey;
             PuTTY_OverrideEnableLog = profileInfo.PuTTY_OverrideEnableLog;
             PuTTY_EnableLog = profileInfo.PuTTY_EnableLog;
             PuTTY_OverrideLogMode = profileInfo.PuTTY_OverrideLogMode;

--- a/Source/NETworkManager/Views/ProfileDialog.xaml
+++ b/Source/NETworkManager/Views/ProfileDialog.xaml
@@ -1073,6 +1073,8 @@
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="10" />
                                     <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="10" />
+                                    <RowDefinition Height="Auto" />
                                 </Grid.RowDefinitions>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="1*" />
@@ -1193,20 +1195,22 @@
                                         </Binding>
                                     </TextBox.Text>
                                 </TextBox>
-                                <CheckBox Grid.Column="0" Grid.Row="16" Content="{x:Static localization:Strings.Profile}" IsChecked="{Binding PuTTY_OverrideProfile}" Style="{StaticResource DefaultCheckBox}" />
+                                <CheckBox Grid.Column="0" Grid.Row="16" Content="{x:Static localization:Strings.Profile}" IsChecked="{Binding PuTTY_OverrideProfile}" mah:TextBoxHelper.Watermark="{x:Static localization:StaticStrings.ExamplePuTTYProfile}" Style="{StaticResource DefaultCheckBox}" />
                                 <TextBox Grid.Column="2" Grid.Row="16" Text="{Binding PuTTY_Profile, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding PuTTY_OverrideProfile}" />
-                                <CheckBox Grid.Column="0" Grid.Row="18" Content="{x:Static localization:Strings.EnableLog}" IsChecked="{Binding PuTTY_OverrideEnableLog}" Style="{StaticResource DefaultCheckBox}" />
-                                <mah:ToggleSwitch Grid.Column="2" Grid.Row="18" OnContent="" OffContent="" IsOn="{Binding PuTTY_EnableLog}" IsEnabled="{Binding PuTTY_OverrideEnableLog}" />
-                                <CheckBox Grid.Column="0" Grid.Row="20" Content="{x:Static localization:Strings.LogMode}" IsChecked="{Binding PuTTY_OverrideLogMode}" Style="{StaticResource DefaultCheckBox}" />
-                                <ComboBox Grid.Column="2" Grid.Row="20" ItemsSource="{Binding PuTTY_LogModes}" SelectedItem="{Binding PuTTY_LogMode}" IsEnabled="{Binding PuTTY_OverrideLogMode}">
+                                <CheckBox Grid.Column="0" Grid.Row="18" Content="{x:Static localization:Strings.Hostkey}" IsChecked="{Binding PuTTY_OverrideHostkey}" Style="{StaticResource DefaultCheckBox}" />
+                                <TextBox Grid.Column="2" Grid.Row="18" Text="{Binding PuTTY_Hostkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" mah:TextBoxHelper.Watermark="{x:Static localization:StaticStrings.ExampleHostkey}" IsEnabled="{Binding PuTTY_OverrideHostkey}" />
+                                <CheckBox Grid.Column="0" Grid.Row="20" Content="{x:Static localization:Strings.EnableLog}" IsChecked="{Binding PuTTY_OverrideEnableLog}" Style="{StaticResource DefaultCheckBox}" />
+                                <mah:ToggleSwitch Grid.Column="2" Grid.Row="20" OnContent="" OffContent="" IsOn="{Binding PuTTY_EnableLog}" IsEnabled="{Binding PuTTY_OverrideEnableLog}" />
+                                <CheckBox Grid.Column="0" Grid.Row="22" Content="{x:Static localization:Strings.LogMode}" IsChecked="{Binding PuTTY_OverrideLogMode}" Style="{StaticResource DefaultCheckBox}" />
+                                <ComboBox Grid.Column="2" Grid.Row="22" ItemsSource="{Binding PuTTY_LogModes}" SelectedItem="{Binding PuTTY_LogMode}" IsEnabled="{Binding PuTTY_OverrideLogMode}">
                                     <ComboBox.ItemTemplate>
                                         <DataTemplate>
                                             <TextBlock Text="{Binding Converter={StaticResource PuTTYLogModeToStringConverter}}" Style="{StaticResource DefaultTextBlock}"/>
                                         </DataTemplate>
                                     </ComboBox.ItemTemplate>
                                 </ComboBox>
-                                <CheckBox Grid.Column="0" Grid.Row="22" Content="{x:Static localization:Strings.LogPath}" IsChecked="{Binding PuTTY_OverrideLogPath}" Style="{StaticResource DefaultCheckBox}" />
-                                <TextBox Grid.Column="2" Grid.Row="22" x:Name="TextBoxPuTTYLogPath" IsEnabled="{Binding PuTTY_OverrideLogPath}">
+                                <CheckBox Grid.Column="0" Grid.Row="24" Content="{x:Static localization:Strings.LogPath}" IsChecked="{Binding PuTTY_OverrideLogPath}" Style="{StaticResource DefaultCheckBox}" />
+                                <TextBox Grid.Column="2" Grid.Row="24" x:Name="TextBoxPuTTYLogPath" IsEnabled="{Binding PuTTY_OverrideLogPath}">
                                     <TextBox.Text>
                                         <Binding Path="PuTTY_LogPath" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
                                             <Binding.ValidationRules>
@@ -1216,8 +1220,8 @@
                                         </Binding>
                                     </TextBox.Text>
                                 </TextBox>
-                                <CheckBox Grid.Column="0" Grid.Row="24" Content="{x:Static localization:Strings.LogFileName}" IsChecked="{Binding PuTTY_OverrideLogFileName}" Style="{StaticResource DefaultCheckBox}" />
-                                <TextBox Grid.Column="2" Grid.Row="24" x:Name="TextBoxPuTTYLogFileName" IsEnabled="{Binding PuTTY_OverrideLogFileName}">
+                                <CheckBox Grid.Column="0" Grid.Row="26" Content="{x:Static localization:Strings.LogFileName}" IsChecked="{Binding PuTTY_OverrideLogFileName}" Style="{StaticResource DefaultCheckBox}" />
+                                <TextBox Grid.Column="2" Grid.Row="26" x:Name="TextBoxPuTTYLogFileName" IsEnabled="{Binding PuTTY_OverrideLogFileName}">
                                     <TextBox.Text>
                                         <Binding Path="PuTTY_LogFileName" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
                                             <Binding.ValidationRules>
@@ -1227,8 +1231,8 @@
                                         </Binding>
                                     </TextBox.Text>
                                 </TextBox>
-                                <CheckBox Grid.Column="0" Grid.Row="26" Content="{x:Static localization:Strings.AdditionalCommandLine}" IsChecked="{Binding PuTTY_OverrideAdditionalCommandLine}" Style="{StaticResource DefaultCheckBox}"/>
-                                <TextBox Grid.Column="2" Grid.Row="26" Text="{Binding PuTTY_AdditionalCommandLine}" IsEnabled="{Binding PuTTY_OverrideAdditionalCommandLine}" Style="{StaticResource DefaultTextBox}" />
+                                <CheckBox Grid.Column="0" Grid.Row="28" Content="{x:Static localization:Strings.AdditionalCommandLine}" IsChecked="{Binding PuTTY_OverrideAdditionalCommandLine}" Style="{StaticResource DefaultCheckBox}"/>
+                                <TextBox Grid.Column="2" Grid.Row="28" Text="{Binding PuTTY_AdditionalCommandLine}" IsEnabled="{Binding PuTTY_OverrideAdditionalCommandLine}" Style="{StaticResource DefaultTextBox}" />
                             </Grid>
                         </StackPanel>
                     </ScrollViewer>

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -52,6 +52,8 @@ New Feature
 - **DNS Lookup**
   - Improve overall DNS lookup performance with multiple DNS servers and hosts [#1940](https://github.com/BornToBeRoot/NETworkManager/pull/1940){:target="\_blank"}
   - New dialog to add/edit DNS servers [#1960](https://github.com/BornToBeRoot/NETworkManager/pull/1960){:target="\_blank"}
+- **PuTTY**
+  - Parameter `-hostkey` is now supported and can be configured in the profile. Multiple hostkeys can be separated by a comma. [#1977](https://github.com/BornToBeRoot/NETworkManager/pull/1977){:target="\_blank"}
 
 ## Bugfixes
 


### PR DESCRIPTION
**Please provide some details about this pull request:**
- PuTTY parameter `-hostkey` added
-
-

Fixes #1514 

**ToDo:** 

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).