### PR TITLE
Feature: Rework ServerConnectionInfoProfile view/viewmodel (Fix DNS, SNTP app crash)

### DIFF
--- a/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
+++ b/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
@@ -565,6 +565,15 @@ namespace NETworkManager.Localization.Resources {
         }
         
         /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Add server ähnelt.
+        /// </summary>
+        public static string AddServer {
+            get {
+                return ResourceManager.GetString("AddServer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die Add SNTP server ähnelt.
         /// </summary>
         public static string AddSNTPServer {
@@ -8586,6 +8595,15 @@ namespace NETworkManager.Localization.Resources {
         public static string SNTPLookup {
             get {
                 return ResourceManager.GetString("SNTPLookup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die SNTP server ähnelt.
+        /// </summary>
+        public static string SNTPServer {
+            get {
+                return ResourceManager.GetString("SNTPServer", resourceCulture);
             }
         }
         

--- a/Source/NETworkManager.Localization/Resources/Strings.resx
+++ b/Source/NETworkManager.Localization/Resources/Strings.resx
@@ -3541,4 +3541,10 @@ Changes to this value will take effect after the application is restarted. Wheth
   <data name="NewSubnetMask" xml:space="preserve">
     <value>New subnet mask</value>
   </data>
+  <data name="AddServer" xml:space="preserve">
+    <value>Add server</value>
+  </data>
+  <data name="SNTPServer" xml:space="preserve">
+    <value>SNTP server</value>
+  </data>
 </root>

--- a/Source/NETworkManager.Models/Network/ServerConnectionInfoProfile.cs
+++ b/Source/NETworkManager.Models/Network/ServerConnectionInfoProfile.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace NETworkManager.Models.Network;
 

--- a/Source/NETworkManager/ViewModels/DNSLookupSettingsViewModel.cs
+++ b/Source/NETworkManager/ViewModels/DNSLookupSettingsViewModel.cs
@@ -17,6 +17,7 @@ public class DNSLookupSettingsViewModel : ViewModelBase
 {
     #region Variables
     private readonly bool _isLoading;
+    private readonly ServerConnectionInfo _profileDialog_DefaultValues = new("10.0.0.1", 53, TransportProtocol.UDP);
 
     private readonly IDialogCoordinator _dialogCoordinator;
 
@@ -289,7 +290,7 @@ public class DNSLookupSettingsViewModel : ViewModelBase
         }, instance =>
         {
             _dialogCoordinator.HideMetroDialogAsync(this, customDialog);
-        }, (ServerInfoProfileNames, false, true));
+        }, (ServerInfoProfileNames, false, true), _profileDialog_DefaultValues);
 
         customDialog.Content = new ServerConnectionInfoProfileDialog()
         {
@@ -315,7 +316,7 @@ public class DNSLookupSettingsViewModel : ViewModelBase
         }, instance =>
         {
             _dialogCoordinator.HideMetroDialogAsync(this, customDialog);
-        }, (ServerInfoProfileNames, true, true), SelectedDNSServer);
+        }, (ServerInfoProfileNames, true, true), _profileDialog_DefaultValues, SelectedDNSServer);
 
         customDialog.Content = new ServerConnectionInfoProfileDialog()
         {

--- a/Source/NETworkManager/ViewModels/DNSLookupSettingsViewModel.cs
+++ b/Source/NETworkManager/ViewModels/DNSLookupSettingsViewModel.cs
@@ -20,8 +20,6 @@ public class DNSLookupSettingsViewModel : ViewModelBase
 
     private readonly IDialogCoordinator _dialogCoordinator;
 
-    private (string Server, int Port, TransportProtocol TransportProtocol) _profileDialog_NewItemsOptions = ("1.1.1.1", 53, TransportProtocol.UDP);
-
     public ICollectionView DNSServers { get; }
 
     private DNSServerConnectionInfoProfile _selectedDNSServer = new();
@@ -287,13 +285,13 @@ public class DNSLookupSettingsViewModel : ViewModelBase
         {
             _dialogCoordinator.HideMetroDialogAsync(this, customDialog);
 
-            SettingsManager.Current.DNSLookup_DNSServers_v2.Add(new DNSServerConnectionInfoProfile(instance.Name, instance.Servers));
+            SettingsManager.Current.DNSLookup_DNSServers_v2.Add(new DNSServerConnectionInfoProfile(instance.Name, instance.Servers.ToList()));
         }, instance =>
         {
             _dialogCoordinator.HideMetroDialogAsync(this, customDialog);
         }, (ServerInfoProfileNames, false, true));
 
-        customDialog.Content = new ServerConnectionInfoProfileDialog(_profileDialog_NewItemsOptions)
+        customDialog.Content = new ServerConnectionInfoProfileDialog()
         {
             DataContext = viewModel
         };
@@ -313,13 +311,13 @@ public class DNSLookupSettingsViewModel : ViewModelBase
             _dialogCoordinator.HideMetroDialogAsync(this, customDialog);
 
             SettingsManager.Current.DNSLookup_DNSServers_v2.Remove(SelectedDNSServer);
-            SettingsManager.Current.DNSLookup_DNSServers_v2.Add(new DNSServerConnectionInfoProfile(instance.Name, instance.Servers));
+            SettingsManager.Current.DNSLookup_DNSServers_v2.Add(new DNSServerConnectionInfoProfile(instance.Name, instance.Servers.ToList()));
         }, instance =>
         {
             _dialogCoordinator.HideMetroDialogAsync(this, customDialog);
         }, (ServerInfoProfileNames, true, true), SelectedDNSServer);
 
