### PR TITLE
Feature: IP Scanner button in network interface, fix bug in redirect

### DIFF
--- a/Source/NETworkManager.Converters/IPAddressSubnetmaskTupleArrayToStringConverter.cs
+++ b/Source/NETworkManager.Converters/IPAddressSubnetmaskTupleArrayToStringConverter.cs
@@ -11,11 +11,11 @@ namespace NETworkManager.Converters;
 public sealed class IPAddressSubnetmaskTupleArrayToStringConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-    {
+    {        
         if (DesignerProperties.GetIsInDesignMode(new DependencyObject()))
             return "-/-";
 
-        if (!(value is Tuple<IPAddress, IPAddress>[] ipAddresses))
+        if (value is not Tuple<IPAddress, IPAddress>[] ipAddresses)
             return "-/-";
 
         var result = string.Empty;

--- a/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
+++ b/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
@@ -1861,6 +1861,15 @@ namespace NETworkManager.Localization.Resources {
         }
         
         /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Could not find the application &quot;{0}&quot;. Maybe the application was hidden in the settings? ähnelt.
+        /// </summary>
+        public static string CouldNotFindApplicationXXXMessage {
+            get {
+                return ResourceManager.GetString("CouldNotFindApplicationXXXMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die Could not get public ip address via WebRequest (http/https) from &quot;{0}&quot;! Check your network connection (firewall, proxy, etc.). ähnelt.
         /// </summary>
         public static string CouldNotGetPublicIPAddressFromXXXMessage {

--- a/Source/NETworkManager.Localization/Resources/Strings.resx
+++ b/Source/NETworkManager.Localization/Resources/Strings.resx
@@ -3316,4 +3316,7 @@ Changes to this value will take effect after the application is restarted. Wheth
   <data name="ScanPorts" xml:space="preserve">
     <value>Scan ports</value>
   </data>
+  <data name="CouldNotFindApplicationXXXMessage" xml:space="preserve">
+    <value>Could not find the application "{0}". Maybe the application was hidden in the settings?</value>
+  </data>
 </root>

--- a/Source/NETworkManager.Models/EventSystem/EventSystem.cs
+++ b/Source/NETworkManager.Models/EventSystem/EventSystem.cs
@@ -4,7 +4,7 @@ namespace NETworkManager.Models.EventSystem;
 
 public class EventSystem
 {
-    // This will notify the mail window, to change the view to another application and redirect some data (hostname, ip)
+    // This will notify the main window, to change the view to another application and redirect some data (hostname, ip)
     public static event EventHandler OnRedirectDataToApplicationEvent;
 
     public static void RedirectToApplication(ApplicationName application, string data)

--- a/Source/NETworkManager/MainWindow.xaml.cs
+++ b/Source/NETworkManager/MainWindow.xaml.cs
@@ -936,13 +936,26 @@ public partial class MainWindow : INotifyPropertyChanged
         ListViewApplication.ScrollIntoView(SelectedApplication);
     }
 
-    private void EventSystem_RedirectDataToApplicationEvent(object sender, EventArgs e)
+    private async void EventSystem_RedirectDataToApplicationEvent(object sender, EventArgs e)
     {
         if (e is not EventSystemRedirectArgs data)
             return;
 
         // Change view
-        SelectedApplication = Applications.SourceCollection.Cast<ApplicationInfo>().FirstOrDefault(x => x.Name == data.Application);
+        var application = Applications.Cast<ApplicationInfo>().FirstOrDefault(x => x.Name == data.Application);
+
+        if (application == null)
+        {
+            var settings = AppearanceManager.MetroDialog;
+            settings.AffirmativeButtonText = Localization.Resources.Strings.OK;
+
+            await this.ShowMessageAsync(Localization.Resources.Strings.Error, string.Format(Localization.Resources.Strings.CouldNotFindApplicationXXXMessage, data.Application.ToString()));
+
+            return;
+        }
+
+        // Change view
+        SelectedApplication = application;               
 
         // Crate a new tab / perform action
         switch (data.Application)

--- a/Source/NETworkManager/Resources/Styles/RectangleStyles.xaml
+++ b/Source/NETworkManager/Resources/Styles/RectangleStyles.xaml
@@ -1,6 +1,13 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks">
+    <Style x:Key="ButtonWithImageRectangle" TargetType="{x:Type Rectangle}">
+        <Setter Property="Width" Value="20" />
+        <Setter Property="Height" Value="20" />
+        <Setter Property="Margin" Value="10,5,0,5" />
+        <Setter Property="Fill" Value="{DynamicResource MahApps.Brushes.Gray3}" />
+    </Style>
+    
     <Style x:Key="HelpImageRectangle" TargetType="{x:Type Rectangle}">
         <Style.Resources>
             <Style TargetType="{x:Type ToolTip}" BasedOn="{StaticResource DefaultToolTip}" />

--- a/Source/NETworkManager/Resources/Styles/TextBlockStyles.xaml
+++ b/Source/NETworkManager/Resources/Styles/TextBlockStyles.xaml
@@ -52,8 +52,13 @@
 
     <Style x:Key="StatusMessageTextBlock" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource WrapTextBlock}" />
 
-    <Style x:Key="CenterTextBlock" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource DefaultTextBlock}" >
-        <Setter Property="Margin"  Value="0,0,10,0" />
+    <!-- TextBlock style for buttons with images and text -->
+    <Style x:Key="ButtonWithImageTextBlock" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource DefaultTextBlock}" >
+        <Setter Property="Margin" Value="10,5" />
+        <Setter Property="TextAlignment" Value="Center" />
+    </Style>
+    
+    <Style x:Key="CenterTextBlock" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource DefaultTextBlock}" >        
         <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
 

--- a/Source/NETworkManager/Resources/Styles/TextBoxStyles.xaml
+++ b/Source/NETworkManager/Resources/Styles/TextBoxStyles.xaml
@@ -11,7 +11,7 @@
         <Setter Property="Validation.ErrorTemplate" Value="{StaticResource DefaultErrorTemplate}" />
     </Style>
 
-    <!-- Apply the default design to all text boxes -->
+    <!-- Apply the default design to all TextBox -->
     <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource DefaultTextBox}" />
 
     <Style x:Key="ConsoleTextBox" TargetType="{x:Type TextBox}" BasedOn="{StaticResource DefaultTextBox}">

--- a/Source/NETworkManager/ViewModels/NetworkInterfaceViewModel.cs
+++ b/Source/NETworkManager/ViewModels/NetworkInterfaceViewModel.cs
@@ -20,6 +20,7 @@ using MahApps.Metro.Controls;
 using NETworkManager.Profiles;
 using System.Windows.Threading;
 using NETworkManager.Models;
+using NETworkManager.Models.EventSystem;
 
 namespace NETworkManager.ViewModels;
 
@@ -681,7 +682,20 @@ public class NetworkInterfaceViewModel : ViewModelBase, IProfileManager
     {
         OpenNetworkConnectionsAsync();
     }
-    
+
+    public ICommand IPScannerCommand => new RelayCommand(p => IPScannerAction(), AdditionalCommands_CanExecute);
+
+    private void IPScannerAction()
+    {
+        var ipTuple = SelectedNetworkInterface?.IPv4Address.FirstOrDefault();
+
+        // ToDo: Log error in the future
+        if (ipTuple == null)
+            return;
+        
+        EventSystem.RedirectToApplication(ApplicationName.IPScanner, $"{ipTuple.Item1}/{Subnetmask.ConvertSubnetmaskToCidr(ipTuple.Item2)}");
+    }
+
     public ICommand FlushDNSCommand => new RelayCommand(p => FlushDNSAction(), AdditionalCommands_CanExecute);
 
     private void FlushDNSAction()

--- a/Source/NETworkManager/Views/NetworkInterfaceView.xaml
+++ b/Source/NETworkManager/Views/NetworkInterfaceView.xaml
@@ -244,12 +244,41 @@
                                             <ColumnDefinition Width="Auto" />
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
-                                        <Rectangle Width="20" Height="20" Margin="10,5,0,5" Fill="{DynamicResource MahApps.Brushes.Gray3}">
+                                        <Rectangle Style="{StaticResource ButtonWithImageRectangle}">
                                             <Rectangle.OpacityMask>
                                                 <VisualBrush Stretch="Uniform" Visual="{iconPacks:Modern Kind=Network}" />
                                             </Rectangle.OpacityMask>
                                         </Rectangle>
-                                        <TextBlock Grid.Column="1" Text="{x:Static localization:Strings.NetworkConnectionsDots}" FontSize="14" Margin="10,5" TextAlignment="Center"/>
+                                        <TextBlock Grid.Column="1" Text="{x:Static localization:Strings.NetworkConnectionsDots}" Style="{StaticResource ButtonWithImageTextBlock}" />
+                                    </Grid>
+                                </Button.Content>
+                            </Button>
+                            <Button HorizontalAlignment="Left" Command="{Binding IPScannerCommand}" Margin="0,0,10,0">
+                                <Button.Resources>
+                                    <Style TargetType="{x:Type Button}" BasedOn="{StaticResource ImageWithTextButton}">
+                                        <Setter Property="IsEnabled" Value="True" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Path=IsNetworkInterfaceLoading}" Value="True">
+                                                <Setter Property="IsEnabled" Value="False" />
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding Path=SelectedNetworkInterface.IPv4ProtocolAvailable}" Value="False">
+                                                <Setter Property="IsEnabled" Value="False" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Resources>
+                                <Button.Content>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <Rectangle Style="{StaticResource ButtonWithImageRectangle}">
+                                            <Rectangle.OpacityMask>
+                                                <VisualBrush Stretch="Uniform" Visual="{iconPacks:FontAwesome Kind=NetworkWiredSolid}" />
+                                            </Rectangle.OpacityMask>
+                                        </Rectangle>
+                                        <TextBlock Grid.Column="1" Text="{x:Static localization:Strings.IPScanner}" Style="{StaticResource ButtonWithImageTextBlock}" />
                                     </Grid>
                                 </Button.Content>
                             </Button>
