### PR TITLE
Fix: Some commands tabcontrol context menu

### DIFF
--- a/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml
+++ b/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml
@@ -163,7 +163,7 @@
                                                                 </MenuItem.Icon>
                                                             </MenuItem>
                                                             <Separator />
-                                                            <MenuItem Header="{x:Static localization:Strings.Resize}" Command="{Binding Data.PuTTY_ResizeWindowCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
+                                                            <MenuItem Header="{x:Static localization:Strings.Resize}" Command="{Binding Data.PowerShell_ResizeWindowCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                                                 <MenuItem.Icon>
                                                                     <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
                                                                         <Rectangle.OpacityMask>

--- a/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
+++ b/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
@@ -115,16 +115,8 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
         }
     }
 
-    #region RemoteDesktop Commands
-    private bool RemoteDesktop_Disconnected_CanExecute(object view)
-    {
-        if (view is RemoteDesktopControl control)
-            return !control.IsConnected;
-
-        return false;
-    }
-
-    private bool RemoteDesktop_Connected_CanExecute(object view)
+    #region RemoteDesktop Commands  
+    private bool RemoteDesktop_IsConnected_CanExecute(object view)
     {
         if (view is RemoteDesktopControl control)
             return control.IsConnected;
@@ -132,18 +124,15 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
         return false;
     }
 
-    public ICommand RemoteDesktop_ReconnectCommand => new RelayCommand(RemoteDesktop_ReconnectAction, RemoteDesktop_Disconnected_CanExecute);
-
-    private void RemoteDesktop_ReconnectAction(object view)
+    private bool RemoteDesktop_IsDisconnected_CanExecute(object view)
     {
         if (view is RemoteDesktopControl control)
-        {
-            if (control.ReconnectCommand.CanExecute(null))
-                control.ReconnectCommand.Execute(null);
-        }
+            return !control.IsConnected;
+
+        return false;
     }
 
-    public ICommand RemoteDesktop_DisconnectCommand => new RelayCommand(RemoteDesktop_DisconnectAction, RemoteDesktop_Connected_CanExecute);
+    public ICommand RemoteDesktop_DisconnectCommand => new RelayCommand(RemoteDesktop_DisconnectAction, RemoteDesktop_IsConnected_CanExecute);
 
     private void RemoteDesktop_DisconnectAction(object view)
     {
@@ -154,7 +143,18 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
         }
     }
 
-    public ICommand RemoteDesktop_FullscreenCommand => new RelayCommand(RemoteDesktop_FullscreenAction, RemoteDesktop_Connected_CanExecute);
+    public ICommand RemoteDesktop_ReconnectCommand => new RelayCommand(RemoteDesktop_ReconnectAction, RemoteDesktop_IsDisconnected_CanExecute);
+
+    private void RemoteDesktop_ReconnectAction(object view)
+    {
+        if (view is RemoteDesktopControl control)
+        {
+            if (control.ReconnectCommand.CanExecute(null))
+                control.ReconnectCommand.Execute(null);
+        }
+    }
+
+    public ICommand RemoteDesktop_FullscreenCommand => new RelayCommand(RemoteDesktop_FullscreenAction, RemoteDesktop_IsConnected_CanExecute);
 
     private void RemoteDesktop_FullscreenAction(object view)
     {
@@ -162,7 +162,7 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
             control.FullScreen();
     }
 
-    public ICommand RemoteDesktop_AdjustScreenCommand => new RelayCommand(RemoteDesktop_AdjustScreenAction, RemoteDesktop_Connected_CanExecute);
+    public ICommand RemoteDesktop_AdjustScreenCommand => new RelayCommand(RemoteDesktop_AdjustScreenAction, RemoteDesktop_IsConnected_CanExecute);
 
     private void RemoteDesktop_AdjustScreenAction(object view)
     {
@@ -170,7 +170,7 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
             control.AdjustScreen();
     }
 
-    public ICommand RemoteDesktop_SendCtrlAltDelCommand => new RelayCommand(RemoteDesktop_SendCtrlAltDelAction, RemoteDesktop_Connected_CanExecute);
+    public ICommand RemoteDesktop_SendCtrlAltDelCommand => new RelayCommand(RemoteDesktop_SendCtrlAltDelAction, RemoteDesktop_IsConnected_CanExecute);
 
     private async void RemoteDesktop_SendCtrlAltDelAction(object view)
     {
@@ -314,6 +314,7 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
     #endregion
     #endregion
 
+    #region Methods
     private async void FocusEmbeddedWindow()
     {
         // Delay the focus to prevent blocking the ui
@@ -336,6 +337,7 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
                 break;
         }
     }
+    #endregion
 
     #region Events
     private void SettingsManager_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
+++ b/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
@@ -222,7 +222,7 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
     #endregion
 
     #region PuTTY commands