-        customDialog.Content = new ServerConnectionInfoProfileDialog(_profileDialog_NewItemsOptions)
+        customDialog.Content = new ServerConnectionInfoProfileDialog()
         {
             DataContext = viewModel
         };

--- a/Source/NETworkManager/ViewModels/SNTPLookupSettingsViewModel.cs
+++ b/Source/NETworkManager/ViewModels/SNTPLookupSettingsViewModel.cs
@@ -16,7 +16,8 @@ public class SNTPLookupSettingsViewModel : ViewModelBase
 {
     #region Variables
     private readonly bool _isLoading;
-
+    private readonly ServerConnectionInfo _profileDialog_DefaultValues = new("time.example.com", 123, TransportProtocol.TCP);
+    
     private readonly IDialogCoordinator _dialogCoordinator;
 
     private ICollectionView _sntpServers;
@@ -132,7 +133,7 @@ public class SNTPLookupSettingsViewModel : ViewModelBase
         }, instance =>
         {
             _dialogCoordinator.HideMetroDialogAsync(this, customDialog);
-        }, (ServerInfoProfileNames, false, false));
+        }, (ServerInfoProfileNames, false, false), _profileDialog_DefaultValues);
 
         customDialog.Content = new ServerConnectionInfoProfileDialog()
         {
@@ -158,7 +159,7 @@ public class SNTPLookupSettingsViewModel : ViewModelBase
         }, instance =>
         {
             _dialogCoordinator.HideMetroDialogAsync(this, customDialog);
-        }, (ServerInfoProfileNames, true, false), SelectedSNTPServer);
+        }, (ServerInfoProfileNames, true, false), _profileDialog_DefaultValues, SelectedSNTPServer);
 
         customDialog.Content = new ServerConnectionInfoProfileDialog()
         {

--- a/Source/NETworkManager/ViewModels/SNTPLookupSettingsViewModel.cs
+++ b/Source/NETworkManager/ViewModels/SNTPLookupSettingsViewModel.cs
@@ -19,8 +19,6 @@ public class SNTPLookupSettingsViewModel : ViewModelBase
 
     private readonly IDialogCoordinator _dialogCoordinator;
 
-    private (string Server, int Port, TransportProtocol TransportProtocol) _profileDialog_NewItemsOptions = ("time.example.com", 123, TransportProtocol.TCP);
-
     private ICollectionView _sntpServers;
     public ICollectionView SNTPServers
     {
@@ -130,13 +128,13 @@ public class SNTPLookupSettingsViewModel : ViewModelBase
         {
             _dialogCoordinator.HideMetroDialogAsync(this, customDialog);
 
-            SettingsManager.Current.SNTPLookup_SNTPServers.Add(new ServerConnectionInfoProfile(instance.Name, instance.Servers));
+            SettingsManager.Current.SNTPLookup_SNTPServers.Add(new ServerConnectionInfoProfile(instance.Name, instance.Servers.ToList()));
         }, instance =>
         {
             _dialogCoordinator.HideMetroDialogAsync(this, customDialog);
         }, (ServerInfoProfileNames, false, false));
 
-        customDialog.Content = new ServerConnectionInfoProfileDialog(_profileDialog_NewItemsOptions)
+        customDialog.Content = new ServerConnectionInfoProfileDialog()
         {
             DataContext = viewModel
         };
@@ -156,13 +154,13 @@ public class SNTPLookupSettingsViewModel : ViewModelBase
             _dialogCoordinator.HideMetroDialogAsync(this, customDialog);
 
             SettingsManager.Current.SNTPLookup_SNTPServers.Remove(SelectedSNTPServer);
-            SettingsManager.Current.SNTPLookup_SNTPServers.Add(new ServerConnectionInfoProfile(instance.Name, instance.Servers));
+            SettingsManager.Current.SNTPLookup_SNTPServers.Add(new ServerConnectionInfoProfile(instance.Name, instance.Servers.ToList()));
         }, instance =>
         {
             _dialogCoordinator.HideMetroDialogAsync(this, customDialog);
         }, (ServerInfoProfileNames, true, false), SelectedSNTPServer);
 
