### PR TITLE
Feature: Release & renew IPv6 & target ethernet adapter

### DIFF
--- a/Source/NETworkManager.Models/Network/IPConfigReleaseRenewMode.cs
+++ b/Source/NETworkManager.Models/Network/IPConfigReleaseRenewMode.cs
@@ -1,0 +1,37 @@
+﻿namespace NETworkManager.Models.Network;
+
+/// <summary>
+/// Release or renew modes to control ipconfig.exe.
+/// </summary>
+public enum IPConfigReleaseRenewMode
+{
+    /// <summary>
+    /// Release and renew IPv4.
+    /// </summary>
+    ReleaseRenew,
+    
+    /// <summary>
+    /// Release and renew IPv6.
+    /// </summary>
+    ReleaseRenew6,
+
+    /// <summary>
+    /// Release IPv4.
+    /// </summary>
+    Release,
+
+    /// <summary>
+    /// Release IPv6.
+    /// </summary>
+    Release6,
+
+    /// <summary>
+    /// Renew IPv4.
+    /// </summary>
+    Renew,
+
+    /// <summary>
+    /// Renew IPv6.
+    /// </summary>
+    Renew6        
+}

--- a/Source/NETworkManager.Utilities/PowerShellHelper.cs
+++ b/Source/NETworkManager.Utilities/PowerShellHelper.cs
@@ -1,28 +1,33 @@
 ﻿using System.Diagnostics;
 
-namespace NETworkManager.Utilities
+namespace NETworkManager.Utilities;
+
+public static class PowerShellHelper
 {
-    public static class PowerShellHelper
+    /// <summary>
+    /// Execute a PowerShell command.
+    /// </summary>
+    /// <param name="command">Command to execute.</param>
+    /// <param name="asAdmin">Start PowerShell as administrator. Error code 1223 is returned when UAC dialog is canceled by user.</param>
+    /// <param name="windowStyle">Window style of the PowerShell console (Default: Hidden)</param>
+    public static void ExecuteCommand(string command, bool asAdmin = false, ProcessWindowStyle windowStyle = ProcessWindowStyle.Hidden)
     {
-        public static void ExecuteCommand(string command, bool asAdmin = false, ProcessWindowStyle windowStyle = ProcessWindowStyle.Hidden)
+        var info = new ProcessStartInfo()
         {
-            var info = new ProcessStartInfo()
-            {
-                FileName = "powershell.exe",
-                Arguments = $"-NoProfile -NoLogo -Command {command}",
-                UseShellExecute = true,
-                WindowStyle = windowStyle
-            };
+            FileName = "powershell.exe",
+            Arguments = $"-NoProfile -NoLogo -Command {command}",
+            UseShellExecute = true,
+            WindowStyle = ProcessWindowStyle.Normal //windowStyle
+        };
 
-            if (asAdmin)
-                info.Verb = "runas";
+        if (asAdmin)
+            info.Verb = "runas";
 
-            using var process = new Process();
+        using var process = new Process();
 
-            process.StartInfo = info;
+        process.StartInfo = info;
 
-            process.Start();
-            process.WaitForExit();
-        }
+        process.Start();
+        process.WaitForExit();
     }
 }

--- a/Source/NETworkManager/Views/NetworkInterfaceView.xaml
+++ b/Source/NETworkManager/Views/NetworkInterfaceView.xaml
@@ -285,33 +285,17 @@
                                     </Grid>
                                 </mah:DropDownButton.Content>
                                 <mah:DropDownButton.Items>
-                                    <MenuItem Header="{x:Static localization:Strings.ReleaseRenew}" Command="{Binding ReleaseRenewCommand}" IsEnabled="{Binding IsConfigurationRunning, Converter={StaticResource BooleanReverseConverter}}">
-                                        <MenuItem.Icon>
-                                            <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
-                                                <Rectangle.OpacityMask>
-                                                    <VisualBrush Stretch="Uniform" Visual="{iconPacks:Modern Kind=Refresh}" />
-                                                </Rectangle.OpacityMask>
-                                            </Rectangle>
-                                        </MenuItem.Icon>
+                                    <MenuItem Header="{x:Static localization:Strings.IPv4}">
+                                        <MenuItem Header="{x:Static localization:Strings.ReleaseRenew}" Command="{Binding ReleaseRenewCommand}" IsEnabled="{Binding IsConfigurationRunning, Converter={StaticResource BooleanReverseConverter}}" />
+                                        <Separator />
+                                        <MenuItem Header="{x:Static localization:Strings.Release}" Command="{Binding ReleaseCommand}" IsEnabled="{Binding IsConfigurationRunning, Converter={StaticResource BooleanReverseConverter}}" />
+                                        <MenuItem Header="{x:Static localization:Strings.Renew}" Command="{Binding RenewCommand}" IsEnabled="{Binding IsConfigurationRunning, Converter={StaticResource BooleanReverseConverter}}" />
                                     </MenuItem>