-    private bool PuTTY_Connected_CanExecute(object view)
+    private bool PuTTY_IsConnected_CanExecute(object view)
     {
         if (view is PuTTYControl control)
             return control.IsConnected;
@@ -241,7 +241,7 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
         }
     }
 
-    public ICommand PuTTY_ResizeWindowCommand => new RelayCommand(PuTTY_ResizeWindowAction, PuTTY_Connected_CanExecute);
+    public ICommand PuTTY_ResizeWindowCommand => new RelayCommand(PuTTY_ResizeWindowAction, PuTTY_IsConnected_CanExecute);
 
     private void PuTTY_ResizeWindowAction(object view)
     {
@@ -249,7 +249,7 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
             control.ResizeEmbeddedWindow();
     }
 
-    public ICommand PuTTY_RestartSessionCommand => new RelayCommand(PuTTY_RestartSessionAction, PuTTY_Connected_CanExecute);
+    public ICommand PuTTY_RestartSessionCommand => new RelayCommand(PuTTY_RestartSessionAction, PuTTY_IsConnected_CanExecute);
 
     private void PuTTY_RestartSessionAction(object view)
     {

--- a/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
+++ b/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
@@ -115,7 +115,7 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
         }
     }
 
-    #region RemoteDesktop Commands  
+    #region RemoteDesktop commands  
     private bool RemoteDesktop_IsConnected_CanExecute(object view)
     {
         if (view is RemoteDesktopControl control)
@@ -192,11 +192,11 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
     }
     #endregion
 
-    #region PowerShell Commands
-    private bool PowerShell_Disconnected_CanExecute(object view)
+    #region PowerShell commands
+    private bool PowerShell_IsConnected_CanExecute(object view)
     {
         if (view is PowerShellControl control)
-            return !control.IsConnected;
+            return control.IsConnected;
 
         return false;
     }
@@ -212,7 +212,7 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
         }
     }
 
-    public ICommand PowerShell_ResizeWindowCommand => new RelayCommand(PowerShell_ResizeWindowAction, PowerShell_Disconnected_CanExecute);
+    public ICommand PowerShell_ResizeWindowCommand => new RelayCommand(PowerShell_ResizeWindowAction, PowerShell_IsConnected_CanExecute);
 
     private void PowerShell_ResizeWindowAction(object view)
     {
@@ -221,7 +221,7 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
     }
     #endregion
 
-    #region PuTTY Commands
+    #region PuTTY commands
     private bool PuTTY_Connected_CanExecute(object view)
     {
         if (view is PuTTYControl control)
@@ -258,7 +258,7 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
     }
     #endregion
 
-    #region AWSSessionManager Commands
+    #region AWSSessionManager commands
     private bool AWSSessionManager_Disconnected_CanExecute(object view)
     {
         if (view is AWSSessionManagerControl control)
@@ -287,7 +287,7 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
     }
     #endregion
 
-    #region TigerVNC Commands
+    #region TigerVNC commands
     public ICommand TigerVNC_ReconnectCommand => new RelayCommand(TigerVNC_ReconnectAction);
 
     private void TigerVNC_ReconnectAction(object view)
@@ -300,7 +300,7 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
     }
     #endregion
 
-    #region WebConsole Commands
+    #region WebConsole commands
     public ICommand WebConsole_ReloadCommand => new RelayCommand(WebConsole_RefreshAction);
 
     private void WebConsole_RefreshAction(object view)

--- a/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
+++ b/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
@@ -259,10 +259,10 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
     #endregion
 
     #region AWSSessionManager commands
-    private bool AWSSessionManager_Disconnected_CanExecute(object view)
+    private bool AWSSessionManager_IsConnected_CanExecute(object view)
     {
         if (view is AWSSessionManagerControl control)
-            return !control.IsConnected;
+            return control.IsConnected;
 
         return false;
     }
@@ -278,11 +278,11 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
         }
     }
 
-    public ICommand AWSSessionManager_ResizeWindowCommand => new RelayCommand(AWSSessionManager_ResizeWindowAction, AWSSessionManager_Disconnected_CanExecute);
+    public ICommand AWSSessionManager_ResizeWindowCommand => new RelayCommand(AWSSessionManager_ResizeWindowAction, AWSSessionManager_IsConnected_CanExecute);
 
     private void AWSSessionManager_ResizeWindowAction(object view)
     {
-        if (view is PowerShellControl control)
+        if (view is AWSSessionManagerControl control)
             control.ResizeEmbeddedWindow();
     }
     #endregion

--- a/Source/NETworkManager/ViewModels/AWSSessionManagerHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/AWSSessionManagerHostViewModel.cs
@@ -346,7 +346,16 @@ public class AWSSessionManagerHostViewModel : ViewModelBase, IProfileManager
         ((args.DragablzItem.Content as DragablzTabItem)?.View as AWSSessionManagerControl)?.CloseTab();
     }
 