-        customDialog.Content = new ServerConnectionInfoProfileDialog(_profileDialog_NewItemsOptions)
+        customDialog.Content = new ServerConnectionInfoProfileDialog()
         {
             DataContext = viewModel
         };

--- a/Source/NETworkManager/ViewModels/ServerConnectionInfoProfileViewModel.cs
+++ b/Source/NETworkManager/ViewModels/ServerConnectionInfoProfileViewModel.cs
@@ -3,10 +3,9 @@ using System;
 using System.Windows.Input;
 using NETworkManager.Models.Network;
 using System.Collections.Generic;
-using System.Windows.Controls;
-using System.Windows;
+using System.Collections.ObjectModel;
+using System.Collections;
 using System.Linq;
-using System.Diagnostics;
 
 namespace NETworkManager.ViewModels;
 
@@ -95,8 +94,8 @@ public class ServerConnectionInfoProfileViewModel : ViewModelBase
         }
     }
 
-    private List<ServerConnectionInfo> _servers;
-    public List<ServerConnectionInfo> Servers
+    private ObservableCollection<ServerConnectionInfo> _servers;
+    public ObservableCollection<ServerConnectionInfo> Servers
     {
         get => _servers;
         set
@@ -105,6 +104,20 @@ public class ServerConnectionInfoProfileViewModel : ViewModelBase
                 return;
 
             _servers = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private IList _selectedServers = new ArrayList();
+    public IList SelectedServers
+    {
+        get => _selectedServers;
+        set
+        {
+            if (Equals(value, _selectedServers))
+                return;
+
+            _selectedServers = value;
             OnPropertyChanged();
         }
     }
@@ -127,8 +140,19 @@ public class ServerConnectionInfoProfileViewModel : ViewModelBase
             UsedNames.Remove(CurrentProfile.Name);
 
         Name = _currentProfile.Name;
-        Servers = _currentProfile.Servers;
+        Servers = new ObservableCollection<ServerConnectionInfo>(_currentProfile.Servers);
 
         _isLoading = false;
+    }
+
+    public ICommand DeleteServerCommand => new RelayCommand(p => DeleteServerAction());
+
+    private void DeleteServerAction()
+    {
+        // Cast to list to avoid exception: Collection was modified; enumeration operation may not execute.
+        // This will create a copy of the list and allow us to remove items from the original list (SelectedServers
+        // is modified when Servers changes)
+        foreach (var item in SelectedServers.Cast<ServerConnectionInfo>().ToList())
+            Servers.Remove(item);
     }
 }

--- a/Source/NETworkManager/Views/SNTPLookupSettingsView.xaml
+++ b/Source/NETworkManager/Views/SNTPLookupSettingsView.xaml
@@ -17,7 +17,7 @@
     </UserControl.Resources>
     <StackPanel>
         <TextBlock Text="{x:Static localization:Strings.SNTPLookup}" Style="{StaticResource HeaderTextBlock}" />
-        <TextBlock Text="{x:Static localization:Strings.SNTPServers}" Style="{DynamicResource DefaultTextBlock}" Margin="0,0,0,10" />
+        <TextBlock Text="{x:Static localization:Strings.SNTPServer}" Style="{DynamicResource DefaultTextBlock}" Margin="0,0,0,10" />
         <DataGrid x:Name="DataGridSNTPServers" ItemsSource="{Binding SNTPServers}" SelectionMode="Single" SelectedItem="{Binding SelectedSNTPServer}" Height="200" Margin="0,0,0,10">
             <DataGrid.Resources>
                 <Style TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource DataGridScrollBar}" />