@@ -260,12 +289,12 @@
                                             <ColumnDefinition Width="Auto" />
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
-                                        <Rectangle Width="20" Height="20" Margin="10,5,0,5" Fill="{DynamicResource MahApps.Brushes.Gray3}">
+                                        <Rectangle Style="{StaticResource ButtonWithImageRectangle}">
                                             <Rectangle.OpacityMask>
                                                 <VisualBrush Stretch="Uniform" Visual="{iconPacks:Modern Kind=ListDelete}" />
                                             </Rectangle.OpacityMask>
                                         </Rectangle>
-                                        <TextBlock Grid.Column="1" Text="{x:Static localization:Strings.FlushDNSCache}" FontSize="14" Margin="10,5" TextAlignment="Center"/>
+                                        <TextBlock Grid.Column="1" Text="{x:Static localization:Strings.FlushDNSCache}" Style="{StaticResource ButtonWithImageTextBlock}" />
                                     </Grid>
                                 </Button.Content>
                             </Button>
@@ -276,12 +305,12 @@
                                             <ColumnDefinition Width="Auto" />
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
-                                        <Rectangle Width="20" Height="20" Margin="10,4,0,4" Fill="{DynamicResource MahApps.Brushes.Gray3}">
+                                        <Rectangle Style="{StaticResource ButtonWithImageRectangle}" Margin="10,4,0,4">
                                             <Rectangle.OpacityMask>
                                                 <VisualBrush Stretch="Uniform" Visual="{iconPacks:Modern Kind=Refresh}" />
                                             </Rectangle.OpacityMask>
                                         </Rectangle>