-    private bool AWSSessionManager_Connected_CanExecute(object view)
+    private bool Connect_CanExecute(object obj) => IsPowerShellConfigured;
+
+    public ICommand ConnectCommand => new RelayCommand(p => ConnectAction(), Connect_CanExecute);
+
+    private void ConnectAction()
+    {
+        Connect();
+    }
+
+    private bool IsConnected_CanExecute(object view)
     {
         if (view is AWSSessionManagerControl control)
             return control.IsConnected;
@@ -354,9 +363,9 @@ public class AWSSessionManagerHostViewModel : ViewModelBase, IProfileManager
         return false;
     }
 
-    public ICommand AWSSessionManager_ReconnectCommand => new RelayCommand(AWSSessionManager_ReconnectAction);
+    public ICommand ReconnectCommand => new RelayCommand(ReconnectAction);
 
-    private void AWSSessionManager_ReconnectAction(object view)
+    private void ReconnectAction(object view)
     {
         if (view is AWSSessionManagerControl control)
         {
@@ -365,23 +374,14 @@ public class AWSSessionManagerHostViewModel : ViewModelBase, IProfileManager
         }
     }
 
-    public ICommand AWSSessionManager_ResizeWindowCommand => new RelayCommand(AWSSessionManager_ResizeWindowAction, AWSSessionManager_Connected_CanExecute);
+    public ICommand ResizeWindowCommand => new RelayCommand(ResizeWindowAction, IsConnected_CanExecute);
 
-    private void AWSSessionManager_ResizeWindowAction(object view)
+    private void ResizeWindowAction(object view)
     {
         if (view is AWSSessionManagerControl control)
             control.ResizeEmbeddedWindow();
     }
-
-    public ICommand ConnectCommand => new RelayCommand(p => ConnectAction(), Connect_CanExecute);
-
-    private bool Connect_CanExecute(object obj) => IsPowerShellConfigured;
-
-    private void ConnectAction()
-    {
-        Connect();
-    }
-
+    
     public ICommand ConnectProfileCommand => new RelayCommand(p => ConnectProfileAction(), ConnectProfile_CanExecute);
 
     private bool ConnectProfile_CanExecute(object obj)

--- a/Source/NETworkManager/ViewModels/PowerShellHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PowerShellHostViewModel.cs
@@ -266,13 +266,22 @@ public class PowerShellHostViewModel : ViewModelBase, IProfileManager
 
     #region ICommand & Actions
     public ItemActionCallback CloseItemCommand => CloseItemAction;
-
+        
     private void CloseItemAction(ItemActionCallbackArgs<TabablzControl> args)
     {
         ((args.DragablzItem.Content as DragablzTabItem)?.View as PowerShellControl)?.CloseTab();
     }
 
-    private bool PowerShell_Connected_CanExecute(object view)
+    private bool Connect_CanExecute(object obj) => IsConfigured;
+
+    public ICommand ConnectCommand => new RelayCommand(p => ConnectAction(), Connect_CanExecute);
+
+    private void ConnectAction()
+    {
+        Connect();
+    }
+
+    private bool IsConnected_CanExecute(object view)
     {
         if (view is PowerShellControl control)
             return control.IsConnected;
@@ -280,9 +289,9 @@ public class PowerShellHostViewModel : ViewModelBase, IProfileManager
         return false;
     }
 
-    public ICommand PowerShell_ReconnectCommand => new RelayCommand(PowerShell_ReconnectAction);
+    public ICommand ReconnectCommand => new RelayCommand(ReconnectAction);
 
-    private void PowerShell_ReconnectAction(object view)
+    private void ReconnectAction(object view)
     {
         if (view is PowerShellControl control)
         {
@@ -291,23 +300,14 @@ public class PowerShellHostViewModel : ViewModelBase, IProfileManager
         }
     }
 
-    public ICommand PowerShell_ResizeWindowCommand => new RelayCommand(PowerShell_ResizeWindowAction, PowerShell_Connected_CanExecute);
+    public ICommand ResizeWindowCommand => new RelayCommand(ResizeWindowAction, IsConnected_CanExecute);
 
-    private void PowerShell_ResizeWindowAction(object view)
+    private void ResizeWindowAction(object view)
     {
         if (view is PowerShellControl control)
             control.ResizeEmbeddedWindow();
     }
-
-    public ICommand ConnectCommand => new RelayCommand(p => ConnectAction(), Connect_CanExecute);
-
-    private bool Connect_CanExecute(object obj) => IsConfigured;
-
-    private void ConnectAction()
-    {
-        Connect();
-    }
-
+   
     public ICommand ConnectProfileCommand => new RelayCommand(p => ConnectProfileAction(), ConnectProfile_CanExecute);
 
     private bool ConnectProfile_CanExecute(object obj)

