### PR TITLE
Fix: ContextMenu focus issue -> closed automatically

### DIFF
--- a/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml
+++ b/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml
@@ -152,7 +152,7 @@
                                             <Border BorderBrush="{DynamicResource MahApps.Brushes.Gray8}" BorderThickness="0,0,1,0">
                                                 <Grid Height="32">
                                                     <Grid.ContextMenu>
-                                                        <ContextMenu>
+                                                        <ContextMenu IsOpen="{Binding Data.HeaderContextMenuIsOpen, Source={StaticResource BindingProxy}, Mode=OneWayToSource}">
                                                             <MenuItem Header="{x:Static localization:Strings.Reconnect}" Command="{Binding Data.PowerShell_ReconnectCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                                                 <MenuItem.Icon>
                                                                     <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
@@ -230,7 +230,7 @@
                                             <Border BorderBrush="{DynamicResource MahApps.Brushes.Gray8}" BorderThickness="0,0,1,0">
                                                 <Grid Height="32">
                                                     <Grid.ContextMenu>
-                                                        <ContextMenu>
+                                                        <ContextMenu IsOpen="{Binding Data.HeaderContextMenuIsOpen, Source={StaticResource BindingProxy}, Mode=OneWayToSource}">
                                                             <MenuItem Header="{x:Static localization:Strings.Reconnect}" Command="{Binding Data.PuTTY_ReconnectCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                                                 <MenuItem.Icon>
                                                                     <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
@@ -317,7 +317,7 @@
                                             <Border BorderBrush="{DynamicResource MahApps.Brushes.Gray8}" BorderThickness="0,0,1,0">
                                                 <Grid Height="32">
                                                     <Grid.ContextMenu>
-                                                        <ContextMenu>
+                                                        <ContextMenu IsOpen="{Binding Data.HeaderContextMenuIsOpen, Source={StaticResource BindingProxy}, Mode=OneWayToSource}">
                                                             <MenuItem Header="{x:Static localization:Strings.Reconnect}" Command="{Binding Data.AWSSessionManager_ReconnectCommand, Source={StaticResource BindingProxy}}" CommandParameter="{Binding View}">
                                                                 <MenuItem.Icon>
                                                                     <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">

--- a/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
+++ b/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
@@ -11,6 +11,7 @@ using MahApps.Metro.Controls.Dialogs;
 using NETworkManager.Localization.Translators;
 using NETworkManager.Models;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace NETworkManager.Controls;
 
@@ -38,6 +39,20 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
                 return;
 
             _applicationName = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private bool _headerContextMenuIsOpen;
+    public bool HeaderContextMenuIsOpen
+    {
+        get => _headerContextMenuIsOpen;
+        set
+        {
+            if (value == _headerContextMenuIsOpen)
+                return;
+
+            _headerContextMenuIsOpen = value;
             OnPropertyChanged();
         }
     }
@@ -318,10 +333,17 @@ public partial class DragablzTabHostWindow : INotifyPropertyChanged
     private async void FocusEmbeddedWindow()
     {
         // Delay the focus to prevent blocking the ui
+        // Detect if window is resizing
         do
         {
             await Task.Delay(250);
-        } while (Mouse.LeftButton == MouseButtonState.Pressed);
+        } while (Control.MouseButtons == MouseButtons.Left);
+
+        /* Don't continue if
+           - Header ContextMenu is opened        
+        */
+        if (HeaderContextMenuIsOpen)
+            return;
 
         // Switch by name
         switch (ApplicationName)

--- a/Source/NETworkManager/MainWindow.xaml.cs
+++ b/Source/NETworkManager/MainWindow.xaml.cs
@@ -1685,6 +1685,7 @@ public partial class MainWindow : INotifyPropertyChanged
     private async void FocusEmbeddedWindow()
     {
         // Delay the focus to prevent blocking the ui
+        // Detect if window is resizing
         do
         {
             await Task.Delay(250);
@@ -1695,8 +1696,7 @@ public partial class MainWindow : INotifyPropertyChanged
            - Settings are opened
            - Profile file drop down is opened
            - Application search textbox is opened
-           - Dialog over an embedded window is opened
-           - Window is resizing
+           - Dialog over an embedded window is opened           
         */
         if (SelectedApplication == null || ShowSettingsView || IsProfileFileDropDownOpened || IsTextBoxSearchFocused || ConfigurationManager.Current.IsDialogOpen)
             return;

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -45,8 +45,12 @@ Release date: **xx.xx.2023**
   - Show port and protocol if service (and desciption) is not available [#2026](https://github.com/BornToBeRoot/NETworkManager/pull/2026){:target="\_blank"}
   - Export to CSV fixed if `Description` contains a comma [#2026](https://github.com/BornToBeRoot/NETworkManager/pull/2026){:target="\_blank"}
 - **PowerShell**
+  - ContextMenu in TabControl in a dragged out window was closed automatically due to a focus problem right after opening it [#2064](https://github.com/BornToBeRoot/NETworkManager/pull/2064){:target="\_blank"}
   - Resize command in TabControl context menu in a dragged out window not working [#2060](https://github.com/BornToBeRoot/NETworkManager/pull/2060){:target="\_blank"}
+- **PuTTY**
+  - ContextMenu in TabControl in a dragged out window was closed automatically due to a focus problem right after opening it [#2064](https://github.com/BornToBeRoot/NETworkManager/pull/2064){:target="\_blank"}
 - **AWS Session Manager**
+  - ContextMenu in TabControl in a dragged out window was closed automatically due to a focus problem right after opening it [#2064](https://github.com/BornToBeRoot/NETworkManager/pull/2064){:target="\_blank"}
   - Resize command in TabControl context menu in a dragged out window not working [#2060](https://github.com/BornToBeRoot/NETworkManager/pull/2060){:target="\_blank"}
 - **Web Console**
   - Reload command in TabControl context menu in main window not working [#2060](https://github.com/BornToBeRoot/NETworkManager/pull/2060){:target="\_blank"}


### PR DESCRIPTION
**Please provide some details about this pull request:**
- ContextMenu in dragged out window had a focus issue and closed itself automatically
-
-

Fixes #2061 

**ToDo:**

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).