### PR TITLE
Feature: IP Scanner > Pass MAC address as argument to a new profile

### DIFF
--- a/Source/NETworkManager.Models/Network/HostInfo.cs
+++ b/Source/NETworkManager.Models/Network/HostInfo.cs
@@ -9,7 +9,7 @@ namespace NETworkManager.Models.Network
         public PhysicalAddress MACAddress { get; set; }
         public string Vendor { get; set; }
 
-        public string MACAddressString => MACAddress.ToString();
+        public string MACAddressString => MACAddress?.ToString();
 
         public HostInfo()
         {

--- a/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
@@ -326,7 +326,10 @@ namespace NETworkManager.ViewModels
             ProfileInfo profileInfo = new()
             {
                 Name = string.IsNullOrEmpty(SelectedResult.Hostname) ? SelectedResult.PingInfo.IPAddress.ToString() : SelectedResult.Hostname.TrimEnd('.'),
-                Host = SelectedResult.PingInfo.IPAddress.ToString()
+                Host = SelectedResult.PingInfo.IPAddress.ToString(),
+
+                // Additional data
+                WakeOnLAN_MACAddress = SelectedResult.MACAddressString
             };
 
             var customDialog = new CustomDialog
@@ -511,7 +514,7 @@ namespace NETworkManager.ViewModels
             CancelScan = true;
             _cancellationTokenSource.Cancel();
         }
-        
+
         private async Task DetectIPRange()
         {
             IsSubnetDetectionRunning = true;
@@ -667,7 +670,7 @@ namespace NETworkManager.ViewModels
         {
             StatusMessage = $"{Localization.Resources.Strings.TheFollowingHostnamesCouldNotBeResolved} {string.Join(", ", e.Flatten().InnerExceptions.Select(x => x.Message))}";
             IsStatusMessageDisplayed = true;
-            
+
             CancelScan = false;
             IsScanRunning = false;
         }
@@ -675,7 +678,7 @@ namespace NETworkManager.ViewModels
         private void UserHasCanceled(object sender, EventArgs e)
         {
             StatusMessage = Localization.Resources.Strings.CanceledByUserMessage;
-            IsStatusMessageDisplayed = true;                        
+            IsStatusMessageDisplayed = true;
         }
 
         private void SettingsManager_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -52,6 +52,7 @@ The profiles and settings are automatically migrated to the new location when th
   - Max threads changed to to 1024 [#1927](https://github.com/BornToBeRoot/NETworkManager/pull/1927){:target="\_blank"}
   - Event handling when a host is found, user has canceled, etc. [#1969](https://github.com/BornToBeRoot/NETworkManager/pull/1969){:target="\_blank"}
   - Remove option to set the preferred IP protocol for DNS resolution (can now be set globally) [#1950](https://github.com/BornToBeRoot/NETworkManager/pull/1950){:target="\_blank"}
+  - Create profile from IP scanner now passes the MAC address, if available [#1998](https://github.com/BornToBeRoot/NETworkManager/pull/1998){:target="\_blank"}
 - **Port Scanner**
   - Add new port profiles / improve existing ones [#1909](https://github.com/BornToBeRoot/NETworkManager/pull/1909){:target="\_blank"}
   - New Port state "Timed out" if the timelimit is reached. [#1969](https://github.com/BornToBeRoot/NETworkManager/pull/1969){:target="\_blank"}


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Pass MAC address as argument to a new profile
-
-

Fixes #1270

**ToDo:**

- [x] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Documentation) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).