--- a/Source/NETworkManager/ViewModels/PuTTYHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PuTTYHostViewModel.cs
@@ -98,7 +98,7 @@ public class PuTTYHostViewModel : ViewModelBase, IProfileManager
             OnPropertyChanged();
         }
     }
-    
+
     private ProfileInfo _selectedProfile = new();
     public ProfileInfo SelectedProfile
     {
@@ -247,7 +247,7 @@ public class PuTTYHostViewModel : ViewModelBase, IProfileManager
 
         _isLoading = false;
     }
-         
+
     private void LoadSettings()
     {
         ExpandProfileView = SettingsManager.Current.PuTTY_ExpandProfileView;
@@ -271,8 +271,20 @@ public class PuTTYHostViewModel : ViewModelBase, IProfileManager
     {
         ((args.DragablzItem.Content as DragablzTabItem)?.View as PuTTYControl)?.CloseTab();
     }
+    
+    private bool Connect_CanExecute(object obj)
+    {
+        return IsConfigured;
+    }
 
-    private bool PuTTY_Connected_CanExecute(object view)
+    public ICommand ConnectCommand => new RelayCommand(p => ConnectAction(), Connect_CanExecute);
+
+    private void ConnectAction()
+    {
+        Connect();
+    }
+
+    private bool IsConnected_CanExecute(object view)
     {
         if (view is PuTTYControl control)
             return control.IsConnected;
@@ -280,9 +292,9 @@ public class PuTTYHostViewModel : ViewModelBase, IProfileManager
         return false;
     }
 
-    public ICommand PuTTY_ReconnectCommand => new RelayCommand(PuTTY_ReconnectAction);
+    public ICommand ReconnectCommand => new RelayCommand(ReconnectAction);
 
-    private void PuTTY_ReconnectAction(object view)
+    private void ReconnectAction(object view)
     {
         if (view is PuTTYControl control)
         {
@@ -291,34 +303,22 @@ public class PuTTYHostViewModel : ViewModelBase, IProfileManager
         }
     }
 
-    public ICommand PuTTY_ResizeWindowCommand => new RelayCommand(PuTTY_ResizeWindowAction, PuTTY_Connected_CanExecute);
+    public ICommand ResizeWindowCommand => new RelayCommand(ResizeWindowAction, IsConnected_CanExecute);
 
-    private void PuTTY_ResizeWindowAction(object view)
+    private void ResizeWindowAction(object view)
     {
         if (view is PuTTYControl control)
             control.ResizeEmbeddedWindow();
     }
 
-    public ICommand PuTTY_RestartSessionCommand => new RelayCommand(PuTTY_RestartSessionAction, PuTTY_Connected_CanExecute);
+    public ICommand RestartSessionCommand => new RelayCommand(RestartSessionAction, IsConnected_CanExecute);
 
-    private void PuTTY_RestartSessionAction(object view)
+    private void RestartSessionAction(object view)
     {
         if (view is PuTTYControl control)
             control.RestartSession();
     }
-
-    public ICommand ConnectCommand => new RelayCommand(p => ConnectAction(), Connect_CanExecute);
-
-    private bool Connect_CanExecute(object obj)
-    {
-        return IsConfigured;
-    }
-
-    private void ConnectAction()
-    {
-        Connect();
-    }
-
+    
     public ICommand ConnectProfileCommand => new RelayCommand(p => ConnectProfileAction(), ConnectProfile_CanExecute);
 
     private bool ConnectProfile_CanExecute(object obj)
@@ -416,7 +416,7 @@ public class PuTTYHostViewModel : ViewModelBase, IProfileManager
         IsConfigured = !string.IsNullOrEmpty(SettingsManager.Current.PuTTY_ApplicationFilePath) && File.Exists(SettingsManager.Current.PuTTY_ApplicationFilePath);
 
         // Create default PuTTY profile for NETworkManager
-        WriteDefaultProfileToRegistry();            
+        WriteDefaultProfileToRegistry();
     }
 
     private async Task Connect(string host = null)
@@ -654,7 +654,7 @@ public class PuTTYHostViewModel : ViewModelBase, IProfileManager
         else
             SelectedProfile = Profiles.Cast<ProfileInfo>().FirstOrDefault();
     }
-    
+
     public void RefreshProfiles()
     {
         if (!_isViewActive)

--- a/Source/NETworkManager/ViewModels/RemoteDesktopHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/RemoteDesktopHostViewModel.cs
@@ -196,15 +196,7 @@ public class RemoteDesktopHostViewModel : ViewModelBase, IProfileManager
         Connect();
     }
 