-                                        <TextBlock Grid.Column="1" Text="{x:Static localization:Strings.ReleaseRenew}" FontSize="14" Margin="10,4" TextAlignment="Center"/>
+                                        <TextBlock Grid.Column="1" Text="{x:Static localization:Strings.ReleaseRenew}" Style="{StaticResource ButtonWithImageTextBlock}" Margin="10,4" />
                                     </Grid>
                                 </mah:DropDownButton.Content>
                                 <mah:DropDownButton.Items>
@@ -603,6 +632,7 @@
                                         </Grid.Resources>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="1*" />
+                                            <ColumnDefinition Width="10" />
                                             <ColumnDefinition Width="1*" />
                                         </Grid.ColumnDefinitions>
                                         <Grid.RowDefinitions>
@@ -612,8 +642,8 @@
                                             <RowDefinition Height="10" />
                                             <RowDefinition Height="Auto" />
                                         </Grid.RowDefinitions>
-                                        <TextBlock Grid.Column="0" Grid.Row="0" Style="{StaticResource CenterTextBlock}" Text="{x:Static localization:Strings.IPv4Address}" />
-                                        <TextBox x:Name="TextBoxConfigIPAddress" Grid.Column="1" Grid.Row="0" mah:TextBoxHelper.Watermark="{x:Static localization:StaticStrings.ExampleIPv4Address}">
+                                        <TextBlock Grid.Column="0" Grid.Row="0" Text="{x:Static localization:Strings.IPv4Address}" />
+                                        <TextBox x:Name="TextBoxConfigIPAddress" Grid.Column="2" Grid.Row="0" mah:TextBoxHelper.Watermark="{x:Static localization:StaticStrings.ExampleIPv4Address}">
                                             <TextBox.Text>
                                                 <Binding Path="ConfigIPAddress" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
                                                     <Binding.ValidationRules>
