### PR TITLE
Improve compare IPAddress in VM (IPScannerViewModel)#2569

### DIFF
--- a/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
@@ -226,10 +226,9 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
         HostHistoryView = CollectionViewSource.GetDefaultView(SettingsManager.Current.IPScanner_HostHistory);
 
         // Result view
+        IPAddressComparer comparer = new();
+        Results = new ObservableCollection<IPScannerHostInfo>(Results.OrderBy(x => x.PingInfo.IPAddress, comparer));
         ResultsView = CollectionViewSource.GetDefaultView(Results);
-        ResultsView.SortDescriptions.Add(new SortDescription(nameof(IPScannerHostInfo.PingInfo) + "." + nameof(PingInfo.IPAddressInt32), ListSortDirection.Ascending));
-
-        LoadSettings();
     }
 
     public void OnLoaded()
@@ -243,10 +242,6 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
         _firstLoad = false;
     }
 
-    private void LoadSettings()
-    {
-
-    }
     #endregion
 
     #region ICommands & Actions
@@ -277,11 +272,11 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
 
     private void RedirectDataToApplicationAction(object name)
     {
-        if(name is not ApplicationName applicationName)
+        if (name is not ApplicationName applicationName)
             return;
 
-        var host = !string.IsNullOrEmpty(SelectedResult.Hostname) 
-            ? SelectedResult.Hostname 
+        var host = !string.IsNullOrEmpty(SelectedResult.Hostname)
+            ? SelectedResult.Hostname
             : SelectedResult.PingInfo.IPAddress.ToString();
 
         EventSystem.RedirectToApplication(applicationName, host);
@@ -330,7 +325,7 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
     {
         StringBuilder stringBuilder = new();
 
-        foreach(var port in SelectedResult.Ports)
+        foreach (var port in SelectedResult.Ports)
         {
             stringBuilder.AppendLine($"{port.Port}/{port.LookupInfo.Protocol},{ResourceTranslator.Translate(ResourceIdentifier.PortState, port.State)},{port.LookupInfo.Service},{port.LookupInfo.Description}");
         }
@@ -380,13 +375,13 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
             UserHasCanceled(this, EventArgs.Empty);
             return;
         }
-        
+
         // Show error message if (some) hostnames could not be resolved
-        if(hosts.hostnamesNotResolved.Count > 0)
+        if (hosts.hostnamesNotResolved.Count > 0)
         {
             StatusMessage = $"{Localization.Resources.Strings.TheFollowingHostnamesCouldNotBeResolved} {string.Join(", ", hosts.hostnamesNotResolved)}";
             IsStatusMessageDisplayed = true;
-            
+
         }
 
         HostsToScan = hosts.hosts.Count;
@@ -570,7 +565,7 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
     {
         HostsScanned = e.Value;
     }
-    
+
     private void ScanComplete(object sender, EventArgs e)
     {
         if (Results.Count == 0)
@@ -587,7 +582,7 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
     {
         StatusMessage = Localization.Resources.Strings.CanceledByUserMessage;
         IsStatusMessageDisplayed = true;
-        
+
         IsCanceling = false;
         IsRunning = false;
     }

--- a/Source/NETworkManager/ViewModels/SNMPViewModel.cs
+++ b/Source/NETworkManager/ViewModels/SNMPViewModel.cs
@@ -22,8 +22,6 @@ using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using NETworkManager.Localization;
-using ControlzEx.Standard;
-using Microsoft.VisualBasic.Devices;
 
 namespace NETworkManager.ViewModels;
 

--- a/Source/NETworkManager/ViewModels/SNMPViewModel.cs
+++ b/Source/NETworkManager/ViewModels/SNMPViewModel.cs
@@ -22,6 +22,8 @@ using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using NETworkManager.Localization;
+using ControlzEx.Standard;
+using Microsoft.VisualBasic.Devices;
 
 namespace NETworkManager.ViewModels;
 
@@ -402,9 +404,11 @@ public class SNMPViewModel : ViewModelBase
         HostHistoryView = CollectionViewSource.GetDefaultView(SettingsManager.Current.SNMP_HostHistory);
         OidHistoryView = CollectionViewSource.GetDefaultView(SettingsManager.Current.SNMP_OidHistory);
 
-        // Result view
-        ResultsView = CollectionViewSource.GetDefaultView(QueryResults);
-        ResultsView.SortDescriptions.Add(new SortDescription(nameof(SNMPInfo.OID), ListSortDirection.Ascending));
+        //
+        StringComparer comparer = StringComparer.InvariantCultureIgnoreCase;
+        QueryResults = new ObservableCollection<SNMPInfo>(QueryResults.OrderBy(x => x.OID, comparer));
+        ResultsView = CollectionViewSource.GetDefaultView(QueryResults);     
+
 
         // OID
         Oid = sessionInfo?.OID;


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Usage of IPAddressComparer   by CollectionObservalbleCollection<>
- Remove Empty method such as LoadSettings()

Fixes #2569

**ToDo:**

- [ ] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Documentation) to reflect this changes
- [ ] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).