-    private bool RemoteDesktop_Disconnected_CanExecute(object view)
-    {
-        if (view is RemoteDesktopControl control)
-            return !control.IsConnected;
-
-        return false;
-    }
-
-    private bool RemoteDesktop_Connected_CanExecute(object view)
+    private bool IsConnected_CanExecute(object view)
     {
         if (view is RemoteDesktopControl control)
             return control.IsConnected;
@@ -212,9 +204,17 @@ public class RemoteDesktopHostViewModel : ViewModelBase, IProfileManager
         return false;
     }
 
-    public ICommand RemoteDesktop_ReconnectCommand => new RelayCommand(RemoteDesktop_ReconnectAction, RemoteDesktop_Disconnected_CanExecute);
+    private bool IsDisconnected_CanExecute(object view)
+    {
+        if (view is RemoteDesktopControl control)
+            return !control.IsConnected;
 
-    private void RemoteDesktop_ReconnectAction(object view)
+        return false;
+    }
+
+    public ICommand ReconnectCommand => new RelayCommand(ReconnectAction, IsDisconnected_CanExecute);
+
+    private void ReconnectAction(object view)
     {
         if (view is RemoteDesktopControl control)
         {
@@ -223,9 +223,9 @@ public class RemoteDesktopHostViewModel : ViewModelBase, IProfileManager
         }
     }
 
-    public ICommand RemoteDesktop_DisconnectCommand => new RelayCommand(RemoteDesktop_DisconnectAction, RemoteDesktop_Connected_CanExecute);
+    public ICommand DisconnectCommand => new RelayCommand(DisconnectAction, IsConnected_CanExecute);
 
-    private void RemoteDesktop_DisconnectAction(object view)
+    private void DisconnectAction(object view)
     {
         if (view is RemoteDesktopControl control)
         {
@@ -234,25 +234,25 @@ public class RemoteDesktopHostViewModel : ViewModelBase, IProfileManager
         }
     }
 
-    public ICommand RemoteDesktop_FullscreenCommand => new RelayCommand(RemoteDesktop_FullscreenAction, RemoteDesktop_Connected_CanExecute);
+    public ICommand FullscreenCommand => new RelayCommand(FullscreenAction, IsConnected_CanExecute);
 
-    private void RemoteDesktop_FullscreenAction(object view)
+    private void FullscreenAction(object view)
     {
         if (view is RemoteDesktopControl control)
             control.FullScreen();
     }
 
-    public ICommand RemoteDesktop_AdjustScreenCommand => new RelayCommand(RemoteDesktop_AdjustScreenAction, RemoteDesktop_Connected_CanExecute);
+    public ICommand AdjustScreenCommand => new RelayCommand(AdjustScreenAction, IsConnected_CanExecute);
 
-    private void RemoteDesktop_AdjustScreenAction(object view)
+    private void AdjustScreenAction(object view)
     {
         if (view is RemoteDesktopControl control)
             control.AdjustScreen();
     }
 
-    public ICommand RemoteDesktop_SendCtrlAltDelCommand => new RelayCommand(RemoteDesktop_SendCtrlAltDelAction, RemoteDesktop_Connected_CanExecute);
+    public ICommand SendCtrlAltDelCommand => new RelayCommand(SendCtrlAltDelAction, IsConnected_CanExecute);
 
-    private async void RemoteDesktop_SendCtrlAltDelAction(object view)
+    private async void SendCtrlAltDelAction(object view)
     {
         if (view is RemoteDesktopControl control)
         {

--- a/Source/NETworkManager/ViewModels/TigerVNCHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/TigerVNCHostViewModel.cs
@@ -222,9 +222,18 @@ public class TigerVNCHostViewModel : ViewModelBase, IProfileManager
         ((args.DragablzItem.Content as DragablzTabItem)?.View as TigerVNCControl)?.CloseTab();
     }
 
-    public ICommand TigerVNC_ReconnectCommand => new RelayCommand(TigerVNC_ReconnectAction);
+    private bool Connect_CanExecute(object obj) => IsConfigured;
 
-    private void TigerVNC_ReconnectAction(object view)
+    public ICommand ConnectCommand => new RelayCommand(p => ConnectAction(), Connect_CanExecute);
+
+    private void ConnectAction()
+    {
+        Connect();
+    }
+
+    public ICommand ReconnectCommand => new RelayCommand(ReconnectAction);
+
+    private void ReconnectAction(object view)
     {
         if (view is TigerVNCControl control)
         {
@@ -232,16 +241,7 @@ public class TigerVNCHostViewModel : ViewModelBase, IProfileManager
                 control.ReconnectCommand.Execute(null);
         }
     }
-
-    public ICommand ConnectCommand => new RelayCommand(p => ConnectAction(), Connect_CanExecute);
-
-    private bool Connect_CanExecute(object obj) => IsConfigured;
-
-    private void ConnectAction()
-    {
-        Connect();
-    }
-
+    
     public ICommand ConnectProfileCommand => new RelayCommand(p => ConnectProfileAction(), ConnectProfile_CanExecute);
 
     private bool ConnectProfile_CanExecute(object obj)

--- a/Source/NETworkManager/ViewModels/WebConsoleHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/WebConsoleHostViewModel.cs
@@ -199,7 +199,7 @@ public class WebConsoleHostViewModel : ViewModelBase, IProfileManager
 
         // Profiles
         SetProfilesView();
-        
+
         ProfileManager.OnProfilesUpdated += ProfileManager_OnProfilesUpdated;
 
         _searchDispatcherTimer.Interval = GlobalStaticConfiguration.SearchDispatcherTimerTimeSpan;
@@ -234,17 +234,6 @@ public class WebConsoleHostViewModel : ViewModelBase, IProfileManager
         ((args.DragablzItem.Content as DragablzTabItem)?.View as WebConsoleControl)?.CloseTab();
     }
 