--- a/Source/NETworkManager/Views/ServerConnectionInfoProfileDialog.xaml
+++ b/Source/NETworkManager/Views/ServerConnectionInfoProfileDialog.xaml
@@ -5,15 +5,20 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"            
              xmlns:validators="clr-namespace:NETworkManager.Validators;assembly=NETworkManager.Validators"
              xmlns:wpfHelpers="clr-namespace:NETworkManager.Utilities.WPF;assembly=NETworkManager.Utilities.WPF"
+             xmlns:controls="clr-namespace:NETworkManager.Controls;assembly=NETworkManager.Controls"
+             xmlns:network="clr-namespace:NETworkManager.Models.Network;assembly=NETworkManager.Models"
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
              xmlns:viewModels="clr-namespace:NETworkManager.ViewModels"
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:localization="clr-namespace:NETworkManager.Localization.Resources;assembly=NETworkManager.Localization"
-             mc:Ignorable="d" Loaded="UserControl_Loaded" d:DataContext="{d:DesignInstance viewModels:ServerConnectionInfoProfileViewModel}">    
+             mc:Ignorable="d" Loaded="UserControl_Loaded" d:DataContext="{d:DesignInstance viewModels:ServerConnectionInfoProfileViewModel}">
     <Grid Margin="0,20">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="10" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="10" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="10" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -35,7 +40,7 @@
                 <TextBox.Resources>
                     <wpfHelpers:BindingProxy x:Key="BindingProxy" Data="{Binding}" />
                 </TextBox.Resources>
-                <TextBox.Text>                    
+                <TextBox.Text>
                     <Binding Path="Name" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
                         <Binding.ValidationRules>
                             <validators:EmptyValidator ValidatesOnTargetUpdated="True" />
@@ -49,37 +54,46 @@
                 </TextBox.Text>
             </TextBox>
         </Grid>
-        <DataGrid x:Name="DataGridServers" AddingNewItem="DataGridServers_AddingNewItem" Grid.Column="0" Grid.Row="2" IsReadOnly="False" ItemsSource="{Binding Servers}">
-            <DataGrid.Resources>
-                <wpfHelpers:BindingProxy x:Key="BindingProxy" Data="{Binding}" />
-            </DataGrid.Resources>
-            <DataGrid.Columns>
-                <DataGridTextColumn Header="{x:Static localization:Strings.Server}" MinWidth="200">
-                    <DataGridTextColumn.Binding>
-                        <Binding Path="Server" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
-                            <Binding.ValidationRules>
-                                <validators:EmptyValidator ValidatesOnTargetUpdated="True" />
-                                <validators:ServerValidator ValidatesOnTargetUpdated="True">
-                                    <validators:ServerValidator.Wrapper>
-                                        <validators:ServerDependencyObjectWrapper AllowOnlyIPAddress="{Binding Data.AllowOnlyIPAddress, Source={StaticResource BindingProxy}}" />
-                                    </validators:ServerValidator.Wrapper>
-                                </validators:ServerValidator>
-                            </Binding.ValidationRules>
-                        </Binding>
-                    </DataGridTextColumn.Binding>
-                </DataGridTextColumn>
-                <DataGridTextColumn Header="{x:Static localization:Strings.Port}">
-                    <DataGridTextColumn.Binding>
-                        <Binding Path="Port" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
-                            <Binding.ValidationRules>
-                                <validators:PortValidator ValidatesOnTargetUpdated="True" />
-                            </Binding.ValidationRules>
-                        </Binding>
-                    </DataGridTextColumn.Binding>
-                </DataGridTextColumn>
-            </DataGrid.Columns>
-        </DataGrid>
-        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" MinWidth="80">
+        <controls:MultiSelectDataGrid x:Name="DataGridServers" Grid.Column="0" Grid.Row="2" ItemsSource="{Binding Servers}" SelectedItemsList="{Binding SelectedServers, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+            <controls:MultiSelectDataGrid.Resources>
+                <Style TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource DataGridScrollBar}" />
+                <ContextMenu x:Key="ContextMenu" Opened="ContextMenu_Opened" MinWidth="150">
+                    <MenuItem Header="{x:Static localization:Strings.Delete}" Command="{Binding DeleteServerCommand}">
+                        <MenuItem.Icon>
+                            <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
+                                <Rectangle.OpacityMask>
+                                    <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=Close}" />
+                                </Rectangle.OpacityMask>
+                            </Rectangle>
+                        </MenuItem.Icon>
+                    </MenuItem>
+                </ContextMenu>
+            </controls:MultiSelectDataGrid.Resources>
+            <controls:MultiSelectDataGrid.Columns>
+                <DataGridTextColumn Header="{x:Static localization:Strings.Server}" Binding="{Binding (network:ServerConnectionInfo.Server)}" Width="1*" />
+                <DataGridTextColumn Header="{x:Static localization:Strings.Port}" Binding="{Binding (network:ServerConnectionInfo.Port)}" Width="2*" />
+            </controls:MultiSelectDataGrid.Columns>
+            <controls:MultiSelectDataGrid.InputBindings>
+                <KeyBinding Command="{Binding DeleteServerCommand}" Key="Delete" />
+            </controls:MultiSelectDataGrid.InputBindings>
+            <controls:MultiSelectDataGrid.RowStyle>
+                <Style TargetType="{x:Type DataGridRow}" BasedOn="{StaticResource MahApps.Styles.DataGridRow}">
+                    <Setter Property="ContextMenu" Value="{StaticResource ContextMenu}"/>
+                </Style>
+            </controls:MultiSelectDataGrid.RowStyle>
+        </controls:MultiSelectDataGrid>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*" />
+                <ColumnDefinition Width="10" />
+                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="10" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+
+        </Grid>
+        <StackPanel Grid.Row="6" Orientation="Horizontal" HorizontalAlignment="Right" MinWidth="80">
             <Button Content="{x:Static localization:Strings.Save}" Command="{Binding SaveCommand}" IsDefault="True" Margin="0,0,10,0">
                 <Button.Style>
                     <Style TargetType="{x:Type Button}" BasedOn="{StaticResource HighlightedButton}">

