### PR TITLE
Fix: Allow dot as windows domain for local authentication

### DIFF
--- a/Source/NETworkManager.Validators/EmptyOrWindowsDomainValidator.cs
+++ b/Source/NETworkManager.Validators/EmptyOrWindowsDomainValidator.cs
@@ -10,9 +10,15 @@ public class EmptyOrWindowsDomainValidator : ValidationRule
 {
     public override ValidationResult Validate(object value, CultureInfo cultureInfo)
     {
-        if (string.IsNullOrEmpty(value as string))
+        string domain = value as string;
+
+        if (string.IsNullOrEmpty(domain))
             return ValidationResult.ValidResult;
 
-        return Regex.IsMatch((string)value, RegexHelper.HostnameRegex) ? ValidationResult.ValidResult : new ValidationResult(false, Strings.EnterValidDomain);        
+        // For local authentication "." is a valid domain
+        if (domain.Equals("."))
+            return ValidationResult.ValidResult;
+        
+        return Regex.IsMatch(domain, RegexHelper.HostnameRegex) ? ValidationResult.ValidResult : new ValidationResult(false, Strings.EnterValidDomain);        
     }
 }

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -30,10 +30,12 @@ Breaking changes
 
 - DNS Lookup
   - Improved validation when adding/changing DNS server profiles [#2282](https://github.com/BornToBeRoot/NETworkManager/pull/2282){:target="\_blank"}
-- SNTP Lookup
-  - Improved validation when adding/changing SNTP server profiles [#2282](https://github.com/BornToBeRoot/NETworkManager/pull/2282){:target="\_blank"}
+- Remote Desktop
+  - Allow `.` as domain to authenticate with local accounts [#2305](https://github.com/BornToBeRoot/NETworkManager/pull/2305){:target="\_blank"}
 - TigerVNC
   - Use port from default config instead of settings if creating a new group [#2249](https://github.com/BornToBeRoot/NETworkManager/pull/2249){:target="\_blank"}
+- SNTP Lookup
+  - Improved validation when adding/changing SNTP server profiles [#2282](https://github.com/BornToBeRoot/NETworkManager/pull/2282){:target="\_blank"}
 - Wake on LAN
   - Change default port from 7 to 9 [#2242](https://github.com/BornToBeRoot/NETworkManager/pull/2242){:target="\_blank"}
 


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Allow dot as windows domain for local authentication
-
-

Fixes #2303

**ToDo:**

- [x] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Documentation) to reflect this changes
- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).