### PR TITLE
Feature: Use Edge instead of iexplore for custom command

### DIFF
--- a/Source/NETworkManager.Models/Network/IPScannerCustomCommand.cs
+++ b/Source/NETworkManager.Models/Network/IPScannerCustomCommand.cs
@@ -10,8 +10,8 @@ public static class IPScannerCustomCommand
     {
         return new List<CustomCommandInfo>
         {
-            new CustomCommandInfo(Guid.NewGuid(), "Internet Explorer", "iexplore.exe", @"http://$$ipaddress$$/"),
-            new CustomCommandInfo(Guid.NewGuid(), "Internet Explorer (https)", "iexplore.exe", @"https://$$ipaddress$$/"),
+            new CustomCommandInfo(Guid.NewGuid(), "Edge", "cmd.exe", @"/c start microsoft-edge:http://$$ipaddress$$/"),
+            new CustomCommandInfo(Guid.NewGuid(), "Edge (https)", "cmd.exe", @"/c start microsoft-edge:https://$$ipaddress$$/"),
             new CustomCommandInfo(Guid.NewGuid(), "Windows Explorer (c$)", "explorer.exe", @"\\$$ipaddress$$\c$")
         };
     }

--- a/Source/NETworkManager.Settings/SettingsManager.cs
+++ b/Source/NETworkManager.Settings/SettingsManager.cs
@@ -246,6 +246,18 @@ public static class SettingsManager
             Current.PortScanner_PortThreads = 1024;
         }
 
+        // Add IP Scanner custom commands
+        foreach(var customCommand in IPScannerCustomCommand.GetDefaultList())
+        {
+            var customCommandFound = Current.IPScanner_CustomCommands.FirstOrDefault(x => x.Name == customCommand.Name);
+
+            if(customCommandFound == null)
+            {
+                _log.Info($"Add \"{customCommand.Name}\" to \"IPScanner_CustomCommands\"...");
+                Current.IPScanner_CustomCommands.Add(customCommand);
+            }
+        }
+
         // Add or update Port Scanner port profiles
         foreach (var portProfile in PortProfile.GetDefaultList())
         {

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -53,6 +53,7 @@ The profiles and settings are automatically migrated to the new location when th
   - Event handling when a host is found, user has canceled, etc. [#1969](https://github.com/BornToBeRoot/NETworkManager/pull/1969){:target="\_blank"}
   - Remove option to set the preferred IP protocol for DNS resolution (can now be set globally) [#1950](https://github.com/BornToBeRoot/NETworkManager/pull/1950){:target="\_blank"}
   - Create profile from IP scanner now passes the MAC address, if available [#1998](https://github.com/BornToBeRoot/NETworkManager/pull/1998){:target="\_blank"}
+  - Edge added to custom commands (iexplore deprecated in new installations) [#2006](https://github.com/BornToBeRoot/NETworkManager/pull/2006){:target="\_blank"}
 - **Port Scanner**
   - Add new port profiles / improve existing ones [#1909](https://github.com/BornToBeRoot/NETworkManager/pull/1909){:target="\_blank"}
   - New Port state "Timed out" if the timelimit is reached. [#1969](https://github.com/BornToBeRoot/NETworkManager/pull/1969){:target="\_blank"}

--- a/docs/Documentation/01_Application/04_IPScanner.md
+++ b/docs/Documentation/01_Application/04_IPScanner.md
@@ -137,11 +137,11 @@ Custom commands that can be executed with a right click on the selected result.
 
 **Default:**
 
-| Name                      | File path      | Arguments                |
-| ------------------------- | -------------- | ------------------------ |
-| Internet Explorer         | `iexplore.exe` | `http://$$ipaddress$$/`  |
-| Internet Explorer (https) | `iexplore.exe` | `https://$$ipaddress$$/` |
-| Windows Explorer (c$)     | `explorer.exe` | `\\$$ipaddress$$\c$`     |
+| Name                  | File path      | Arguments                                        |
+| --------------------- | -------------- | ------------------------------------------------ |
+| Edge                  | `cmd.exe`      | `/c start microsoft-edge:http://$$ipaddress$$/`  |
+| Edge (https)          | `cmd.exe`      | `/c start microsoft-edge:https://$$ipaddress$$/` |
+| Windows Explorer (c$) | `explorer.exe` | `\\$$ipaddress$$\c$`                             |
 
 In the arguments you can use the following placeholders:
 


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Use Edge instead of iexplore for custom command
-
-

Fixes #2005

**ToDo:**

- [x] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Documentation) to reflect this changes
- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).