@@ -623,8 +653,8 @@
                                                 </Binding>
                                             </TextBox.Text>
                                         </TextBox>
-                                        <TextBlock Grid.Column="0" Grid.Row="2" Style="{StaticResource CenterTextBlock}" Text="{x:Static localization:Strings.SubnetmaskOrCIDR}" />
-                                        <ComboBox x:Name="ComboBoxConfigSubnetmaskOrCidr" Grid.Column="1" Grid.Row="2" Style="{StaticResource EditableComboBox}" mah:TextBoxHelper.Watermark="{x:Static localization:StaticStrings.ExampleIPv4SubnetmaskIPv4CIDR}" ItemsSource="{x:Static network:Subnetmask.List}">
+                                        <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static localization:Strings.SubnetmaskOrCIDR}" />
+                                        <ComboBox x:Name="ComboBoxConfigSubnetmaskOrCidr" Grid.Column="2" Grid.Row="2" Style="{StaticResource EditableComboBox}" mah:TextBoxHelper.Watermark="{x:Static localization:StaticStrings.ExampleIPv4SubnetmaskIPv4CIDR}" ItemsSource="{x:Static network:Subnetmask.List}">
                                             <ComboBox.Text>
                                                 <Binding Path="ConfigSubnetmaskOrCidr" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
                                                     <Binding.ValidationRules>
@@ -650,7 +680,7 @@
                                             </ComboBox.ItemTemplate>
                                         </ComboBox>
                                         <TextBlock Grid.Column="0" Grid.Row="4" Style="{StaticResource CenterTextBlock}"  Text="{x:Static localization:Strings.DefaultGateway}"  />
-                                        <TextBox x:Name="TextBoxConfigGateway" Grid.Column="1" Grid.Row="4" mah:TextBoxHelper.Watermark="{x:Static localization:StaticStrings.ExampleIPv4Gateway}">
+                                        <TextBox x:Name="TextBoxConfigGateway" Grid.Column="2" Grid.Row="4" mah:TextBoxHelper.Watermark="{x:Static localization:StaticStrings.ExampleIPv4Gateway}">
                                             <TextBox.Text>
                                                 <Binding Path="ConfigGateway" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
                                                     <Binding.ValidationRules>
@@ -677,6 +707,7 @@
                                         </Grid.Resources>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="1*" />
+                                            <ColumnDefinition Width="10" />
                                             <ColumnDefinition Width="1*" />
                                         </Grid.ColumnDefinitions>
                                         <Grid.RowDefinitions>
@@ -684,8 +715,8 @@
                                             <RowDefinition Height="10" />
                                             <RowDefinition Height="Auto" />
                                         </Grid.RowDefinitions>