-    public ICommand WebConsole_RefreshCommand => new RelayCommand(WebConsole_RefreshAction);
-
-    private void WebConsole_RefreshAction(object view)
-    {
-        if (view is WebConsoleControl control)
-        {
-            if (control.ReloadCommand.CanExecute(null))
-                control.ReloadCommand.Execute(null);
-        }
-    }
-
     public ICommand ConnectCommand => new RelayCommand(p => ConnectAction());
 
     private void ConnectAction()
@@ -252,6 +241,17 @@ public class WebConsoleHostViewModel : ViewModelBase, IProfileManager
         Connect();
     }
 
+    public ICommand ReloadCommand => new RelayCommand(ReloadAction);
+
+    private void ReloadAction(object view)
+    {
+        if (view is WebConsoleControl control)
+        {
+            if (control.ReloadCommand.CanExecute(null))
+                control.ReloadCommand.Execute(null);
+        }
+    }
+    
     public ICommand ConnectProfileCommand => new RelayCommand(p => ConnectProfileAction(), ConnectProfile_CanExecute);
 
     private bool ConnectProfile_CanExecute(object obj)
@@ -381,9 +381,9 @@ public class WebConsoleHostViewModel : ViewModelBase, IProfileManager
         if (string.IsNullOrEmpty(url))
             return;
 
-         SettingsManager.Current.WebConsole_UrlHistory = new ObservableCollection<string>(ListHelper.Modify(SettingsManager.Current.WebConsole_UrlHistory.ToList(), url, SettingsManager.Current.General_HistoryListEntries));
+        SettingsManager.Current.WebConsole_UrlHistory = new ObservableCollection<string>(ListHelper.Modify(SettingsManager.Current.WebConsole_UrlHistory.ToList(), url, SettingsManager.Current.General_HistoryListEntries));
     }
-    
+
     private void ResizeProfile(bool dueToChangedSize)
     {
         _canProfileWidthChange = false;
@@ -455,7 +455,7 @@ public class WebConsoleHostViewModel : ViewModelBase, IProfileManager
         else
             SelectedProfile = Profiles.Cast<ProfileInfo>().FirstOrDefault();
     }