--- a/Source/NETworkManager/Views/ServerConnectionInfoProfileDialog.xaml
+++ b/Source/NETworkManager/Views/ServerConnectionInfoProfileDialog.xaml
@@ -70,8 +70,8 @@
                 </ContextMenu>
             </controls:MultiSelectDataGrid.Resources>
             <controls:MultiSelectDataGrid.Columns>
-                <DataGridTextColumn Header="{x:Static localization:Strings.Server}" Binding="{Binding (network:ServerConnectionInfo.Server)}" Width="1*" />
-                <DataGridTextColumn Header="{x:Static localization:Strings.Port}" Binding="{Binding (network:ServerConnectionInfo.Port)}" Width="2*" />
+                <DataGridTextColumn Header="{x:Static localization:Strings.Server}" Binding="{Binding (network:ServerConnectionInfo.Server)}" Width="250" />
+                <DataGridTextColumn Header="{x:Static localization:Strings.Port}" Binding="{Binding (network:ServerConnectionInfo.Port)}" Width="*" />
             </controls:MultiSelectDataGrid.Columns>
             <controls:MultiSelectDataGrid.InputBindings>
                 <KeyBinding Command="{Binding DeleteServerCommand}" Key="Delete" />
@@ -82,29 +82,89 @@
                 </Style>
             </controls:MultiSelectDataGrid.RowStyle>
         </controls:MultiSelectDataGrid>
-        <Grid>
+        <Grid Grid.Column="0" Grid.Row="4">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="1*" />
+                <ColumnDefinition Width="240" />
                 <ColumnDefinition Width="10" />