-                                    <Separator />
-                                    <MenuItem Header="{x:Static localization:Strings.Release}" Command="{Binding ReleaseCommand}" IsEnabled="{Binding IsConfigurationRunning, Converter={StaticResource BooleanReverseConverter}}">
-                                        <MenuItem.Icon>
-                                            <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
-                                                <Rectangle.OpacityMask>
-                                                    <VisualBrush Stretch="Uniform" Visual="{iconPacks:Modern Kind=Refresh}" />
-                                                </Rectangle.OpacityMask>
-                                            </Rectangle>
-                                        </MenuItem.Icon>
-                                    </MenuItem>
-                                    <MenuItem Header="{x:Static localization:Strings.Renew}" Command="{Binding RenewCommand}" IsEnabled="{Binding IsConfigurationRunning, Converter={StaticResource BooleanReverseConverter}}">
-                                        <MenuItem.Icon>
-                                            <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
-                                                <Rectangle.OpacityMask>
-                                                    <VisualBrush Stretch="Uniform" Visual="{iconPacks:Modern Kind=Refresh}" />
-                                                </Rectangle.OpacityMask>
-                                            </Rectangle>
-                                        </MenuItem.Icon>
+                                    <MenuItem Header="{x:Static localization:Strings.IPv6}">
+                                        <MenuItem Header="{x:Static localization:Strings.ReleaseRenew}" Command="{Binding ReleaseRenew6Command}" IsEnabled="{Binding IsConfigurationRunning, Converter={StaticResource BooleanReverseConverter}}" />
+                                        <Separator />
+                                        <MenuItem Header="{x:Static localization:Strings.Release}" Command="{Binding Release6Command}" IsEnabled="{Binding IsConfigurationRunning, Converter={StaticResource BooleanReverseConverter}}" />
+                                        <MenuItem Header="{x:Static localization:Strings.Renew}" Command="{Binding Renew6Command}" IsEnabled="{Binding IsConfigurationRunning, Converter={StaticResource BooleanReverseConverter}}" />
                                     </MenuItem>
                                 </mah:DropDownButton.Items>
                             </mah:DropDownButton>

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -33,6 +33,9 @@ New Feature
 - DataGrid Column header design improved [#1910](https://github.com/BornToBeRoot/NETworkManager/pull/1910){:target="\_blank"}
 - DataGrid Columns can now be resized [#1910](https://github.com/BornToBeRoot/NETworkManager/pull/1910){:target="\_blank"}
 - Add text wrapping for status textboxes [#1949](https://github.com/BornToBeRoot/NETworkManager/pull/1940){:target="\_blank"}
+- **Network Interface**
+  - Release & Renew button now targets the selected interface instead of all interfaces [#1982](https://github.com/BornToBeRoot/NETworkManager/pull/1982){:target="\_blank"}
+  - Release & Renew button now supports IPv6 [#1982](https://github.com/BornToBeRoot/NETworkManager/pull/1982){:target="\_blank"}  
 - **WiFi**
   - Improve search - you can now search for SSID, Security, Channel, BSSID (MAC address), Vendor and Phy kind [#1941](https://github.com/BornToBeRoot/NETworkManager/pull/1941){:target="\_blank"}
 - **IP Scanner**

--- a/docs/Documentation/01_Application/02_NetworkInterface.md
+++ b/docs/Documentation/01_Application/02_NetworkInterface.md
@@ -21,9 +21,14 @@ In addition, further actions can be performed using the buttons at the bottom le
 - **Network connections...** - Opens the `Control Panel > Network and Internet > Network Connections` window
 - **Flush DNS cache** - Flush the DNS cache (`ipconfig /flushdns`)
 - **Release & Renew**
-  - **Release & Renew** - Releases the current IPv4 addresses obtained via DHCP and renews them via DHCP for all network adapters that are configured to automatically obtain an IPv4 address (`ipconfig /release && ipconfig /renew`)
-  - **Release** - Releases the current IPv4 addresses obtained via DHCP for all network adapters that are configured to automatically obtain an IPv4 address. (`ipconfig /release`)
-  - **Renew** - Renews the current IPv4 address via DHCP for all network adapters that are configured to automatically obtain an IPv4 address. (`ipconfig /renew`)
+  - **IPv4**
+    - **Release & Renew** - Releases the current IPv4 addresses obtained via DHCP and renews them via DHCP for the _selected_ network adapter that is configured to automatically obtain an IPv4 address (`ipconfig /release && ipconfig /renew`)
+    - **Release** - Releases the current IPv4 addresses obtained via DHCP for the _selected_ network adapter that is configured to automatically obtain an IPv4 address. (`ipconfig /release`)
+    - **Renew** - Renews the current IPv4 address via DHCP for the _selected_ network adapter that is configured to automatically obtain an IPv4 address. (`ipconfig /renew`)
+  - **IPv6**
+    - **Release & Renew** - Releases the current IPv6 addresses obtained via DHCPv6 and renews them via DHCPv6 for the _selected_ adapter that ist configured to automatically obtain an IPv6 address (`ipconfig /release6 && ipconfig /renew6`)
+    - **Release** - Releases the current IPv6 addresses obtained via DHCPv6 for the _selected_ network adapter that is configured to automatically obtain an IPv6 address. (`ipconfig /release6`)
+    - **Renew** - Renews the current IPv6 address via DHCPv6 for the _selected_ network adapter that is configured to automatically obtain an IPv6 address. (`ipconfig /renew6`)
 
 ![NetworkInterface_Information](02_NetworkInterface_Information.png)
 


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Add IPv6 to Network Interface `Release & Renew`
- Target the selected network interface adapter.
-

Fixes #1873
Fixes #1874 

**ToDo:**

- [ ] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Documentation) to reflect this changes
- [ ] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).