### PR TITLE
Fix: Enable credentials only if LogonMethod is Userpass

### DIFF
--- a/Source/NETworkManager/Views/GroupDialog.xaml
+++ b/Source/NETworkManager/Views/GroupDialog.xaml
@@ -753,6 +753,7 @@
                                                     <MultiDataTrigger.Conditions>
                                                         <Condition Binding="{Binding RemoteDesktop_OverrideGatewayServer}" Value="True" />
                                                         <Condition Binding="{Binding RemoteDesktop_EnableGatewayServer}" Value="True" />
+                                                        <Condition Binding="{Binding RemoteDesktop_GatewayServerLogonMethod}" Value="Userpass" />
                                                     </MultiDataTrigger.Conditions>
                                                     <MultiDataTrigger.Setters>
                                                         <Setter Property="IsEnabled" Value="True" />

--- a/Source/NETworkManager/Views/ProfileDialog.xaml
+++ b/Source/NETworkManager/Views/ProfileDialog.xaml
@@ -1591,6 +1591,7 @@
                                                     <MultiDataTrigger.Conditions>
                                                         <Condition Binding="{Binding RemoteDesktop_OverrideGatewayServer}" Value="True" />
                                                         <Condition Binding="{Binding RemoteDesktop_EnableGatewayServer}" Value="True" />
+                                                        <Condition Binding="{Binding RemoteDesktop_GatewayServerLogonMethod}" Value="Userpass" />
                                                     </MultiDataTrigger.Conditions>
                                                     <MultiDataTrigger.Setters>
                                                         <Setter Property="IsEnabled" Value="True" />

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -55,8 +55,10 @@ Breaking changes
 - [AirSpace Fixer](https://www.nuget.org/packages/AirspaceFixer){:target="\_blank"} code optimized (only called if needed). This will also prevent a screenshot bug when the application is loading and a dialog is shown. [#2253](https://github.com/BornToBeRoot/NETworkManager/pull/2253){:target="\_blank"}
 - Group dialog
   - Fix default value for Remote Desktop sreen size [#2293](https://github.com/BornToBeRoot/NETworkManager/pull/2293){:target="\_blank"}
+  - Enable Remote Desktop `Use gateway credentials` only if logon method is set to `Userpass` [#2316](https://github.com/BornToBeRoot/NETworkManager/pull/2316){:target="\_blank"}
 - Profile dialog
   - Fix default value for Remote Desktop sreen size [#2293](https://github.com/BornToBeRoot/NETworkManager/pull/2293){:target="\_blank"}
+  - Enable Remote Desktop `Use gateway credentials` only if logon method is set to `Userpass` [#2316](https://github.com/BornToBeRoot/NETworkManager/pull/2316){:target="\_blank"}
   - Fix validation rule for TigerVNC port [#2309](https://github.com/BornToBeRoot/NETworkManager/pull/2309){:target="\_blank"}
 
 ## Deprecated


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Enable Remote Desktop `Use gateway credentials` only if logon method is set to `Userpass`
-
-

**ToDo:**

- [x] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Documentation) to reflect this changes
- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).