### PR TITLE
Feature: Add more SHA and AES standards for SNMPv3

### DIFF
--- a/Source/NETworkManager.Models/Network/SNMPClient.cs
+++ b/Source/NETworkManager.Models/Network/SNMPClient.cs
@@ -182,7 +182,7 @@ public partial class SNMPClient
                 IPrivacyProvider privacy = GetPrivacyProvider(options);
 
                 var results = new List<Variable>();
-                
+
                 await Messenger.BulkWalkAsync(VersionCode.V3, ipEndpoint, username, OctetString.Empty, table, results, 10, options.WalkMode, privacy, report, options.CancellationToken);
 
                 foreach (var result in results)
@@ -298,20 +298,27 @@ public partial class SNMPClient
     // authPriv
     private static IPrivacyProvider GetPrivacyProvider(SNMPV3AuthenticationProvider authProvider, string auth, SNMPV3PrivacyProvider privProvider, string priv)
     {
-        IAuthenticationProvider authenticationProvider;
-
-        if (privProvider == SNMPV3PrivacyProvider.DES)
-            return new DESPrivacyProvider(new OctetString(priv), GetAuthenticationProvider(authProvider, auth));
-
-        return new AESPrivacyProvider(new OctetString(priv), GetAuthenticationProvider(authProvider, auth));
+        return privProvider switch
+        {
+            SNMPV3PrivacyProvider.DES => new DESPrivacyProvider(new OctetString(priv), GetAuthenticationProvider(authProvider, auth)),
+            SNMPV3PrivacyProvider.AES => new AESPrivacyProvider(new OctetString(priv), GetAuthenticationProvider(authProvider, auth)),
+            SNMPV3PrivacyProvider.AES192 => new AES192PrivacyProvider(new OctetString(priv), GetAuthenticationProvider(authProvider, auth)),
+            SNMPV3PrivacyProvider.AES256 => new AES256PrivacyProvider(new OctetString(priv), GetAuthenticationProvider(authProvider, auth)),
+            _ => null,
+        };
     }
 
     private static IAuthenticationProvider GetAuthenticationProvider(SNMPV3AuthenticationProvider authProvider, string auth)
     {
-        if (authProvider == SNMPV3AuthenticationProvider.MD5)
-            return new MD5AuthenticationProvider(new OctetString(auth));
-
-        return new SHA1AuthenticationProvider(new OctetString(auth));
+        return authProvider switch
+        {
+            SNMPV3AuthenticationProvider.MD5 => new MD5AuthenticationProvider(new OctetString(auth)),
+            SNMPV3AuthenticationProvider.SHA1 => new SHA1AuthenticationProvider(new OctetString(auth)),
+            SNMPV3AuthenticationProvider.SHA256 => new SHA256AuthenticationProvider(new OctetString(auth)),
+            SNMPV3AuthenticationProvider.SHA384 => new SHA384AuthenticationProvider(new OctetString(auth)),
+            SNMPV3AuthenticationProvider.SHA512 => new SHA512AuthenticationProvider(new OctetString(auth)),
+            _ => null,
+        };
     }
     #endregion
 }

--- a/Source/NETworkManager.Models/Network/SNMPV3AuthenticationProvider.cs
+++ b/Source/NETworkManager.Models/Network/SNMPV3AuthenticationProvider.cs
@@ -5,6 +5,28 @@
 /// </summary>
 public enum SNMPV3AuthenticationProvider
 {
+    /// <summary>
+    /// MD5.
+    /// </summary>
     MD5,
-    SHA1
+
+    /// <summary>
+    /// SHA 1.
+    /// </summary>
+    SHA1,
+    
+    /// <summary>
+    /// SHA 256.
+    /// </summary>
+    SHA256,
+
+    /// <summary>
+    /// SHA 384.
+    /// </summary>
+    SHA384,
+
+    /// <summary>
+    /// SHA 512.
+    /// </summary>
+    SHA512
 }

--- a/Source/NETworkManager.Models/Network/SNMPV3PrivacyProvider.cs
+++ b/Source/NETworkManager.Models/Network/SNMPV3PrivacyProvider.cs
@@ -4,7 +4,24 @@
 /// Enum for the SNMP v3 privacy provider.
 /// </summary>
 public enum SNMPV3PrivacyProvider
-{    
+{   
+    /// <summary>
+    /// DES.
+    /// </summary>
     DES,
-    AES
+    
+    /// <summary>
+    /// AES with 128 bit.
+    /// </summary>
+    AES,
+
+    /// <summary>
+    /// AES with 192 bit.
+    /// </summary>
+    AES192,
+
+    /// <summary>
+    /// AES with 256 bit.
+    /// </summary>
+    AES256
 }

--- a/Source/NETworkManager/ViewModels/SNMPViewModel.cs
+++ b/Source/NETworkManager/ViewModels/SNMPViewModel.cs
@@ -411,7 +411,7 @@ public class SNMPViewModel : ViewModelBase
         QueryResultsView.SortDescriptions.Add(new SortDescription(nameof(SNMPReceivedInfo.OID), ListSortDirection.Ascending));
 
         // Versions (v1, v2c, v3)
-        Versions = System.Enum.GetValues(typeof(SNMPVersion)).Cast<SNMPVersion>().ToList();
+        Versions = Enum.GetValues(typeof(SNMPVersion)).Cast<SNMPVersion>().ToList();
 
         // Modes
         Modes = new List<SNMPMode> { SNMPMode.Get, SNMPMode.Walk, SNMPMode.Set };
@@ -420,8 +420,8 @@ public class SNMPViewModel : ViewModelBase
         Securitys = new List<SNMPV3Security> { SNMPV3Security.NoAuthNoPriv, SNMPV3Security.AuthNoPriv, SNMPV3Security.AuthPriv };
 
         // Auth / Priv
-        AuthenticationProviders = new List<SNMPV3AuthenticationProvider> { SNMPV3AuthenticationProvider.MD5, SNMPV3AuthenticationProvider.SHA1 };
-        PrivacyProviders = new List<SNMPV3PrivacyProvider> { SNMPV3PrivacyProvider.DES, SNMPV3PrivacyProvider.AES };
+        AuthenticationProviders = Enum.GetValues(typeof(SNMPV3AuthenticationProvider)).Cast<SNMPV3AuthenticationProvider>().ToList();
+        PrivacyProviders = Enum.GetValues(typeof(SNMPV3PrivacyProvider)).Cast<SNMPV3PrivacyProvider>().ToList();
 
         LoadSettings();
 

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -33,6 +33,9 @@ Release date: **xx.xx.2023**
 - Remote Desktop
   - Domain added to connect dialog [#2165](https://github.com/BornToBeRoot/NETworkManager/pull/2165){:target="\_blank"}
   - Domain added to credentials [#2108](https://github.com/BornToBeRoot/NETworkManager/pull/2108){:target="\_blank"}
+- SNMP
+  - SHA256, SHA384 and SHA512 for SNMPv3 auth added [#2166](https://github.com/BornToBeRoot/NETworkManager/pull/2166){:target="\_blank"}
+  - AES192 and AES256 for SNMPv3 privacy added [#2166](https://github.com/BornToBeRoot/NETworkManager/pull/2166){:target="\_blank"}
 - Connections
   - Automatically refresh is now enabled if it was enabled on the last exit [#2116](https://github.com/BornToBeRoot/NETworkManager/pull/2116){:target="\_blank"}
 - Listeners


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Add more SHA and AES protocols for SNMPv3
-
-

Fixes #1753

**ToDo:**

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).