-    
+
     public void RefreshProfiles()
     {
         if (!_isViewActive)

--- a/Source/NETworkManager/Views/AWSSessionManagerHostView.xaml
+++ b/Source/NETworkManager/Views/AWSSessionManagerHostView.xaml
@@ -85,7 +85,7 @@
                                 <Grid Height="32">
                                     <Grid.ContextMenu>
                                         <ContextMenu IsOpen="{Binding Data.HeaderContextMenuIsOpen, Source={StaticResource BindingProxy}, Mode=OneWayToSource}">
-                                            <MenuItem Header="{x:Static localization:Strings.Reconnect}" Command="{Binding Data.AWSSessionManager_ReconnectCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
+                                            <MenuItem Header="{x:Static localization:Strings.Reconnect}" Command="{Binding Data.ReconnectCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                                 <MenuItem.Icon>
                                                     <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
                                                         <Rectangle.OpacityMask>
@@ -95,7 +95,7 @@
                                                 </MenuItem.Icon>
                                             </MenuItem>
                                             <Separator />
-                                            <MenuItem Header="{x:Static localization:Strings.Resize}" Command="{Binding Data.AWSSessionManager_ResizeWindowCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
+                                            <MenuItem Header="{x:Static localization:Strings.Resize}" Command="{Binding Data.ResizeWindowCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                                 <MenuItem.Icon>
                                                     <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
                                                         <Rectangle.OpacityMask>

--- a/Source/NETworkManager/Views/PowerShellHostView.xaml
+++ b/Source/NETworkManager/Views/PowerShellHostView.xaml
@@ -76,7 +76,7 @@
                                 <Grid Height="32">
                                     <Grid.ContextMenu>
                                         <ContextMenu IsOpen="{Binding Data.HeaderContextMenuIsOpen, Source={StaticResource BindingProxy}, Mode=OneWayToSource}">
-                                            <MenuItem Header="{x:Static localization:Strings.Reconnect}" Command="{Binding Data.PowerShell_ReconnectCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
+                                            <MenuItem Header="{x:Static localization:Strings.Reconnect}" Command="{Binding Data.ReconnectCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                                 <MenuItem.Icon>
                                                     <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
                                                         <Rectangle.OpacityMask>
@@ -86,7 +86,7 @@
                                                 </MenuItem.Icon>
                                             </MenuItem>
                                             <Separator />
-                                            <MenuItem Header="{x:Static localization:Strings.Resize}" Command="{Binding Data.PowerShell_ResizeWindowCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
+                                            <MenuItem Header="{x:Static localization:Strings.Resize}" Command="{Binding Data.ResizeWindowCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                                 <MenuItem.Icon>
                                                     <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
                                                         <Rectangle.OpacityMask>

--- a/Source/NETworkManager/Views/PuTTYHostView.xaml
+++ b/Source/NETworkManager/Views/PuTTYHostView.xaml
@@ -77,7 +77,7 @@
                                 <Grid Height="32">
                                     <Grid.ContextMenu>
                                         <ContextMenu IsOpen="{Binding Data.HeaderContextMenuIsOpen, Source={StaticResource BindingProxy}, Mode=OneWayToSource}">
-                                            <MenuItem Header="{x:Static localization:Strings.Reconnect}" Command="{Binding Data.PuTTY_ReconnectCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
+                                            <MenuItem Header="{x:Static localization:Strings.Reconnect}" Command="{Binding Data.ReconnectCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                                 <MenuItem.Icon>
                                                     <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
                                                         <Rectangle.OpacityMask>
@@ -87,7 +87,7 @@
                                                 </MenuItem.Icon>
                                             </MenuItem>
                                             <Separator />
-                                            <MenuItem Header="{x:Static localization:Strings.Resize}" Command="{Binding Data.PuTTY_ResizeWindowCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
+                                            <MenuItem Header="{x:Static localization:Strings.Resize}" Command="{Binding Data.ResizeWindowCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                                 <MenuItem.Icon>
                                                     <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
                                                         <Rectangle.OpacityMask>
@@ -96,7 +96,7 @@
                                                     </Rectangle>
                                                 </MenuItem.Icon>
                                             </MenuItem>
-                                            <MenuItem Header="{x:Static localization:Strings.RestartSession}" Command="{Binding Data.PuTTY_RestartSessionCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
+                                            <MenuItem Header="{x:Static localization:Strings.RestartSession}" Command="{Binding Data.RestartSessionCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                                 <MenuItem.Icon>
                                                     <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
                                                         <Rectangle.OpacityMask>

--- a/Source/NETworkManager/Views/RemoteDesktopHostView.xaml
+++ b/Source/NETworkManager/Views/RemoteDesktopHostView.xaml
@@ -65,7 +65,7 @@
                             <Grid Height="32">
                                 <Grid.ContextMenu>
                                     <ContextMenu>
-                                        <MenuItem Header="{x:Static localization:Strings.Reconnect}" Command="{Binding Data.RemoteDesktop_ReconnectCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
+                                        <MenuItem Header="{x:Static localization:Strings.Reconnect}" Command="{Binding Data.ReconnectCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                             <MenuItem.Icon>
                                                 <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
                                                     <Rectangle.OpacityMask>
@@ -74,7 +74,7 @@
                                                 </Rectangle>
                                             </MenuItem.Icon>
                                         </MenuItem>
-                                        <MenuItem Header="{x:Static localization:Strings.Disconnect}" Command="{Binding Data.RemoteDesktop_DisconnectCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
+                                        <MenuItem Header="{x:Static localization:Strings.Disconnect}" Command="{Binding Data.DisconnectCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                             <MenuItem.Icon>
                                                 <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
                                                     <Rectangle.OpacityMask>
@@ -84,7 +84,7 @@
                                             </MenuItem.Icon>
                                         </MenuItem>
                                         <Separator />
-                                        <MenuItem Header="{x:Static localization:Strings.Fullscreen}" Command="{Binding Data.RemoteDesktop_FullscreenCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
+                                        <MenuItem Header="{x:Static localization:Strings.Fullscreen}" Command="{Binding Data.FullscreenCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                             <MenuItem.Icon>
                                                 <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
                                                     <Rectangle.OpacityMask>
@@ -93,7 +93,7 @@
                                                 </Rectangle>
                                             </MenuItem.Icon>
                                         </MenuItem>
-                                        <MenuItem Header="{x:Static localization:Strings.AdjustScreen}" Command="{Binding Data.RemoteDesktop_AdjustScreenCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
+                                        <MenuItem Header="{x:Static localization:Strings.AdjustScreen}" Command="{Binding Data.AdjustScreenCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                             <MenuItem.Icon>
                                                 <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
                                                     <Rectangle.OpacityMask>
@@ -111,7 +111,7 @@
                                                     </Rectangle.OpacityMask>
                                                 </Rectangle>
                                             </MenuItem.Icon>
-                                            <MenuItem Header="{x:Static localization:Strings.CtrlAltDel}" Command="{Binding Data.RemoteDesktop_SendCtrlAltDelCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}" />
+                                            <MenuItem Header="{x:Static localization:Strings.CtrlAltDel}" Command="{Binding Data.SendCtrlAltDelCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}" />
                                         </MenuItem>
                                     </ContextMenu>
                                 </Grid.ContextMenu>

--- a/Source/NETworkManager/Views/TigerVNCHostView.xaml
+++ b/Source/NETworkManager/Views/TigerVNCHostView.xaml
@@ -75,7 +75,7 @@
                                 <Grid Height="32">
                                     <Grid.ContextMenu>
                                         <ContextMenu>
-                                            <MenuItem Header="{x:Static localization:Strings.Reconnect}" Command="{Binding Data.TigerVNC_ReconnectCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
+                                            <MenuItem Header="{x:Static localization:Strings.Reconnect}" Command="{Binding Data.ReconnectCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                                 <MenuItem.Icon>
                                                     <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
                                                         <Rectangle.OpacityMask>

--- a/Source/NETworkManager/Views/WebConsoleHostView.xaml
+++ b/Source/NETworkManager/Views/WebConsoleHostView.xaml
@@ -75,7 +75,7 @@
                                 <Grid Height="32">
                                     <Grid.ContextMenu>
                                         <ContextMenu>
-                                            <MenuItem Header="{x:Static localization:Strings.Reload}" Command="{Binding Data.WebConsole_ReloadCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
+                                            <MenuItem Header="{x:Static localization:Strings.Reload}" Command="{Binding Data.ReloadCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                                 <MenuItem.Icon>
                                                     <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
                                                         <Rectangle.OpacityMask>

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -44,6 +44,12 @@ Release date: **xx.xx.2023**
 - **Port Scanner**
   - Show port and protocol if service (and desciption) is not available [#2026](https://github.com/BornToBeRoot/NETworkManager/pull/2026){:target="\_blank"}
   - Export to CSV fixed if `Description` contains a comma [#2026](https://github.com/BornToBeRoot/NETworkManager/pull/2026){:target="\_blank"}
+- **PowerShell**
+  - Resize command in TabControl context menu in a dragged out window not working [#2060](https://github.com/BornToBeRoot/NETworkManager/pull/2060){:target="\_blank"}
+- **AWS Session Manager**
+  - Resize command in TabControl context menu in a dragged out window not working [#2060](https://github.com/BornToBeRoot/NETworkManager/pull/2060){:target="\_blank"}
+- **Web Console**
+  - Reload command in TabControl context menu in main window not working [#2060](https://github.com/BornToBeRoot/NETworkManager/pull/2060){:target="\_blank"}
 - **Lookup - OUI**
   - Export to CSV fixed if `Vendor` contains a comma [#2026](https://github.com/BornToBeRoot/NETworkManager/pull/2026){:target="\_blank"}
 - **Lookup - Port**
@@ -51,6 +57,6 @@ Release date: **xx.xx.2023**
 
 ## Other
 
-- Code cleanup [#2024](https://github.com/BornToBeRoot/NETworkManager/pull/2024){:target="\_blank"} [#2026](https://github.com/BornToBeRoot/NETworkManager/pull/2026){:target="\_blank"}
+- Code cleanup [#2024](https://github.com/BornToBeRoot/NETworkManager/pull/2024){:target="\_blank"} [#2026](https://github.com/BornToBeRoot/NETworkManager/pull/2026){:target="\_blank"} [#2060](https://github.com/BornToBeRoot/NETworkManager/pull/2060){:target="\_blank"}
 - Language files updated [#transifex](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Ftransifex-integration){:target="\_blank"}
 - Dependencies updated [#dependencies](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Fdependabot){:target="\_blank"}


### PR DESCRIPTION
**Please provide some details about this pull request:**
- PowerShell resize command not working in dragged out window
- AWS Session Manager resize command not working in dragged out window
- WebConsole reload command not working in main window
- Code refactoring

Fixes #2049

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).