### PR TITLE
Fix: Use http instead of https (free endpoint)

### DIFF
--- a/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
+++ b/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
@@ -4057,7 +4057,7 @@ namespace NETworkManager.Localization.Resources {
         /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die The DNS resolver is determined via ip-api.com.
         ///
-        ///URL: https://edns.ip-api.com/ ähnelt.
+        ///URL: http://edns.ip-api.com/ ähnelt.
         /// </summary>
         public static string HelpMessage_CheckDNSResolver {
             get {

--- a/Source/NETworkManager.Localization/Resources/Strings.it-IT.resx
+++ b/Source/NETworkManager.Localization/Resources/Strings.it-IT.resx
@@ -3717,7 +3717,7 @@ Disponibile solo se la modalità è "SSH", "Telnet" o "Rlogin".</value>
   <data name="HelpMessage_CheckDNSResolver" xml:space="preserve">
     <value>Il risoutore DNS viene determinato tramite ip-api.com.
 
-URL: https://edns.ip-api.com/</value>
+URL: http://edns.ip-api.com/</value>
   </data>
   <data name="HelpMessage_CheckIPGeolocation" xml:space="preserve">
     <value>La geolocalizzazione IP viene determinata tramite ip-api.com.

--- a/Source/NETworkManager.Localization/Resources/Strings.resx
+++ b/Source/NETworkManager.Localization/Resources/Strings.resx
@@ -3632,7 +3632,7 @@ Changes to this value will take effect after the application is restarted. Wheth
   <data name="HelpMessage_CheckDNSResolver" xml:space="preserve">
     <value>The DNS resolver is determined via ip-api.com.
 
-URL: https://edns.ip-api.com/</value>
+URL: http://edns.ip-api.com/</value>
   </data>
   <data name="HelpMessage_CheckIPGeolocation" xml:space="preserve">
     <value>The IP geolocation is determined via ip-api.com.

--- a/Source/NETworkManager.Models/IPApi/DNSResolverService.cs
+++ b/Source/NETworkManager.Models/IPApi/DNSResolverService.cs
@@ -17,7 +17,7 @@ public class DNSResolverService : SingletonBase<DNSResolverService>
     /// <summary>
     /// Base URL fo the edns.ip-api.
     /// </summary>
-    private const string _baseURL = "https://edns.ip-api.com/json";
+    private const string _baseURL = "http://edns.ip-api.com/json";
 
     /// <summary>
     /// Gets the IP DNS details from the API asynchronously.


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Use http instead of https (free endpoint doesn't support it)

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).