### PR TITLE
Fix: Improve re-select if filter for application or settingsview is applied or removed

### DIFF
--- a/Source/NETworkManager/MainWindow.xaml.cs
+++ b/Source/NETworkManager/MainWindow.xaml.cs
@@ -175,8 +175,7 @@ public partial class MainWindow : INotifyPropertyChanged
         }
     }
 
-    private ApplicationName _filterLastViewName;
-    private int? _filterLastCount;
+    private ApplicationName _searchLastSelectedApplicationName;
 
     private string _search = string.Empty;
     public string Search
@@ -189,25 +188,19 @@ public partial class MainWindow : INotifyPropertyChanged
 
             _search = value;
 
+            // Store the current selected application name
             if (SelectedApplication != null)
-                _filterLastViewName = SelectedApplication.Name;
+                _searchLastSelectedApplicationName = SelectedApplication.Name;
 
+            // Refresh (apply filter)
             Applications.Refresh();
 
-            var sourceCollection = Applications.SourceCollection.Cast<ApplicationInfo>();
-            var filteredCollection = Applications.Cast<ApplicationInfo>();
+            // Try to select the last selected application
+            if (!Applications.IsEmpty && SelectedApplication == null)
+                SelectedApplication = Applications.Cast<ApplicationInfo>().FirstOrDefault(x => x.Name == _searchLastSelectedApplicationName) ?? Applications.Cast<ApplicationInfo>().FirstOrDefault();
 
-            var sourceInfos = sourceCollection as ApplicationInfo[] ?? sourceCollection.ToArray();
-            var filteredInfos = filteredCollection as ApplicationInfo[] ?? filteredCollection.ToArray();
-
-            _filterLastCount ??= sourceInfos.Length;
-
-            SelectedApplication = _filterLastCount > filteredInfos.Length ? filteredInfos.FirstOrDefault() : sourceInfos.FirstOrDefault(x => x.Name == _filterLastViewName);
-
-            _filterLastCount = filteredInfos.Length;
-
-            // Show note when there was nothing found
-            SearchNothingFound = filteredInfos.Length == 0;
+            // Show note if nothing was found
+            SearchNothingFound = Applications.IsEmpty;
 
             OnPropertyChanged();
         }
@@ -577,8 +570,8 @@ public partial class MainWindow : INotifyPropertyChanged
 
         _isApplicationListLoading = false;
 
-        // Select the application
-        SelectedApplication = Applications.SourceCollection.Cast<ApplicationInfo>().FirstOrDefault(x => x.Name == (CommandLineManager.Current.Application != ApplicationName.None ? CommandLineManager.Current.Application : SettingsManager.Current.General_DefaultApplicationViewName));
+        // Select the application        
+        SelectedApplication = Applications.Cast<ApplicationInfo>().FirstOrDefault(x => x.Name == (CommandLineManager.Current.Application != ApplicationName.None ? CommandLineManager.Current.Application : SettingsManager.Current.General_DefaultApplicationViewName));
 
         // Scroll into view
         if (SelectedApplication != null)

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -62,6 +62,9 @@ Breaking changes
   - Fix default value for Remote Desktop sreen size [#2293](https://github.com/BornToBeRoot/NETworkManager/pull/2293){:target="\_blank"}
   - Enable Remote Desktop `Use gateway credentials` only if logon method is set to `Userpass` [#2316](https://github.com/BornToBeRoot/NETworkManager/pull/2316){:target="\_blank"}
   - Fix validation rule for TigerVNC port [#2309](https://github.com/BornToBeRoot/NETworkManager/pull/2309){:target="\_blank"}
+- Settings
+  - Settings view is now re-selected if the filter (search) is removed [#2325](https://github.com/BornToBeRoot/NETworkManager/pull/2325){:target="\_blank"}
+  - If settings are opened again, the last selected settings view is now selected (except an application was selected that has a settings view, then the settings view of the application is selected) [#2325](https://github.com/BornToBeRoot/NETworkManager/pull/2325){:target="\_blank"}
 
 ## Deprecated
 
@@ -73,7 +76,7 @@ Deprecated
 
 ## Other
 
-- Code cleanup [#2100](https://github.com/BornToBeRoot/NETworkManager/pull/2100){:target="\_blank"} [#2172](https://github.com/BornToBeRoot/NETworkManager/pull/2172){:target="\_blank"} [#2254](https://github.com/BornToBeRoot/NETworkManager/pull/2254){:target="\_blank"}
+- Code cleanup [#2100](https://github.com/BornToBeRoot/NETworkManager/pull/2100){:target="\_blank"} [#2172](https://github.com/BornToBeRoot/NETworkManager/pull/2172){:target="\_blank"} [#2254](https://github.com/BornToBeRoot/NETworkManager/pull/2254){:target="\_blank"} [#2325](https://github.com/BornToBeRoot/NETworkManager/pull/2325){:target="\_blank"}
 - Language files updated [#transifex](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Ftransifex-integration){:target="\_blank"}
 - Dependencies updated [#dependencies](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Fdependabot){:target="\_blank"}
 - Add documentation for:
@@ -83,7 +86,7 @@ Deprecated
   - Application > DNS Lookup [#2273](https://github.com/BornToBeRoot/NETworkManager/pull/2273){:target="\_blank"}
   - Application > Remote Desktop [#2293](https://github.com/BornToBeRoot/NETworkManager/pull/2293){:target="\_blank"} [#2324](https://github.com/BornToBeRoot/NETworkManager/pull/2324){:target="\_blank"}
   - Application > PowerShell [#2249](https://github.com/BornToBeRoot/NETworkManager/pull/2249){:target="\_blank"} [#2324](https://github.com/BornToBeRoot/NETworkManager/pull/2324){:target="\_blank"}
-  - Application > PuTTY [#2324](https://github.com/BornToBeRoot/NETworkManager/pull/2324){:target="\_blank"}  
+  - Application > PuTTY [#2324](https://github.com/BornToBeRoot/NETworkManager/pull/2324){:target="\_blank"}
   - Application > TigerVNC [#2248](https://github.com/BornToBeRoot/NETworkManager/pull/2248){:target="\_blank"} [#2324](https://github.com/BornToBeRoot/NETworkManager/pull/2324){:target="\_blank"}
   - Application > Web Console [#2244](https://github.com/BornToBeRoot/NETworkManager/pull/2244){:target="\_blank"} [#2324](https://github.com/BornToBeRoot/NETworkManager/pull/2324){:target="\_blank"}
   - Application > SNMP [#2289](https://github.com/BornToBeRoot/NETworkManager/pull/2289){:target="\_blank"} [#2293](https://github.com/BornToBeRoot/NETworkManager/pull/2293){:target="\_blank"}


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Improve filter in MainWindow for Applications
- Re-select settings view if nothing was found
- If settings are opened again, the last selected settings view is now selected (except an application was selected that has a settings view, then the settings view of the application is selected)

Fixes #2261


**ToDo:**

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).