-                                        <TextBlock Grid.Column="0" Grid.Row="0" Style="{StaticResource CenterTextBlock}"  Text="{x:Static localization:Strings.PrimaryDNSServer}"  />
-                                        <TextBox x:Name="TextBoxConfigPrimaryDNSServer" Grid.Column="1" Grid.Row="0" mah:TextBoxHelper.Watermark="{x:Static localization:StaticStrings.ExampleIPv4Gateway}">
+                                        <TextBlock Grid.Column="0" Grid.Row="0" Text="{x:Static localization:Strings.PrimaryDNSServer}"  />
+                                        <TextBox x:Name="TextBoxConfigPrimaryDNSServer" Grid.Column="2" Grid.Row="0" mah:TextBoxHelper.Watermark="{x:Static localization:StaticStrings.ExampleIPv4Gateway}">
                                             <TextBox.Text>
                                                 <Binding Path="ConfigPrimaryDNSServer" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
                                                     <Binding.ValidationRules>
@@ -694,8 +725,8 @@
                                                 </Binding>
                                             </TextBox.Text>
                                         </TextBox>
-                                        <TextBlock Grid.Column="0" Grid.Row="2" Style="{StaticResource CenterTextBlock}"  Text="{x:Static localization:Strings.SecondaryDNSServer}"  />
-                                        <TextBox x:Name="TextBoxConfigSecondaryDNSServer" Grid.Column="1" Grid.Row="2" mah:TextBoxHelper.Watermark="{x:Static localization:StaticStrings.ExampleIPv4DNSServer}">
+                                        <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static localization:Strings.SecondaryDNSServer}"  />
+                                        <TextBox x:Name="TextBoxConfigSecondaryDNSServer" Grid.Column="2" Grid.Row="2" mah:TextBoxHelper.Watermark="{x:Static localization:StaticStrings.ExampleIPv4DNSServer}">
                                             <TextBox.Text>
                                                 <Binding Path="ConfigSecondaryDNSServer" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
                                                     <Binding.ValidationRules>

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -26,6 +26,8 @@ Release date: **xx.xx.2023**
 - Reselect profile or select first profile after (re)loading or search [#2014](https://github.com/BornToBeRoot/NETworkManager/pull/2014){:target="\_blank"}
 - Some designs have been improved (Error & Warning icons). [#2014](https://github.com/BornToBeRoot/NETworkManager/pull/2014){:target="\_blank"}
 - You can now configure the application wide [ThreadPool](https://learn.microsoft.com/en-us/dotnet/standard/threading/the-managed-thread-pool) under `Settings > General > Multithreading`, which is used for the IP scanner and the port scanner. The default value for min. threads are CPU threads + 512. Depending on the hardware, this can improve the performance of the scan. [#2026](https://github.com/BornToBeRoot/NETworkManager/pull/2026){:target="\_blank"}
+- **Network Interface**
+  - Add a button to redirect the the IPv4 address and subnetmask of the selected network interface to the IP scanner [#2046](https://github.com/BornToBeRoot/NETworkManager/pull/2046){:target="\_blank"}
 - **IP Scanner**
   - Option added to limit the number of concurrent threads per host scan (256) & port scan (5). Increasing the values can speed up the scan, but can also lead to resource problems. [#2026](https://github.com/BornToBeRoot/NETworkManager/pull/2026){:target="\_blank"}
 - **Port Scanner**
@@ -33,6 +35,7 @@ Release date: **xx.xx.2023**
 
 ## Bugfixes
 
+- Show error message when redirecting to another application, but the application is hidden in the settings or somehow invalid [#2046](https://github.com/BornToBeRoot/NETworkManager/pull/2046){:target="\_blank"}
 - Group name check is now case insensitive and a group name can only be used once. If you create a group named `Test`, you cannot create a group named `test`. [#2014](https://github.com/BornToBeRoot/NETworkManager/pull/2014){:target="\_blank"}
 - Profile dialog
   - Validate AWS Session Manager input (instance ID, profile, region) [#2025](https://github.com/BornToBeRoot/NETworkManager/pull/2025){:target="\_blank"}


### PR DESCRIPTION
**Please provide some details about this pull request:**
-  Add a button to redirect the the IPv4 address and subnetmask of the selected network interface to the IP scanner
- Show error if app is hidden


Close #2043 

**ToDo:**

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).