-                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="10" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-
-
-        </Grid>
-        <StackPanel Grid.Row="6" Orientation="Horizontal" HorizontalAlignment="Right" MinWidth="80">
-            <Button Content="{x:Static localization:Strings.Save}" Command="{Binding SaveCommand}" IsDefault="True" Margin="0,0,10,0">
-                <Button.Style>
-                    <Style TargetType="{x:Type Button}" BasedOn="{StaticResource HighlightedButton}">
-                        <Setter Property="IsEnabled" Value="False" />
+            <TextBox x:Name="TextBoxServer" Grid.Column="0" Grid.Row="0" mah:TextBoxHelper.Watermark="{Binding ServerWatermark}">
+                <TextBox.Resources>
+                    <wpfHelpers:BindingProxy x:Key="BindingProxy" Data="{Binding}" />
+                </TextBox.Resources>
+                <TextBox.Text>
+                    <Binding Path="Server" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
+                        <Binding.ValidationRules>
+                            <validators:EmptyValidator ValidatesOnTargetUpdated="True" />
+                            <validators:ServerValidator ValidatesOnTargetUpdated="True">
+                                <validators:ServerValidator.Wrapper>
+                                    <validators:ServerDependencyObjectWrapper AllowOnlyIPAddress="{Binding Data.AllowOnlyIPAddress, Source={StaticResource BindingProxy}}" />
+                                </validators:ServerValidator.Wrapper>
+                            </validators:ServerValidator>
+                        </Binding.ValidationRules>
+                    </Binding>
+                </TextBox.Text>
+            </TextBox>
+            <TextBox x:Name="TextBoxPort" Grid.Column="2" Grid.Row="0" mah:TextBoxHelper.Watermark="{Binding PortWatermark}">
+                <TextBox.Text>
+                    <Binding Path="Port" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
+                        <Binding.ValidationRules>
+                            <validators:PortValidator ValidatesOnTargetUpdated="True" />
+                        </Binding.ValidationRules>
+                    </Binding>
+                </TextBox.Text>
+            </TextBox>
+            <Button Grid.Column="4" Grid.Row="0" Command="{Binding AddServerCommand}" ToolTip="{x:Static localization:Strings.AddServer}">
+                <Button.Resources>
+                    <Style TargetType="{x:Type Button}" BasedOn="{StaticResource ImageButton}">
                         <Style.Triggers>
                             <MultiDataTrigger>
                                 <MultiDataTrigger.Conditions>
-                                    <Condition Binding="{Binding Path=(Validation.HasError), ElementName=TextBoxName}" Value="False" />
+                                    <Condition Binding="{Binding Path=(Validation.HasError), ElementName=TextBoxServer}" Value="True" />
                                 </MultiDataTrigger.Conditions>
                                 <MultiDataTrigger.Setters>
-                                    <Setter Property="IsEnabled" Value="True" />
+                                    <Setter Property="IsEnabled" Value="False" />
+                                </MultiDataTrigger.Setters>
+                            </MultiDataTrigger>
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding Path=(Validation.HasError), ElementName=TextBoxPort}" Value="True" />
+                                </MultiDataTrigger.Conditions>
+                                <MultiDataTrigger.Setters>
+                                    <Setter Property="IsEnabled" Value="False" />
+                                </MultiDataTrigger.Setters>
+                            </MultiDataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Resources>
+                <Rectangle Width="20" Height="20" Fill="{DynamicResource MahApps.Brushes.Gray3}">
+                    <Rectangle.OpacityMask>
+                        <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=Plus}" />
+                    </Rectangle.OpacityMask>
+                </Rectangle>
+            </Button>
+        </Grid>
+        <StackPanel Grid.Column="0" Grid.Row="6" Orientation="Horizontal" HorizontalAlignment="Right" MinWidth="80">
+            <Button Content="{x:Static localization:Strings.Save}" Command="{Binding SaveCommand}" IsDefault="True" Margin="0,0,10,0">
+                <Button.Style>
+                    <Style TargetType="{x:Type Button}" BasedOn="{StaticResource HighlightedButton}">
+                        <Style.Triggers>
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding Path=(Validation.HasError), ElementName=TextBoxName}" Value="True" />
+                                </MultiDataTrigger.Conditions>
+                                <MultiDataTrigger.Setters>
+                                    <Setter Property="IsEnabled" Value="False" />
+                                </MultiDataTrigger.Setters>
+                            </MultiDataTrigger>
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding Path=Servers.Count}" Value="0" />
+                                </MultiDataTrigger.Conditions>
+                                <MultiDataTrigger.Setters>
+                                    <Setter Property="IsEnabled" Value="False" />
                                 </MultiDataTrigger.Setters>
                             </MultiDataTrigger>
                         </Style.Triggers>

--- a/Source/NETworkManager/Views/ServerConnectionInfoProfileDialog.xaml.cs
+++ b/Source/NETworkManager/Views/ServerConnectionInfoProfileDialog.xaml.cs
@@ -1,15 +1,13 @@
-﻿using NETworkManager.Models.Network;
+﻿using NETworkManager.ViewModels;
+using System.Windows.Controls;
 
 namespace NETworkManager.Views;
 
 public partial class ServerConnectionInfoProfileDialog
 {
-    private (string Server, int Port, TransportProtocol TransportProtocol) _newItemOptions;
-    public ServerConnectionInfoProfileDialog((string Server, int Port, TransportProtocol TransportProtocol) NewItemOptions)
+    public ServerConnectionInfoProfileDialog()
     {
         InitializeComponent();
-
-        _newItemOptions = NewItemOptions;
     }
 
     private void UserControl_Loaded(object sender, System.Windows.RoutedEventArgs e)
@@ -18,13 +16,9 @@ public partial class ServerConnectionInfoProfileDialog
         TextBoxName.Focus();
     }
 
-    private void DataGridServers_AddingNewItem(object sender, System.Windows.Controls.AddingNewItemEventArgs e)
+    private void ContextMenu_Opened(object sender, System.Windows.RoutedEventArgs e)
     {
-        e.NewItem = new ServerConnectionInfo
-        {
-            Server = _newItemOptions.Server,
-            Port = _newItemOptions.Port,
-            TransportProtocol = _newItemOptions.TransportProtocol
-        };
+        if (sender is ContextMenu menu)
+            menu.DataContext = (ServerConnectionInfoProfileViewModel)DataContext;
     }
 }

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -19,6 +19,10 @@ Release date: **xx.xx.2023**
 
 ## Improvements
 
+- DNS Lookup
+  - Improved validation when adding/changing DNS server profiles [#2282](https://github.com/BornToBeRoot/NETworkManager/pull/2282){:target="\_blank"}
+- SNTP Lookup
+  - Improved validation when adding/changing SNTP server profiles [#2282](https://github.com/BornToBeRoot/NETworkManager/pull/2282){:target="\_blank"}
 - TigerVNC
   - Use port from default config instead of settings if creating a new group [#2249](https://github.com/BornToBeRoot/NETworkManager/pull/2249){:target="\_blank"}
 - Wake on LAN
@@ -26,6 +30,10 @@ Release date: **xx.xx.2023**
 
 ## Bugfixes
 
+- DNS Lookup
+  - Fixed app crash when editing DNS server profile in some rare cases [#2282](https://github.com/BornToBeRoot/NETworkManager/pull/2282){:target="\_blank"}
+- SNTP Lookup
+  - Fixed app crash when editing SNTP server profile in some rare cases [#2282](https://github.com/BornToBeRoot/NETworkManager/pull/2282){:target="\_blank"}
 - Subnet Calculator
   - Fixed a design issue with the calculate button in subnetting [#2230](https://github.com/BornToBeRoot/NETworkManager/pull/2230){:target="\_blank"}
 - [AirSpace Fixer](https://www.nuget.org/packages/AirspaceFixer){:target="\_blank"} code optimized (only called if needed). This will also prevent a screenshot bug when the application is loading and a dialog is shown. [#2253](https://github.com/BornToBeRoot/NETworkManager/pull/2253){:target="\_blank"}

--- a/docs/Documentation/01_Application/08_DNSLookup.md
+++ b/docs/Documentation/01_Application/08_DNSLookup.md
@@ -52,7 +52,7 @@ Hostname or IP address (or any other resource record) to query.
 
 ### DNS server
 
-List of DNS servers to query.
+List of DNS server profiles. A profile can contain one or more DNS servers with IP address and port.
 
 **Type:** `List<NETworkManager.Models.Network.DNSServerConnectionInfoProfile>`
 

--- a/docs/Documentation/01_Application/16_SNTPLookup.md
+++ b/docs/Documentation/01_Application/16_SNTPLookup.md
@@ -29,11 +29,11 @@ Right-click on the result to copy or export the information.
 
 ## Settings
 
-### Servers
+### SNTP servers
 
 List of SNTP server profiles. A profile can contain one or more SNTP servers with host/IP address and port.
 
-**Type:** `List<NETworkManager.Models.Network.ServerInfoProfile>`
+**Type:** `List<NETworkManager.Models.Network.ServerConnectionInfoProfile>`
 
 **Default:**
 


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Re-work view / viewmodel for ServerConnectionInfoProfile
- Improve input validation
-

Fix: #2274 
Fix #2275
Close #1914 

**ToDo:**

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).