### PR TITLE
Feature: Improve sort of IP addresses and Data

### DIFF
--- a/Source/NETworkManager.Models/Network/ARPInfo.cs
+++ b/Source/NETworkManager.Models/Network/ARPInfo.cs
@@ -1,5 +1,4 @@
-﻿using NETworkManager.Utilities;
-using System.Net;
+﻿using System.Net;
 using System.Net.NetworkInformation;
 
 namespace NETworkManager.Models.Network;
@@ -23,24 +22,6 @@ public class ARPInfo
     /// Indicates if the ARP entry is a multicast address.
     /// </summary>
     public bool IsMulticast { get; set; }
-
-    /// <summary>
-    /// IP address as Int32.
-    /// </summary>
-    public int IPAddressInt32 => IPAddress.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork ? IPv4Address.ToInt32(IPAddress) : 0;
-    
-    /// <summary>
-    /// Physical address as string.
-    /// </summary>
-    public string MACAddressString => MACAddress.ToString().Replace("-","").Replace("-","");
-
-    /// <summary>
-    /// Creates a new instance of <see cref="ARPInfo"/>.
-    /// </summary>
-    public ARPInfo()
-    {
-
-    }
 
     /// <summary>
     /// Creates a new instance of <see cref="ARPInfo"/> with the given parameters.

--- a/Source/NETworkManager.Models/Network/ConnectionInfo.cs
+++ b/Source/NETworkManager.Models/Network/ConnectionInfo.cs
@@ -1,6 +1,5 @@
 ﻿using System.Net;
 using System.Net.NetworkInformation;
-using static NETworkManager.Models.Network.Connection;
 
 namespace NETworkManager.Models.Network;
 
@@ -12,9 +11,6 @@ public class ConnectionInfo
     public IPAddress RemoteIPAddress { get; set; }
     public int RemotePort { get; set; }
     public TcpState TcpState { get; set; }
-
-    public int LocalIPAddressInt32 => LocalIPAddress.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork ? IPv4Address.ToInt32(LocalIPAddress) : 0;
-    public int RemoteIPAddressInt32 => LocalIPAddress.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork ? IPv4Address.ToInt32(RemoteIPAddress) : 0;
     
     public ConnectionInfo()
     {

--- a/Source/NETworkManager.Models/Network/ListenerInfo.cs
+++ b/Source/NETworkManager.Models/Network/ListenerInfo.cs
@@ -2,23 +2,20 @@
 
 namespace NETworkManager.Models.Network;
 
-public class ListenerInfo
+public class ListenerInfo(TransportProtocol protocol, IPAddress ipAddress, int port)
 {
-    public TransportProtocol Protocol { get; set; }
-    public IPAddress IPAddress { get; set; }
-    public int Port { get; set; }
-
-    public int IPAddressInt32 => IPAddress.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork ? IPv4Address.ToInt32(IPAddress) : 0;
-
-    public ListenerInfo()
-    {
-
-    }
-
-    public ListenerInfo(TransportProtocol protocol, IPAddress ipAddress, int port)
-    {
-        Protocol = protocol;
-        IPAddress = ipAddress;
-        Port = port;
-    }
+    /// <summary>
+    /// Transport protocol of the listener.
+    /// </summary>
+    public TransportProtocol Protocol { get; set; } = protocol;
+    
+    /// <summary>
+    /// IP address of the listener.
+    /// </summary>
+    public IPAddress IPAddress { get; set; } = ipAddress;
+    
+    /// <summary>
+    /// Port of the listener.
+    /// </summary>
+    public int Port { get; set; } = port;
 }

--- a/Source/NETworkManager.Models/Network/PortScannerPortInfo.cs
+++ b/Source/NETworkManager.Models/Network/PortScannerPortInfo.cs
@@ -19,11 +19,6 @@ public class PortScannerPortInfo : PortInfo
     public string Hostname { get; set; }
     
     /// <summary>
-    /// IP address of the host as a integer.
-    /// </summary>
-    public int IPAddressInt32 => IPAddress is { AddressFamily: System.Net.Sockets.AddressFamily.InterNetwork } ? IPv4Address.ToInt32(IPAddress) : 0;
-
-    /// <summary>
     /// Hostname (if available) or IP address of the host.
     /// </summary>
     public string HostAsString => string.IsNullOrEmpty(Hostname) ? IPAddress.ToString() : Hostname;

--- a/Source/NETworkManager.Utilities/ByteHelper.cs
+++ b/Source/NETworkManager.Utilities/ByteHelper.cs
@@ -1,4 +1,6 @@
-﻿namespace NETworkManager.Utilities;
+﻿using System;
+
+namespace NETworkManager.Utilities;
 
 public static class ByteHelper
 {
@@ -10,10 +12,12 @@ public static class ByteHelper
     /// <returns>0 if the byte arrays are equal, otherwise a negative or positive value.</returns>
     public static int Compare(byte[] x, byte[] y)
     {
-        for (var i = 0; i < x.Length; i++)
+        for (var i = 0; i < Math.Min(x.Length, y.Length); i++)
+        {
             if (x[i] != y[i])
                 return x[i] - y[i];
-
-        return 0;
+        }
+        
+        return x.Length - y.Length;
     }
 }

--- a/Source/NETworkManager.Utilities/ByteHelper.cs
+++ b/Source/NETworkManager.Utilities/ByteHelper.cs
@@ -1,0 +1,19 @@
+﻿namespace NETworkManager.Utilities;
+
+public static class ByteHelper
+{
+    /// <summary>
+    /// Compare two byte arrays.
+    /// </summary>
+    /// <param name="x">Byte array to compare.</param>
+    /// <param name="y">Byte array to compare.</param>
+    /// <returns>0 if the byte arrays are equal, otherwise a negative or positive value.</returns>
+    public static int Compare(byte[] x, byte[] y)
+    {
+        for (var i = 0; i < x.Length; i++)
+            if (x[i] != y[i])
+                return x[i] - y[i];
+
+        return 0;
+    }
+}

--- a/Source/NETworkManager.Utilities/IPAddressComparer.cs
+++ b/Source/NETworkManager.Utilities/IPAddressComparer.cs
@@ -3,11 +3,20 @@ using System.Net;
 
 namespace NETworkManager.Utilities
 {
+    /// <summary>
+    /// IP address comparer.
+    /// </summary>
     public class IPAddressComparer : IComparer<IPAddress>
     {
-        public int Compare(IPAddress first, IPAddress second)
+        /// <summary>
+        /// Compare two IP addresses.
+        /// </summary>
+        /// <param name="x">First IP address.</param>
+        /// <param name="y">Second IP address.</param>
+        /// <returns>0 if the IP addresses are equal, otherwise a negative or positive value.</returns>
+        public int Compare(IPAddress x, IPAddress y)
         {
-            return IPAddressHelper.CompareIPAddresses(first, second);
+            return IPAddressHelper.CompareIPAddresses(x, y);
         }
     }
 }

--- a/Source/NETworkManager.Utilities/IPAddressComparer.cs
+++ b/Source/NETworkManager.Utilities/IPAddressComparer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Net;
 
 namespace NETworkManager.Utilities

--- a/Source/NETworkManager.Utilities/IPAddressComparer.cs
+++ b/Source/NETworkManager.Utilities/IPAddressComparer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using System.ComponentModel;
+﻿using System.Collections.Generic;
 using System.Net;
 
 namespace NETworkManager.Utilities

--- a/Source/NETworkManager.Utilities/IPAddressHelper.cs
+++ b/Source/NETworkManager.Utilities/IPAddressHelper.cs
@@ -31,18 +31,11 @@ public static class IPAddressHelper
     /// <summary>
     /// Compare two IP addresses.
     /// </summary>
-    /// <param name="first">First IP address.</param>
-    /// <param name="second">Second IP address.</param>
+    /// <param name="x">First IP address.</param>
+    /// <param name="y">Second IP address.</param>
     /// <returns>0 if the IP addresses are equal, otherwise a negative or positive value.</returns>
-    public static int CompareIPAddresses(IPAddress first, IPAddress second)
+    public static int CompareIPAddresses(IPAddress x, IPAddress y)
     {
-        var bytesFirst = first.GetAddressBytes();
-        var bytesSecond = second.GetAddressBytes();
-
-        for (var i = 0; i < bytesFirst.Length; i++)
-            if (bytesFirst[i] != bytesSecond[i])
-                return bytesFirst[i] - bytesSecond[i];
-
-        return 0; // IP addresses are equal
+        return ByteHelper.Compare(x.GetAddressBytes(), y.GetAddressBytes());
     }
 }

--- a/Source/NETworkManager.Utilities/IPAddressHelper.cs
+++ b/Source/NETworkManager.Utilities/IPAddressHelper.cs
@@ -36,10 +36,10 @@ public static class IPAddressHelper
     /// <returns>0 if the IP addresses are equal, otherwise a negative or positive value.</returns>
     public static int CompareIPAddresses(IPAddress first, IPAddress second)
     {
-        byte[] bytesFirst = first.GetAddressBytes();
-        byte[] bytesSecond = second.GetAddressBytes();
+        var bytesFirst = first.GetAddressBytes();
+        var bytesSecond = second.GetAddressBytes();
 
-        for (int i = 0; i < bytesFirst.Length; i++)
+        for (var i = 0; i < bytesFirst.Length; i++)
             if (bytesFirst[i] != bytesSecond[i])
                 return bytesFirst[i] - bytesSecond[i];
 

--- a/Source/NETworkManager.Utilities/MACAddressHelper.cs
+++ b/Source/NETworkManager.Utilities/MACAddressHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Net.NetworkInformation;
 using System.Text.RegularExpressions;
 
 namespace NETworkManager.Utilities;
@@ -63,5 +64,17 @@ public static class MACAddressHelper
             "." => string.Join(separator, Enumerable.Range(0, 3).Select(i => macAddress.Substring(i * 4, 4))),
             _ => macAddress
         };
+    }
+
+
+    /// <summary>
+    /// Compare two MAC-Addresses.
+    /// </summary>
+    /// <param name="x">First MAC-Address.</param>
+    /// <param name="y">Second MAC-Address.</param>
+    /// <returns>0 if the MAC-Addresses are equal, otherwise a negative or positive value.</returns>
+    public static int CompareMACAddresses(PhysicalAddress x, PhysicalAddress y)
+    {
+        return ByteHelper.Compare(x.GetAddressBytes(), y.GetAddressBytes());
     }
 }

--- a/Source/NETworkManager.Utilities/MACAddressHelper.cs
+++ b/Source/NETworkManager.Utilities/MACAddressHelper.cs
@@ -37,7 +37,6 @@ public static class MACAddressHelper
     /// <returns>MAC-Address in default format</returns>
     public static string GetDefaultFormat(string macAddress)
     {
-        Debug.WriteLine(Format(macAddress, ":"));
         return Format(macAddress, ":");
     }
 

--- a/Source/NETworkManager.Utilities/SNMPOIDHelper.cs
+++ b/Source/NETworkManager.Utilities/SNMPOIDHelper.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace NETworkManager.Utilities;
+
+public static class SNMPOIDHelper
+{
+    /// <summary>
+    /// Compare two OIDs.
+    /// </summary>
+    /// <param name="x">First OID</param>
+    /// <param name="y">Second OID</param>
+    /// <returns>0 if the OIDs are equal, otherwise a negative or positive value.</returns>
+    public static int CompareOIDs(string x, string y)
+    {
+        var xArray = Array.ConvertAll(x.Split('.'), int.Parse);
+        var yArray = Array.ConvertAll(y.Split('.'), int.Parse);
+        
+        // Compare each element of the OIDs and return the first non-equal element.
+        for (var i = 0; i < Math.Min(xArray.Length, yArray.Length); i++)
+        {
+            if(xArray[i] != yArray[i])
+                return xArray[i] - yArray[i];
+        }
+
+        // If the OIDs are equal up to this point, the shorter OID is smaller.
+        return xArray.Length - yArray.Length;
+    }
+}

--- a/Source/NETworkManager/App.xaml.cs
+++ b/Source/NETworkManager/App.xaml.cs
@@ -200,7 +200,7 @@ public partial class App
         else
         {
             // Bring the already running application into the foreground
-            Log.Info("Another NETworkManager process is already running. Try to bring the window to the foreground...");
+            Log.Info("Another NETworkManager process is already running. Trying to bring the window to the foreground...");
             SingleInstance.PostMessage((IntPtr)SingleInstance.HWND_BROADCAST, SingleInstance.WM_SHOWME, IntPtr.Zero, IntPtr.Zero);
 
             // Close the application                

--- a/Source/NETworkManager/MainWindow.xaml.cs
+++ b/Source/NETworkManager/MainWindow.xaml.cs
@@ -180,13 +180,9 @@ public sealed partial class MainWindow : INotifyPropertyChanged
             {
                 // Hide the old application view
                 if (_selectedApplication != null)
-                {
-                    Debug.WriteLine($"Hide application view: {_selectedApplication.Name}");
                     OnApplicationViewHide(_selectedApplication.Name);
-                }
 
                 // Show the new application view
-                Debug.WriteLine($"Show application view: {value.Name}");
                 OnApplicationViewVisible(value.Name);
 
                 // Store the last selected application name

--- a/Source/NETworkManager/ViewModels/ARPTableViewModel.cs
+++ b/Source/NETworkManager/ViewModels/ARPTableViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using NETworkManager.Models.Network;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Windows.Input;
 using System.ComponentModel;
 using System.Windows.Data;
@@ -193,7 +194,10 @@ public class ARPTableViewModel : ViewModelBase
 
         // Result view + search
         ResultsView = CollectionViewSource.GetDefaultView(Results);
-        ResultsView.SortDescriptions.Add(new SortDescription(nameof(ARPInfo.IPAddressInt32), ListSortDirection.Ascending));
+        
+        ((ListCollectionView)ResultsView).CustomSort = Comparer<ARPInfo>.Create((x, y) =>
+            IPAddressHelper.CompareIPAddresses(x.IPAddress, y.IPAddress));
+        
         ResultsView.Filter = o =>
         {
             if (o is not ARPInfo info)

--- a/Source/NETworkManager/ViewModels/AWSSessionManagerHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/AWSSessionManagerHostViewModel.cs
@@ -734,9 +734,7 @@ public class AWSSessionManagerHostViewModel : ViewModelBase, IProfileManager
 
     private void RemoveDynamicGroup(string profile, string region)
     {
-        string groupName = $"~ [{profile}\\{region}]";
-
-        //Debug.WriteLine("Remove dynamic group: " + groupName);
+        var groupName = $"~ [{profile}\\{region}]";
 
         var profilesChangedCurrentState = ProfileManager.ProfilesChanged;
         ProfileManager.ProfilesChanged = false;

--- a/Source/NETworkManager/ViewModels/ConnectionsViewModel.cs
+++ b/Source/NETworkManager/ViewModels/ConnectionsViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using NETworkManager.Models.Network;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Windows.Input;
 using System.ComponentModel;
 using System.Windows.Data;
@@ -195,7 +196,10 @@ public class ConnectionsViewModel : ViewModelBase
 
         // Result view + search
         ResultsView = CollectionViewSource.GetDefaultView(Results);
-        ResultsView.SortDescriptions.Add(new SortDescription(nameof(ConnectionInfo.LocalIPAddressInt32), ListSortDirection.Ascending));
+        
+        ((ListCollectionView)ResultsView).CustomSort = Comparer<ConnectionInfo>.Create((x, y) =>
+            IPAddressHelper.CompareIPAddresses(x.LocalIPAddress, y.LocalIPAddress));
+        
         ResultsView.Filter = o =>
         {
             if (o is not ConnectionInfo info)

--- a/Source/NETworkManager/ViewModels/DNSLookupViewModel.cs
+++ b/Source/NETworkManager/ViewModels/DNSLookupViewModel.cs
@@ -11,6 +11,7 @@ using System.ComponentModel;
 using System.Windows.Data;
 using NETworkManager.Utilities;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using NETworkManager.Controls;
 using Dragablz;
 using MahApps.Metro.Controls;
@@ -30,8 +31,6 @@ public class DNSLookupViewModel : ViewModelBase
 
     private readonly Guid _tabId;
     private bool _firstLoad = true;
-
-    private string _lastSortDescriptionAscending = string.Empty;
 
     private readonly bool _isLoading;
 
@@ -402,25 +401,6 @@ public class DNSLookupViewModel : ViewModelBase
         // Fill with the new items
         list.ForEach(x => SettingsManager.Current.DNSLookup_HostHistory.Add(x));
     }
-
-    public void SortResultByPropertyName(string sortDescription)
-    {
-        ResultsView.SortDescriptions.Clear();
-        ResultsView.SortDescriptions.Add(new SortDescription(nameof(DNSLookupRecordInfo.NameServerIPAddress),
-            ListSortDirection.Descending));
-
-        if (_lastSortDescriptionAscending.Equals(sortDescription))
-        {
-            ResultsView.SortDescriptions.Add(new SortDescription(sortDescription, ListSortDirection.Descending));
-            _lastSortDescriptionAscending = string.Empty;
-        }
-        else
-        {
-            ResultsView.SortDescriptions.Add(new SortDescription(sortDescription, ListSortDirection.Ascending));
-            _lastSortDescriptionAscending = sortDescription;
-        }
-    }
-
     #endregion
 
     #region Events

--- a/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
@@ -226,9 +226,11 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
         HostHistoryView = CollectionViewSource.GetDefaultView(SettingsManager.Current.IPScanner_HostHistory);
 
         // Result view
-        IPAddressComparer comparer = new();
-        Results = new ObservableCollection<IPScannerHostInfo>(Results.OrderBy(x => x.PingInfo.IPAddress, comparer));
         ResultsView = CollectionViewSource.GetDefaultView(Results);
+        
+        // Custom comparer to sort by IP address
+        ((ListCollectionView)ResultsView).CustomSort = Comparer<IPScannerHostInfo>.Create((x, y) =>
+            IPAddressHelper.CompareIPAddresses(x.PingInfo.IPAddress, y.PingInfo.IPAddress));
     }
 
     public void OnLoaded()

--- a/Source/NETworkManager/ViewModels/ListenersViewModel.cs
+++ b/Source/NETworkManager/ViewModels/ListenersViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using NETworkManager.Models.Network;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Windows.Input;
 using System.ComponentModel;
 using System.Windows.Data;
@@ -194,11 +195,12 @@ public class ListenersViewModel : ViewModelBase
 
         // Result view + search
         ResultsView = CollectionViewSource.GetDefaultView(Results);
-        ResultsView.SortDescriptions.Add(new SortDescription(nameof(ListenerInfo.Protocol), ListSortDirection.Ascending));
-        ResultsView.SortDescriptions.Add(new SortDescription(nameof(ListenerInfo.IPAddressInt32), ListSortDirection.Ascending));
+        
+        ((ListCollectionView)ResultsView).CustomSort = Comparer<ListenerInfo>.Create((x, y) =>
+            IPAddressHelper.CompareIPAddresses(x.IPAddress, y.IPAddress));
+        
         ResultsView.Filter = o =>
         {
-
             if (o is not ListenerInfo info)
                 return false;
 

--- a/Source/NETworkManager/ViewModels/LookupOUILookupViewModel.cs
+++ b/Source/NETworkManager/ViewModels/LookupOUILookupViewModel.cs
@@ -141,10 +141,12 @@ public class LookupOUILookupViewModel : ViewModelBase
     {
         _dialogCoordinator = instance;
 
-        // Set collection view
-        SearchHistoryView =
-            CollectionViewSource.GetDefaultView(SettingsManager.Current.Lookup_OUI_SearchHistory);
+        // Search history
+        SearchHistoryView = CollectionViewSource.GetDefaultView(SettingsManager.Current.Lookup_OUI_SearchHistory);
+        
+        // Result view
         ResultsView = CollectionViewSource.GetDefaultView(Results);
+        ResultsView.SortDescriptions.Add(new SortDescription(nameof(OUIInfo.MACAddress), ListSortDirection.Ascending));
     }
 
     #endregion

--- a/Source/NETworkManager/ViewModels/PortScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PortScannerViewModel.cs
@@ -449,23 +449,6 @@ public class PortScannerViewModel : ViewModelBase
         // Fill with the new items
         list.ForEach(x => SettingsManager.Current.PortScanner_PortHistory.Add(x));
     }
-
-    public void SortResultByPropertyName(string sortDescription)
-    {
-        ResultsView.SortDescriptions.Clear();
-        ResultsView.SortDescriptions.Add(new SortDescription(nameof(PortScannerPortInfo.IPAddressInt32), ListSortDirection.Descending));
-
-        if (_lastSortDescriptionAscending.Equals(sortDescription))
-        {
-            ResultsView.SortDescriptions.Add(new SortDescription(sortDescription, ListSortDirection.Descending));
-            _lastSortDescriptionAscending = string.Empty;
-        }
-        else
-        {
-            ResultsView.SortDescriptions.Add(new SortDescription(sortDescription, ListSortDirection.Ascending));
-            _lastSortDescriptionAscending = sortDescription;
-        }
-    }
     #endregion
 
     #region Events

--- a/Source/NETworkManager/ViewModels/PortScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PortScannerViewModel.cs
@@ -226,7 +226,6 @@ public class PortScannerViewModel : ViewModelBase
         // Result view
         ResultsView = CollectionViewSource.GetDefaultView(Results);
         ResultsView.GroupDescriptions.Add(new PropertyGroupDescription(nameof(PortScannerPortInfo.HostAsString)));
-        ResultsView.SortDescriptions.Add(new SortDescription(nameof(PortScannerPortInfo.IPAddressInt32), ListSortDirection.Descending));
 
         LoadSettings();
     }

--- a/Source/NETworkManager/ViewModels/SNMPViewModel.cs
+++ b/Source/NETworkManager/ViewModels/SNMPViewModel.cs
@@ -402,11 +402,12 @@ public class SNMPViewModel : ViewModelBase
         HostHistoryView = CollectionViewSource.GetDefaultView(SettingsManager.Current.SNMP_HostHistory);
         OidHistoryView = CollectionViewSource.GetDefaultView(SettingsManager.Current.SNMP_OidHistory);
 
-        //
-        StringComparer comparer = StringComparer.InvariantCultureIgnoreCase;
-        QueryResults = new ObservableCollection<SNMPInfo>(QueryResults.OrderBy(x => x.OID, comparer));
-        ResultsView = CollectionViewSource.GetDefaultView(QueryResults);     
-
+        // Result view
+        ResultsView = CollectionViewSource.GetDefaultView(QueryResults);
+        
+        // Custom comparer to sort by OID
+        ((ListCollectionView)ResultsView).CustomSort = Comparer<SNMPInfo>.Create((x, y) =>
+            SNMPOIDHelper.CompareOIDs(x.OID, y.OID));
 
         // OID
         Oid = sessionInfo?.OID;

--- a/Source/NETworkManager/ViewModels/SNMPViewModel.cs
+++ b/Source/NETworkManager/ViewModels/SNMPViewModel.cs
@@ -315,7 +315,7 @@ public class SNMPViewModel : ViewModelBase
         }
     }
 
-    private ObservableCollection<SNMPInfo> _queryResults = new();
+    private ObservableCollection<SNMPInfo> _queryResults = [];
     public ObservableCollection<SNMPInfo> QueryResults
     {
         get => _queryResults;

--- a/Source/NETworkManager/Views/ARPTableView.xaml
+++ b/Source/NETworkManager/Views/ARPTableView.xaml
@@ -37,7 +37,12 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <TextBox Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Right" Width="250" Text="{Binding Search, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource SearchTextBox}" />
-                <controls:MultiSelectDataGrid x:Name="DataGridArpTable" Grid.Row="2" ItemsSource="{Binding ResultsView}" SelectedItem="{Binding SelectedResult}" SelectedItemsList="{Binding SelectedResults, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                <controls:MultiSelectDataGrid x:Name="DataGridArpTable"
+                                             Grid.Column="0" Grid.Row="2" 
+                                             ItemsSource="{Binding ResultsView}"
+                                             SelectedItem="{Binding SelectedResult}" 
+                                             SelectedItemsList="{Binding SelectedResults, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             Sorting="DataGrid_OnSorting">
                     <controls:MultiSelectDataGrid.Resources>
                         <Style TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource DataGridScrollBar}" />
                         <ContextMenu x:Key="RowContextMenu" Opened="ContextMenu_Opened"  MinWidth="150">
@@ -98,9 +103,18 @@
                         </Style>
                     </controls:MultiSelectDataGrid.RowStyle>
                     <controls:MultiSelectDataGrid.Columns>
-                        <DataGridTextColumn Header="{x:Static localization:Strings.IPAddress}" Binding="{Binding (network:ARPInfo.IPAddress)}" SortMemberPath="IPAddressInt32" MinWidth="150" />
-                        <DataGridTextColumn Header="{x:Static localization:Strings.MACAddress}" Binding="{Binding (network:ARPInfo.MACAddress), Converter={StaticResource PhysicalAddressToStringConverter}}" SortMemberPath="MACAddressString" MinWidth="200" />
-                        <DataGridTextColumn Header="{x:Static localization:Strings.Multicast}" Binding="{Binding (network:ARPInfo.IsMulticast), Converter={StaticResource BooleanToStringConverter}}" SortMemberPath="IsMulticast" MinWidth="100" />
+                        <DataGridTextColumn Header="{x:Static localization:Strings.IPAddress}"
+                                            Binding="{Binding (network:ARPInfo.IPAddress)}" 
+                                            SortMemberPath="IPAddress" 
+                                            MinWidth="150" />
+                        <DataGridTextColumn Header="{x:Static localization:Strings.MACAddress}" 
+                                            Binding="{Binding (network:ARPInfo.MACAddress), Converter={StaticResource PhysicalAddressToStringConverter}}" 
+                                            SortMemberPath="MACAddress"
+                                            MinWidth="200" />
+                        <DataGridTextColumn Header="{x:Static localization:Strings.Multicast}"
+                                            Binding="{Binding (network:ARPInfo.IsMulticast), Converter={StaticResource BooleanToStringConverter}}"
+                                            SortMemberPath="IsMulticast"
+                                            MinWidth="100" />
                     </controls:MultiSelectDataGrid.Columns>
                 </controls:MultiSelectDataGrid>
                 <TextBlock Grid.Row="3" Foreground="{DynamicResource MahApps.Brushes.Accent}" Text="{Binding StatusMessage}" Visibility="{Binding IsStatusMessageDisplayed, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" Style="{DynamicResource StatusMessageTextBlock}" Margin="0,10,0,0" />

--- a/Source/NETworkManager/Views/ARPTableView.xaml.cs
+++ b/Source/NETworkManager/Views/ARPTableView.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Windows.Controls;
 using System.Windows.Data;
 using NETworkManager.ViewModels;

--- a/Source/NETworkManager/Views/ARPTableView.xaml.cs
+++ b/Source/NETworkManager/Views/ARPTableView.xaml.cs
@@ -1,6 +1,12 @@
-﻿using System.Windows.Controls;
+﻿using System.Collections;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Windows.Controls;
+using System.Windows.Data;
 using NETworkManager.ViewModels;
 using MahApps.Metro.Controls.Dialogs;
+using NETworkManager.Models.Network;
+using NETworkManager.Utilities;
 
 namespace NETworkManager.Views;
 
@@ -28,5 +34,69 @@ public partial class ARPTableView
     public void OnViewVisible()
     {
         _viewModel.OnViewVisible();
+    }
+
+    private void DataGrid_OnSorting(object sender, DataGridSortingEventArgs e)
+    {
+        var column = e.Column;
+
+        var selectedComparer = -1;
+
+        switch (column.SortMemberPath)
+        {
+            case nameof(ARPInfo.IPAddress):
+                selectedComparer = 0;
+                break;
+            case nameof(ARPInfo.MACAddress):
+                selectedComparer = 1;
+                break;
+            default:
+                return;
+        }
+        
+        // Prevent the built-in sort from sorting
+        e.Handled = true;
+
+        // Get the direction
+        var direction = column.SortDirection != ListSortDirection.Ascending
+            ? ListSortDirection.Ascending
+            : ListSortDirection.Descending;
+
+        // Update the sort direction
+        e.Column.SortDirection = direction;
+
+        // Get the view
+        var view = (ListCollectionView)CollectionViewSource.GetDefaultView(((DataGrid)sender).ItemsSource);
+
+        // Sort the view
+        view.CustomSort = new DataGridComparer(direction, selectedComparer);
+    }
+    
+    public class DataGridComparer(ListSortDirection direction, int comparer = -1) : IComparer
+    {
+        public int Compare(object x, object y)
+        {
+            // No comparer selected
+            if (comparer == -1)
+                return 0;
+
+            // Get data from objects
+            if (x is not ARPInfo first || y is not ARPInfo second)
+                return 0;
+
+            // Compare the data
+            return comparer switch
+            {
+                // IP address
+                0 => direction == ListSortDirection.Ascending
+                    ? IPAddressHelper.CompareIPAddresses(first.IPAddress, second.IPAddress)
+                    : IPAddressHelper.CompareIPAddresses(second.IPAddress, first.IPAddress),
+                // MAC address
+                1 => direction == ListSortDirection.Ascending
+                    ? MACAddressHelper.CompareMACAddresses(first.MACAddress, second.MACAddress)
+                    : MACAddressHelper.CompareMACAddresses(second.MACAddress, first.MACAddress),
+                _ => 0
+            };
+        }
     }
 }

--- a/Source/NETworkManager/Views/ConnectionsView.xaml
+++ b/Source/NETworkManager/Views/ConnectionsView.xaml
@@ -34,8 +34,17 @@
                     <RowDefinition Height="10" />
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                <TextBox x:Name="TextBoxSearch" Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Right" Width="250" Text="{Binding Search, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource SearchTextBox}" />
-                <controls:MultiSelectDataGrid x:Name="DataGridConnection" Grid.Row="2" ItemsSource="{Binding ResultsView}" SelectedItem="{Binding SelectedResult}" SelectedItemsList="{Binding SelectedResults, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                <TextBox Grid.Column="0" Grid.Row="0"
+                         VerticalAlignment="Center" 
+                         HorizontalAlignment="Right" 
+                         Width="250" 
+                         Text="{Binding Search, UpdateSourceTrigger=PropertyChanged}" 
+                         Style="{StaticResource SearchTextBox}" />
+                <controls:MultiSelectDataGrid Grid.Column="0" Grid.Row="2" 
+                                              ItemsSource="{Binding ResultsView}" 
+                                              SelectedItem="{Binding SelectedResult}"
+                                              SelectedItemsList="{Binding SelectedResults, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                              Sorting="DataGrid_OnSorting">
                     <DataGrid.Resources>
                         <Style TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource DataGridScrollBar}" />
                         <ContextMenu x:Key="RowContextMenu" Opened="ContextMenu_Opened"  MinWidth="150">
@@ -99,12 +108,24 @@
                         </Style>
                     </DataGrid.RowStyle>
                     <DataGrid.Columns>
-                        <DataGridTextColumn Header="{x:Static localization:Strings.Protocol}" Binding="{Binding (network:ConnectionInfo.Protocol)}" SortMemberPath="Protocol" MinWidth="100" />
-                        <DataGridTextColumn Header="{x:Static localization:Strings.LocalIPAddress}" Binding="{Binding (network:ConnectionInfo.LocalIPAddress)}" SortMemberPath="LocalIPAddressInt32" MinWidth="150" />
-                        <DataGridTextColumn Header="{x:Static localization:Strings.LocalPort}" Binding="{Binding (network:ConnectionInfo.LocalPort)}" SortMemberPath="LocalPort" MinWidth="100" />
-                        <DataGridTextColumn Header="{x:Static localization:Strings.RemoteIPAddress}" Binding="{Binding (network:ConnectionInfo.RemoteIPAddress)}" SortMemberPath="RemoteIPAddressInt32" MinWidth="150"/>
-                        <DataGridTextColumn Header="{x:Static localization:Strings.RemotePort}" Binding="{Binding (network:ConnectionInfo.RemotePort)}" SortMemberPath="RemotePort" MinWidth="100" />
-                        <DataGridTextColumn Header="{x:Static localization:Strings.State}" Binding="{Binding (network:ConnectionInfo.TcpState), Converter={StaticResource TcpStateToStringConverter}}" SortMemberPath="TcpState" MinWidth="150" />
+                        <DataGridTextColumn Header="{x:Static localization:Strings.Protocol}" 
+                                            Binding="{Binding (network:ConnectionInfo.Protocol)}" 
+                                            SortMemberPath="Protocol" MinWidth="100" />
+                        <DataGridTextColumn Header="{x:Static localization:Strings.LocalIPAddress}"
+                                            Binding="{Binding (network:ConnectionInfo.LocalIPAddress)}"
+                                            SortMemberPath="LocalIPAddress" MinWidth="150" />
+                        <DataGridTextColumn Header="{x:Static localization:Strings.LocalPort}" 
+                                            Binding="{Binding (network:ConnectionInfo.LocalPort)}"
+                                            SortMemberPath="LocalPort" MinWidth="100" />
+                        <DataGridTextColumn Header="{x:Static localization:Strings.RemoteIPAddress}"
+                                            Binding="{Binding (network:ConnectionInfo.RemoteIPAddress)}" 
+                                            SortMemberPath="RemoteIPAddress" MinWidth="150"/>
+                        <DataGridTextColumn Header="{x:Static localization:Strings.RemotePort}" 
+                                            Binding="{Binding (network:ConnectionInfo.RemotePort)}"
+                                            SortMemberPath="RemotePort" MinWidth="100" />
+                        <DataGridTextColumn Header="{x:Static localization:Strings.State}" 
+                                            Binding="{Binding (network:ConnectionInfo.TcpState), Converter={StaticResource TcpStateToStringConverter}}" 
+                                            SortMemberPath="TcpState" MinWidth="150" />
                     </DataGrid.Columns>
                 </controls:MultiSelectDataGrid>
                 <TextBlock Grid.Row="3" Foreground="{DynamicResource MahApps.Brushes.Accent}" Text="{Binding StatusMessage}" Visibility="{Binding IsStatusMessageDisplayed, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" Style="{DynamicResource StatusMessageTextBlock}" Margin="0,10,0,0" />

--- a/Source/NETworkManager/Views/ConnectionsView.xaml.cs
+++ b/Source/NETworkManager/Views/ConnectionsView.xaml.cs
@@ -1,6 +1,11 @@
-﻿using NETworkManager.ViewModels;
+﻿using System.Collections;
+using System.ComponentModel;
+using NETworkManager.ViewModels;
 using System.Windows.Controls;
+using System.Windows.Data;
 using MahApps.Metro.Controls.Dialogs;
+using NETworkManager.Models.Network;
+using NETworkManager.Utilities;
 
 namespace NETworkManager.Views;
 
@@ -28,5 +33,69 @@ public partial class ConnectionsView
     public void OnViewVisible()
     {
         _viewModel.OnViewVisible();
+    }
+
+    private void DataGrid_OnSorting(object sender, DataGridSortingEventArgs e)
+    {
+        var column = e.Column;
+
+        var selectedComparer = -1;
+
+        switch (column.SortMemberPath)
+        {
+            case nameof(ConnectionInfo.LocalIPAddress):
+                selectedComparer = 0;
+                break;
+            case nameof(ConnectionInfo.RemoteIPAddress):
+                selectedComparer = 1;
+                break;
+            default:
+                return;
+        }
+
+        // Prevent the built-in sort from sorting
+        e.Handled = true;
+
+        // Get the direction
+        var direction = column.SortDirection != ListSortDirection.Ascending
+            ? ListSortDirection.Ascending
+            : ListSortDirection.Descending;
+
+        // Update the sort direction
+        e.Column.SortDirection = direction;
+
+        // Get the view
+        var view = (ListCollectionView)CollectionViewSource.GetDefaultView(((DataGrid)sender).ItemsSource);
+
+        // Sort the view
+        view.CustomSort = new DataGridComparer(direction, selectedComparer);
+    }
+    
+    public class DataGridComparer(ListSortDirection direction, int comparer = -1) : IComparer
+    {
+        public int Compare(object x, object y)
+        {
+            // No comparer selected
+            if (comparer == -1)
+                return 0;
+
+            // Get data from objects
+            if (x is not ConnectionInfo first || y is not ConnectionInfo second)
+                return 0;
+
+            // Compare the data
+            return comparer switch
+            {
+                // Local IP address
+                0 => direction == ListSortDirection.Ascending
+                    ? IPAddressHelper.CompareIPAddresses(first.LocalIPAddress, second.LocalIPAddress)
+                    : IPAddressHelper.CompareIPAddresses(second.LocalIPAddress, first.LocalIPAddress),
+                // Remote IP address
+                1 => direction == ListSortDirection.Ascending
+                    ? IPAddressHelper.CompareIPAddresses(first.RemoteIPAddress, second.RemoteIPAddress)
+                    : IPAddressHelper.CompareIPAddresses(second.RemoteIPAddress, first.RemoteIPAddress),
+                _ => 0
+            };
+        }
     }
 }

--- a/Source/NETworkManager/Views/DNSLookupView.xaml
+++ b/Source/NETworkManager/Views/DNSLookupView.xaml
@@ -131,11 +131,7 @@
             <TextBlock Grid.Row="2" Foreground="{DynamicResource MahApps.Brushes.Accent}" Text="{Binding StatusMessage}" Visibility="{Binding IsStatusMessageDisplayed, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" Style="{DynamicResource StatusMessageTextBlock}" Margin="0,10,0,0" />
         </Grid>
         <TextBlock Grid.Row="2" Text="{x:Static localization:Strings.Result}" Style="{StaticResource HeaderTextBlock}" />
-        <!-- 
-        The sort function is in the code behind -> when you click on the header of the column, the SortMemberPath is passed to the viewmodel
-        CanUserSortColumns="False" -> Default sort won't work with grouped
-        -->
-        <controls:MultiSelectDataGrid Grid.Row="3" CanUserSortColumns="False" ItemsSource="{Binding ResultsView}" SelectedItem="{Binding SelectedResult}" SelectedItemsList="{Binding SelectedResults, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+        <controls:MultiSelectDataGrid Grid.Row="3" ItemsSource="{Binding ResultsView}" SelectedItem="{Binding SelectedResult}" SelectedItemsList="{Binding SelectedResults, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
             <controls:MultiSelectDataGrid.Resources>
                 <Style TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource DataGridScrollBar}" />
                 <ContextMenu x:Key="RowContextMenu" Opened="ContextMenu_Opened" MinWidth="150">
@@ -182,10 +178,7 @@
                             </Rectangle>
                         </MenuItem.Icon>
                     </MenuItem>
-                </ContextMenu>
-                <Style TargetType="DataGridColumnHeader" BasedOn="{StaticResource DefaultDataGridColumnHeader}">
-                    <EventSetter Event="Click" Handler="ColumnHeader_Click" />
-                </Style>
+                </ContextMenu>                
             </controls:MultiSelectDataGrid.Resources>
             <controls:MultiSelectDataGrid.RowStyle>
                 <Style TargetType="{x:Type DataGridRow}" BasedOn="{StaticResource MahApps.Styles.DataGridRow}">
@@ -221,24 +214,24 @@
             </controls:MultiSelectDataGrid.GroupStyle>
             <controls:MultiSelectDataGrid.Columns>
                 <DataGridTextColumn Header="{x:Static localization:Strings.DomainName}" 
-                                    Binding="{Binding (network:DNSLookupRecordInfo.DomainName)}"
-                                    SortMemberPath="DomainName" 
+                                    Binding="{Binding Path=(network:DNSLookupRecordInfo.DomainName)}"
+                                    SortMemberPath="DomainName"
                                     MinWidth="200" />
                 <DataGridTextColumn Header="{x:Static localization:Strings.TTL}"
-                                    Binding="{Binding (network:DNSLookupRecordInfo.TTL)}" 
-                                    SortMemberPath="TTL" 
+                                    Binding="{Binding Path=(network:DNSLookupRecordInfo.TTL)}"
+                                    SortMemberPath="TTL"
                                     MinWidth="80" />
                 <DataGridTextColumn Header="{x:Static localization:Strings.Class}" 
-                                    Binding="{Binding (network:DNSLookupRecordInfo.RecordClass)}"
-                                    SortMemberPath="Class" 
+                                    Binding="{Binding Path=(network:DNSLookupRecordInfo.RecordClass)}"
+                                    SortMemberPath="RecordClass"
                                     MinWidth="80" />
                 <DataGridTextColumn Header="{x:Static localization:Strings.Type}" 
-                                    Binding="{Binding (network:DNSLookupRecordInfo.RecordType)}" 
-                                    SortMemberPath="Type"
+                                    Binding="{Binding Path=(network:DNSLookupRecordInfo.RecordType)}"
+                                    SortMemberPath="RecordType"
                                     MinWidth="80" />
                 <DataGridTextColumn Header="{x:Static localization:Strings.Result}" 
-                                    Binding="{Binding (network:DNSLookupRecordInfo.Result)}" 
-                                    SortMemberPath="Result" 
+                                    Binding="{Binding Path=(network:DNSLookupRecordInfo.Result)}"
+                                    SortMemberPath="Result"
                                     MinWidth="200" />
             </controls:MultiSelectDataGrid.Columns>
         </controls:MultiSelectDataGrid>

--- a/Source/NETworkManager/Views/DNSLookupView.xaml.cs
+++ b/Source/NETworkManager/Views/DNSLookupView.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
 using MahApps.Metro.Controls.Dialogs;
 using NETworkManager.ViewModels;
 
@@ -34,11 +33,5 @@ public partial class DNSLookupView
     {
         if (sender is ContextMenu menu)
             menu.DataContext = _viewModel;
-    }
-
-    private void ColumnHeader_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is DataGridColumnHeader columnHeader)
-            _viewModel.SortResultByPropertyName(columnHeader.Column.SortMemberPath);
     }
 }

--- a/Source/NETworkManager/Views/IPScannerView.xaml
+++ b/Source/NETworkManager/Views/IPScannerView.xaml
@@ -200,13 +200,21 @@
                     </TextBlock.Text>
                 </TextBlock>
             </StackPanel>
-            <TextBlock Grid.Row="2" Foreground="{DynamicResource MahApps.Brushes.Accent}" Text="{Binding StatusMessage}" Visibility="{Binding IsStatusMessageDisplayed, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" Style="{DynamicResource StatusMessageTextBlock}" Margin="0,10,0,0" />
+            <TextBlock Grid.Column="0" Grid.Row="2" 
+                       Foreground="{DynamicResource MahApps.Brushes.Accent}" 
+                       Text="{Binding StatusMessage}" 
+                       Visibility="{Binding IsStatusMessageDisplayed, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" 
+                       Style="{DynamicResource StatusMessageTextBlock}" 
+                       Margin="0,10,0,0" />
         </Grid>
-        <TextBlock Grid.Row="2" Style="{StaticResource HeaderTextBlock}" Text="{x:Static localization:Strings.Result}" />
-        <controls:MultiSelectDataGrid Grid.Row="3" 
+        <TextBlock Grid.Column="0" Grid.Row="2"
+                   Style="{StaticResource HeaderTextBlock}"
+                   Text="{x:Static localization:Strings.Result}" />
+        <controls:MultiSelectDataGrid Grid.Column="0" Grid.Row="3"
                                       ItemsSource="{Binding Path=ResultsView}" 
                                       SelectedItem="{Binding Path=SelectedResult}" 
                                       SelectedItemsList="{Binding Path=SelectedResults, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                      Sorting="DataGrid_OnSorting"
                                       RowDetailsVisibilityMode="Collapsed"
                                       EnableRowVirtualization="True"
                                       ScrollViewer.CanContentScroll="True"
@@ -467,7 +475,7 @@
                 </DataGridTemplateColumn>
                 <DataGridTextColumn Header="{x:Static localization:Strings.IPAddress}" 
                                     Binding="{Binding (network:IPScannerHostInfo.PingInfo).IPAddress}" 
-                                    SortMemberPath="PingInfo.IPAddressInt32" 
+                                    SortMemberPath="PingInfo.IPAddress"
                                     MinWidth="150" />
                 <DataGridTextColumn Header="{x:Static localization:Strings.Hostname}"
                                     Binding="{Binding (network:IPScannerHostInfo.Hostname)}" 
@@ -481,10 +489,11 @@
                                     MinWidth="150" />
                 <DataGridTextColumn Header="{x:Static localization:Strings.PingStatus}"
                                     Binding="{Binding (network:IPScannerHostInfo.PingInfo).Status, Converter={StaticResource IPStatusToStringConverter}}"
+                                    SortMemberPath="PingInfo.Status"
                                     MinWidth="150" />
                 <DataGridTextColumn Header="{x:Static localization:Strings.MACAddress}" 
                                     Binding="{Binding (network:IPScannerHostInfo.MACAddress), Converter={StaticResource PhysicalAddressToStringConverter}}" 
-                                    SortMemberPath="MACAddressString"
+                                    SortMemberPath="MACAddress"
                                     Visibility="{Binding Source={x:Static Member=settings:SettingsManager.Current}, Path=IPScanner_ResolveMACAddress, Converter={StaticResource ResourceKey=BooleanToVisibilityCollapsedConverter}}" 
                                     MinWidth="150" />
                 <DataGridTextColumn Header="{x:Static localization:Strings.Vendor}"

--- a/Source/NETworkManager/Views/IPScannerView.xaml.cs
+++ b/Source/NETworkManager/Views/IPScannerView.xaml.cs
@@ -141,14 +141,14 @@ public partial class IPScannerView
 
     public class DataGridComparer(ListSortDirection direction, int comparer = -1) : IComparer
     {
-        public int Compare(object first, object second)
+        public int Compare(object x, object y)
         {
             // No comparer selected
             if (comparer == -1)
                 return 0;
 
             // Get data from objects
-            if (first is not IPScannerHostInfo firstInfo || second is not IPScannerHostInfo secondInfo)
+            if (x is not IPScannerHostInfo first || y is not IPScannerHostInfo second)
                 return 0;
 
             // Compare the data
@@ -156,12 +156,12 @@ public partial class IPScannerView
             {
                 // IP address
                 0 => direction == ListSortDirection.Ascending
-                    ? IPAddressHelper.CompareIPAddresses(firstInfo.PingInfo.IPAddress, secondInfo.PingInfo.IPAddress)
-                    : IPAddressHelper.CompareIPAddresses(secondInfo.PingInfo.IPAddress, firstInfo.PingInfo.IPAddress),
+                    ? IPAddressHelper.CompareIPAddresses(first.PingInfo.IPAddress, second.PingInfo.IPAddress)
+                    : IPAddressHelper.CompareIPAddresses(second.PingInfo.IPAddress, first.PingInfo.IPAddress),
                 // MAC address
                 1 => direction == ListSortDirection.Ascending
-                    ? MACAddressHelper.CompareMACAddresses(firstInfo.MACAddress, secondInfo.MACAddress)
-                    : MACAddressHelper.CompareMACAddresses(secondInfo.MACAddress, firstInfo.MACAddress),
+                    ? MACAddressHelper.CompareMACAddresses(first.MACAddress, second.MACAddress)
+                    : MACAddressHelper.CompareMACAddresses(second.MACAddress, first.MACAddress),
                 _ => 0
             };
         }

--- a/Source/NETworkManager/Views/IPScannerView.xaml.cs
+++ b/Source/NETworkManager/Views/IPScannerView.xaml.cs
@@ -1,9 +1,16 @@
 ﻿using System;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Windows;
 using NETworkManager.ViewModels;
 using MahApps.Metro.Controls.Dialogs;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Media;
+using NETworkManager.Models.Network;
+using NETworkManager.Utilities;
+using VisualTreeHelper = System.Windows.Media.VisualTreeHelper;
+using System.Collections;
 
 namespace NETworkManager.Views;
 
@@ -39,9 +46,9 @@ public partial class IPScannerView
 
     private void ContextMenu_Opened(object sender, RoutedEventArgs e)
     {
-        if (sender is not ContextMenu menu) 
+        if (sender is not ContextMenu menu)
             return;
-        
+
         // Set DataContext to ViewModel
         menu.DataContext = _viewModel;
 
@@ -52,9 +59,9 @@ public partial class IPScannerView
 
         for (var i = 0; i < menu.Items.Count; i++)
         {
-            if (menu.Items[i] is not MenuItem item) 
+            if (menu.Items[i] is not MenuItem item)
                 continue;
-                
+
             if ((string)item.Tag != "CustomCommands")
                 continue;
 
@@ -90,10 +97,77 @@ public partial class IPScannerView
         {
             if (visual is not DataGridRow row)
                 continue;
-            
+
             row.DetailsVisibility = row.DetailsVisibility == Visibility.Visible ? Visibility.Collapsed : Visibility.Visible;
-            
+
             break;
+        }
+    }
+
+    private void DataGrid_OnSorting(object sender, DataGridSortingEventArgs e)
+    {
+        var column = e.Column;
+
+        var selectedComparer = -1;
+
+        switch (column.SortMemberPath)
+        {
+            case $"{nameof(PingInfo)}.{nameof(PingInfo.IPAddress)}":
+                selectedComparer = 0;
+                break;
+            case nameof(IPScannerHostInfo.MACAddress):
+                selectedComparer = 1;
+                break;
+            default:
+                return;
+        }
+
+        // Prevent the built-in sort from sorting
+        e.Handled = true;
+
+        // Get the direction
+        var direction = column.SortDirection != ListSortDirection.Ascending
+            ? ListSortDirection.Ascending
+            : ListSortDirection.Descending;
+
+        // Update the sort direction
+        e.Column.SortDirection = direction;
+
+        // Get the view
+        var view = (ListCollectionView)CollectionViewSource.GetDefaultView(((DataGrid)sender).ItemsSource);
+
+        // Sort the view
+        view.CustomSort = new DataGridComparer(direction, selectedComparer);
+    }
+
+    public class DataGridComparer(ListSortDirection direction, int comparer = -1) : IComparer
+    {
+        public int Compare(object first, object second)
+        {
+            // No comparer selected
+            if (comparer == -1)
+                return 0;
+
+            // Get data from objects
+            if (first is not IPScannerHostInfo firstInfo || second is not IPScannerHostInfo secondInfo)
+                return 0;
+
+            switch (comparer)
+            {
+                // IP address
+                case 0:
+                    return direction == ListSortDirection.Ascending ?
+                IPAddressHelper.CompareIPAddresses(firstInfo.PingInfo.IPAddress, secondInfo.PingInfo.IPAddress) :
+                IPAddressHelper.CompareIPAddresses(secondInfo.PingInfo.IPAddress, firstInfo.PingInfo.IPAddress);
+
+                // MAC address
+                case 1:
+
+                    return 0;
+
+                default:
+                    return 0;
+            }
         }
     }
 }

--- a/Source/NETworkManager/Views/IPScannerView.xaml.cs
+++ b/Source/NETworkManager/Views/IPScannerView.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Windows;
 using NETworkManager.ViewModels;
 using MahApps.Metro.Controls.Dialogs;
@@ -152,22 +151,19 @@ public partial class IPScannerView
             if (first is not IPScannerHostInfo firstInfo || second is not IPScannerHostInfo secondInfo)
                 return 0;
 
-            switch (comparer)
+            // Compare the data
+            return comparer switch
             {
                 // IP address
-                case 0:
-                    return direction == ListSortDirection.Ascending ?
-                IPAddressHelper.CompareIPAddresses(firstInfo.PingInfo.IPAddress, secondInfo.PingInfo.IPAddress) :
-                IPAddressHelper.CompareIPAddresses(secondInfo.PingInfo.IPAddress, firstInfo.PingInfo.IPAddress);
-
+                0 => direction == ListSortDirection.Ascending
+                    ? IPAddressHelper.CompareIPAddresses(firstInfo.PingInfo.IPAddress, secondInfo.PingInfo.IPAddress)
+                    : IPAddressHelper.CompareIPAddresses(secondInfo.PingInfo.IPAddress, firstInfo.PingInfo.IPAddress),
                 // MAC address
-                case 1:
-
-                    return 0;
-
-                default:
-                    return 0;
-            }
+                1 => direction == ListSortDirection.Ascending
+                    ? MACAddressHelper.CompareMACAddresses(firstInfo.MACAddress, secondInfo.MACAddress)
+                    : MACAddressHelper.CompareMACAddresses(secondInfo.MACAddress, firstInfo.MACAddress),
+                _ => 0
+            };
         }
     }
 }

--- a/Source/NETworkManager/Views/ListenersView.xaml
+++ b/Source/NETworkManager/Views/ListenersView.xaml
@@ -33,8 +33,17 @@
                     <RowDefinition Height="10" />
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                <TextBox x:Name="TextBoxSearch" Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Right" Width="250" Text="{Binding Search, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource SearchTextBox}" />
-                <controls:MultiSelectDataGrid x:Name="DataGridConnection" Grid.Row="2" ItemsSource="{Binding ResultsView}" SelectedItem="{Binding SelectedResult}" SelectedItemsList="{Binding SelectedResults, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                <TextBox Grid.Column="0" Grid.Row="0" 
+                         VerticalAlignment="Center" 
+                         HorizontalAlignment="Right" 
+                         Width="250" 
+                         Text="{Binding Search, UpdateSourceTrigger=PropertyChanged}" 
+                         Style="{StaticResource SearchTextBox}" />
+                <controls:MultiSelectDataGrid Grid.Column="0" Grid.Row="2"
+                                              ItemsSource="{Binding ResultsView}" 
+                                              SelectedItem="{Binding SelectedResult}"
+                                              SelectedItemsList="{Binding SelectedResults, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                              Sorting="DataGrid_OnSorting">
                     <controls:MultiSelectDataGrid.Resources>
                         <Style TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource DataGridScrollBar}" />
                         <ContextMenu x:Key="RowContextMenu" Opened="ContextMenu_Opened"  MinWidth="150">
@@ -86,9 +95,15 @@
                         </Style>
                     </controls:MultiSelectDataGrid.RowStyle>
                     <controls:MultiSelectDataGrid.Columns>
-                        <DataGridTextColumn Header="{x:Static localization:Strings.Protocol}" Binding="{Binding (network:ListenerInfo.Protocol)}" SortMemberPath="Protocol" MinWidth="100" />
-                        <DataGridTextColumn Header="{x:Static localization:Strings.IPAddress}" Binding="{Binding (network:ListenerInfo.IPAddress)}" SortMemberPath="IPAddressInt32" MinWidth="150" />
-                        <DataGridTextColumn Header="{x:Static localization:Strings.Port}" Binding="{Binding (network:ListenerInfo.Port)}" SortMemberPath="Port" MinWidth="100" />
+                        <DataGridTextColumn Header="{x:Static localization:Strings.Protocol}" 
+                                            Binding="{Binding (network:ListenerInfo.Protocol)}" 
+                                            SortMemberPath="Protocol" MinWidth="100" />
+                        <DataGridTextColumn Header="{x:Static localization:Strings.IPAddress}" 
+                                            Binding="{Binding (network:ListenerInfo.IPAddress)}" 
+                                            SortMemberPath="IPAddress" MinWidth="150" />
+                        <DataGridTextColumn Header="{x:Static localization:Strings.Port}" 
+                                            Binding="{Binding (network:ListenerInfo.Port)}" 
+                                            SortMemberPath="Port" MinWidth="100" />
                     </controls:MultiSelectDataGrid.Columns>
                 </controls:MultiSelectDataGrid>
                 <TextBlock Grid.Row="3" Foreground="{DynamicResource MahApps.Brushes.Accent}" Text="{Binding StatusMessage}" Visibility="{Binding IsStatusMessageDisplayed, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" Style="{DynamicResource StatusMessageTextBlock}" Margin="0,10,0,0" />

--- a/Source/NETworkManager/Views/ListenersView.xaml.cs
+++ b/Source/NETworkManager/Views/ListenersView.xaml.cs
@@ -1,6 +1,11 @@
-﻿using NETworkManager.ViewModels;
+﻿using System.Collections;
+using System.ComponentModel;
+using NETworkManager.ViewModels;
 using System.Windows.Controls;
+using System.Windows.Data;
 using MahApps.Metro.Controls.Dialogs;
+using NETworkManager.Models.Network;
+using NETworkManager.Utilities;
 
 namespace NETworkManager.Views;
 
@@ -28,5 +33,45 @@ public partial class ListenersView
     public void OnViewVisible()
     {
          _viewModel.OnViewVisible();
+    }
+
+    private void DataGrid_OnSorting(object sender, DataGridSortingEventArgs e)
+    {
+        var column = e.Column;
+     
+        if(column.SortMemberPath != nameof(ListenerInfo.IPAddress))
+            return;
+        
+        // Prevent the built-in sort from sorting
+        e.Handled = true;
+        
+        // Get the direction
+        var direction = column.SortDirection == ListSortDirection.Ascending
+            ? ListSortDirection.Descending
+            : ListSortDirection.Ascending;
+        
+        // Update the sort direction
+        column.SortDirection = direction;
+        
+        // Get the view
+        var view = (ListCollectionView)CollectionViewSource.GetDefaultView(((DataGrid)sender).ItemsSource);
+
+        // Sort the view
+        view.CustomSort = new DataGridComparer(direction);
+    }
+    
+    public class DataGridComparer(ListSortDirection direction) : IComparer
+    {
+        public int Compare(object x, object y)
+        {
+            // Get data from objects
+            if(x is not ListenerInfo first || y is not ListenerInfo second)
+                return 0;
+            
+            // Compare the data
+            return direction == ListSortDirection.Ascending
+                ? IPAddressHelper.CompareIPAddresses(first.IPAddress, second.IPAddress)
+                : IPAddressHelper.CompareIPAddresses(second.IPAddress, first.IPAddress);
+        }
     }
 }

--- a/Source/NETworkManager/Views/LookupOUILookupView.xaml
+++ b/Source/NETworkManager/Views/LookupOUILookupView.xaml
@@ -158,11 +158,13 @@
             </controls:MultiSelectDataGrid.RowStyle>
             <controls:MultiSelectDataGrid.Columns>
                 <DataGridTextColumn Header="{x:Static localization:Strings.MACAddress}"
-                                    Binding="{Binding (lookup:OUIInfo.MACAddress)}" SortMemberPath="MACAddressString"
+                                    Binding="{Binding (lookup:OUIInfo.MACAddress)}"
+                                    SortMemberPath="MACAddress"
                                     MinWidth="150" />
                 <DataGridTextColumn Header="{x:Static localization:Strings.Vendor}"
                                     Binding="{Binding (lookup:OUIInfo.Vendor), Converter={StaticResource StringNullOrEmptyToStringConverter}}"
-                                    SortMemberPath="Vendor" MinWidth="200" />
+                                    SortMemberPath="Vendor"
+                                    MinWidth="200" />
             </controls:MultiSelectDataGrid.Columns>
         </controls:MultiSelectDataGrid>
     </Grid>

--- a/Source/NETworkManager/Views/PortProfilesDialog.xaml
+++ b/Source/NETworkManager/Views/PortProfilesDialog.xaml
@@ -16,27 +16,38 @@
             <RowDefinition Height="10" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <TextBox x:Name="TextBoxSearch" Grid.Column="0" VerticalAlignment="Center" Text="{Binding Search, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource SearchTextBox}" />
-        <Grid Grid.Row="2">
-            <controls:MultiSelectDataGrid x:Name="DataGridPortProfiles" ItemsSource="{Binding PortProfiles}" SelectedItemsList="{Binding SelectedPortProfiles, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+        <TextBox x:Name="TextBoxSearch" 
+                 Grid.Column="0" Grid.Row="0"
+                 VerticalAlignment="Center" Text="{Binding Path=Search, UpdateSourceTrigger=PropertyChanged}" 
+                 Style="{StaticResource ResourceKey=SearchTextBox}" />
+        <Grid Grid.Column="0" Grid.Row="2">
+            <controls:MultiSelectDataGrid x:Name="DataGridPortProfiles"
+                                          ItemsSource="{Binding Path=PortProfiles}"
+                                          SelectedItemsList="{Binding Path=SelectedPortProfiles, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                 <controls:MultiSelectDataGrid.Columns>
-                    <DataGridTextColumn Header="{x:Static localization:Strings.Name}" Binding="{Binding (network:PortProfileInfo.Name)}" Width="1*" />
-                    <DataGridTextColumn Header="{x:Static localization:Strings.Ports}" Binding="{Binding (network:PortProfileInfo.Ports)}" Width="2*" />
+                    <DataGridTextColumn Header="{x:Static Member=localization:Strings.Name}" 
+                                        Binding="{Binding Path=(network:PortProfileInfo.Name)}"
+                                        SortMemberPath="Name"
+                                        Width="1*" />
+                    <DataGridTextColumn Header="{x:Static Member=localization:Strings.Ports}" 
+                                        Binding="{Binding Path=(network:PortProfileInfo.Ports)}"
+                                        SortMemberPath="Ports"
+                                        Width="2*" />
                 </controls:MultiSelectDataGrid.Columns>
                 <controls:MultiSelectDataGrid.InputBindings>
-                    <KeyBinding Command="{Binding OKCommand}" Key="Return" />
+                    <KeyBinding Command="{Binding Path=OKCommand}" Key="Return" />
                 </controls:MultiSelectDataGrid.InputBindings>
                 <controls:MultiSelectDataGrid.RowStyle>
-                    <Style TargetType="{x:Type DataGridRow}" BasedOn="{StaticResource MahApps.Styles.DataGridRow}">
+                    <Style TargetType="{x:Type TypeName=DataGridRow}" BasedOn="{StaticResource ResourceKey=MahApps.Styles.DataGridRow}">
                         <EventSetter Event="MouseDoubleClick" Handler="DataGridRow_MouseDoubleClick" />
                     </Style>
                 </controls:MultiSelectDataGrid.RowStyle>
             </controls:MultiSelectDataGrid>
         </Grid>
         <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Content="{x:Static localization:Strings.OK}" Command="{Binding OKCommand}" IsDefault="True" Margin="0,0,10,0">
+            <Button Content="{x:Static Member=localization:Strings.OK}" Command="{Binding Path=OKCommand}" IsDefault="True" Margin="0,0,10,0">
                 <Button.Style>
-                    <Style TargetType="{x:Type Button}" BasedOn="{StaticResource HighlightedButton}">
+                    <Style TargetType="{x:Type TypeName=Button}" BasedOn="{StaticResource ResourceKey=HighlightedButton}">
                         <Setter Property="IsEnabled" Value="True" />
                         <Style.Triggers>
                             <MultiDataTrigger>
@@ -51,7 +62,7 @@
                     </Style>
                 </Button.Style>
             </Button>
-            <Button Content="{x:Static localization:Strings.Cancel}" Command="{Binding CancelCommand}" IsCancel="True" Style="{StaticResource DefaultButton}" />
+            <Button Content="{x:Static Member=localization:Strings.Cancel}" Command="{Binding Path=CancelCommand}" IsCancel="True" Style="{StaticResource ResourceKey=DefaultButton}" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Source/NETworkManager/Views/PortProfilesDialog.xaml
+++ b/Source/NETworkManager/Views/PortProfilesDialog.xaml
@@ -1,35 +1,39 @@
 ﻿<UserControl x:Class="NETworkManager.Views.PortProfilesDialog"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"            
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:network="clr-namespace:NETworkManager.Models.Network;assembly=NETworkManager.Models"
              xmlns:viewModels="clr-namespace:NETworkManager.ViewModels"
              xmlns:controls="clr-namespace:NETworkManager.Controls;assembly=NETworkManager.Controls"
              xmlns:localization="clr-namespace:NETworkManager.Localization.Resources;assembly=NETworkManager.Localization"
-             mc:Ignorable="d" Loaded="UserControl_Loaded" d:DataContext="{d:DesignInstance viewModels:PortProfilesViewModel}">
+             mc:Ignorable="d" Loaded="UserControl_Loaded"
+             d:DataContext="{d:DesignInstance viewModels:PortProfilesViewModel}">
     <Grid Margin="0,20">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="10" />
-            <RowDefinition MinHeight="150" Height="*" />
+            <RowDefinition Height="300" />
             <RowDefinition Height="10" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <TextBox x:Name="TextBoxSearch" 
+        <TextBox x:Name="TextBoxSearch"
                  Grid.Column="0" Grid.Row="0"
-                 VerticalAlignment="Center" Text="{Binding Path=Search, UpdateSourceTrigger=PropertyChanged}" 
+                 VerticalAlignment="Center" Text="{Binding Path=Search, UpdateSourceTrigger=PropertyChanged}"
                  Style="{StaticResource ResourceKey=SearchTextBox}" />
         <Grid Grid.Column="0" Grid.Row="2">
-            <controls:MultiSelectDataGrid x:Name="DataGridPortProfiles"
+            <controls:MultiSelectDataGrid x:Name="DataGridProfiles"
                                           ItemsSource="{Binding Path=PortProfiles}"
                                           SelectedItemsList="{Binding Path=SelectedPortProfiles, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                <controls:MultiSelectDataGrid.Resources>
+                    <Style TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource DataGridScrollBar}" />
+                </controls:MultiSelectDataGrid.Resources>
                 <controls:MultiSelectDataGrid.Columns>
-                    <DataGridTextColumn Header="{x:Static Member=localization:Strings.Name}" 
+                    <DataGridTextColumn Header="{x:Static Member=localization:Strings.Name}"
                                         Binding="{Binding Path=(network:PortProfileInfo.Name)}"
                                         SortMemberPath="Name"
                                         Width="1*" />
-                    <DataGridTextColumn Header="{x:Static Member=localization:Strings.Ports}" 
+                    <DataGridTextColumn Header="{x:Static Member=localization:Strings.Ports}"
                                         Binding="{Binding Path=(network:PortProfileInfo.Ports)}"
                                         SortMemberPath="Ports"
                                         Width="2*" />
@@ -38,31 +42,37 @@
                     <KeyBinding Command="{Binding Path=OKCommand}" Key="Return" />
                 </controls:MultiSelectDataGrid.InputBindings>
                 <controls:MultiSelectDataGrid.RowStyle>
-                    <Style TargetType="{x:Type TypeName=DataGridRow}" BasedOn="{StaticResource ResourceKey=MahApps.Styles.DataGridRow}">
+                    <Style TargetType="{x:Type TypeName=DataGridRow}"
+                           BasedOn="{StaticResource ResourceKey=MahApps.Styles.DataGridRow}">
                         <EventSetter Event="MouseDoubleClick" Handler="DataGridRow_MouseDoubleClick" />
                     </Style>
                 </controls:MultiSelectDataGrid.RowStyle>
             </controls:MultiSelectDataGrid>
         </Grid>
         <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Content="{x:Static Member=localization:Strings.OK}" Command="{Binding Path=OKCommand}" IsDefault="True" Margin="0,0,10,0">
+            <Button Content="{x:Static Member=localization:Strings.OK}" Command="{Binding Path=OKCommand}"
+                    IsDefault="True" Margin="0,0,10,0">
                 <Button.Style>
-                    <Style TargetType="{x:Type TypeName=Button}" BasedOn="{StaticResource ResourceKey=HighlightedButton}">
+                    <Style TargetType="{x:Type TypeName=Button}"
+                           BasedOn="{StaticResource ResourceKey=HighlightedButton}">
                         <Setter Property="IsEnabled" Value="True" />
                         <Style.Triggers>
                             <MultiDataTrigger>
                                 <MultiDataTrigger.Conditions>
-                                    <Condition Binding="{Binding ElementName=DataGridPortProfiles, Path=SelectedItems.Count}" Value="0" />
+                                    <Condition
+                                        Binding="{Binding ElementName=DataGridProfiles, Path=SelectedItems.Count}"
+                                        Value="0" />
                                 </MultiDataTrigger.Conditions>
                                 <MultiDataTrigger.Setters>
-                                    <Setter Property="IsEnabled" Value="False"/>
+                                    <Setter Property="IsEnabled" Value="False" />
                                 </MultiDataTrigger.Setters>
                             </MultiDataTrigger>
                         </Style.Triggers>
                     </Style>
                 </Button.Style>
             </Button>
-            <Button Content="{x:Static Member=localization:Strings.Cancel}" Command="{Binding Path=CancelCommand}" IsCancel="True" Style="{StaticResource ResourceKey=DefaultButton}" />
+            <Button Content="{x:Static Member=localization:Strings.Cancel}" Command="{Binding Path=CancelCommand}"
+                    IsCancel="True" Style="{StaticResource ResourceKey=DefaultButton}" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Source/NETworkManager/Views/PortScannerView.xaml
+++ b/Source/NETworkManager/Views/PortScannerView.xaml
@@ -211,10 +211,6 @@
             <TextBlock Grid.Row="2" Foreground="{DynamicResource MahApps.Brushes.Accent}" Text="{Binding StatusMessage}" Visibility="{Binding IsStatusMessageDisplayed, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" Style="{DynamicResource StatusMessageTextBlock}" Margin="0,10,0,0" />
         </Grid>
         <TextBlock Grid.Row="2" Style="{StaticResource HeaderTextBlock}" Text="{x:Static localization:Strings.Result}" />
-        <!-- 
-        The sort function is in the code behind -> when you click on the header of the column, the SortMemberPath is passed to the viewmodel
-        CanUserSortColumns="False" -> Default sort won't work with grouped
-        -->
         <controls:MultiSelectDataGrid Grid.Row="3" ItemsSource="{Binding Path=ResultsView}" 
                                       SelectedItem="{Binding Path=SelectedResult}" 
                                       SelectedItemsList="{Binding Path=SelectedResults, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"                                      
@@ -281,9 +277,6 @@
                         </MenuItem.Icon>
                     </MenuItem>
                 </ContextMenu>
-                <Style TargetType="DataGridColumnHeader" BasedOn="{StaticResource DefaultDataGridColumnHeader}">
-                    <EventSetter Event="Click" Handler="ColumnHeader_Click" />
-                </Style>
             </controls:MultiSelectDataGrid.Resources>
             <controls:MultiSelectDataGrid.RowStyle>
                 <Style TargetType="{x:Type DataGridRow}" BasedOn="{StaticResource MahApps.Styles.DataGridRow}">
@@ -320,7 +313,8 @@
             <controls:MultiSelectDataGrid.Columns>
                 <DataGridTextColumn Header="{x:Static localization:Strings.IPAddress}" 
                                     Binding="{Binding (network:PortScannerPortInfo.IPAddress), Converter={StaticResource IPAddressToStringConverter}}"
-                                    SortMemberPath="IPAddressInt32" MinWidth="150" />
+                                    SortMemberPath="IPAddress"
+                                    MinWidth="150" />
                 <DataGridTextColumn Header="{x:Static localization:Strings.Hostname}" 
                                     Binding="{Binding (network:PortScannerPortInfo.Hostname), Converter={StaticResource StringNullOrEmptyToStringConverter}}" 
                                     SortMemberPath="Hostname" 

--- a/Source/NETworkManager/Views/PortScannerView.xaml.cs
+++ b/Source/NETworkManager/Views/PortScannerView.xaml.cs
@@ -42,10 +42,4 @@ public partial class PortScannerView
         if (sender is ContextMenu menu)
             menu.DataContext = _viewModel;
     }
-
-    private void ColumnHeader_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is DataGridColumnHeader columnHeader)
-            _viewModel.SortResultByPropertyName(columnHeader.Column.SortMemberPath);
-    }
 }

--- a/Source/NETworkManager/Views/SNMPOIDProfilesDialog.xaml
+++ b/Source/NETworkManager/Views/SNMPOIDProfilesDialog.xaml
@@ -15,28 +15,41 @@
             <RowDefinition Height="10" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <TextBox x:Name="TextBoxSearch" Grid.Column="0" VerticalAlignment="Center" Text="{Binding Search, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource SearchTextBox}" />
-        <Grid Grid.Row="2">
-            <DataGrid x:Name="DataGridPortProfiles" ItemsSource="{Binding OIDProfiles}" SelectedItem="{Binding SelectedOIDProfile}">
+        <TextBox x:Name="TextBoxSearch" 
+                 Grid.Column="0" Grid.Row="0"
+                 VerticalAlignment="Center"
+                 Text="{Binding Path=Search, UpdateSourceTrigger=PropertyChanged}"
+                 Style="{StaticResource ResourceKey=SearchTextBox}" />
+        <Grid Grid.Column="0" Grid.Row="2">
+            <DataGrid x:Name="DataGridPortProfiles" ItemsSource="{Binding Path=OIDProfiles}" SelectedItem="{Binding Path=SelectedOIDProfile}">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Header="{x:Static localization:Strings.Name}" Binding="{Binding (network:SNMPOIDProfileInfo.Name)}" Width="1*" />
-                    <DataGridTextColumn Header="{x:Static localization:Strings.OID}" Binding="{Binding (network:SNMPOIDProfileInfo.OID)}" Width="2*" />
-                    <DataGridTextColumn Header="{x:Static localization:Strings.Mode}" Binding="{Binding (network:SNMPOIDProfileInfo.Mode)}" Width="1*" />
+                    <DataGridTextColumn Header="{x:Static Member=localization:Strings.Name}" 
+                                        Binding="{Binding Path=(network:SNMPOIDProfileInfo.Name)}"
+                                        SortMemberPath="Name"
+                                        Width="1*" />
+                    <DataGridTextColumn Header="{x:Static Member=localization:Strings.OID}" 
+                                        Binding="{Binding Path=(network:SNMPOIDProfileInfo.OID)}"
+                                        SortMemberPath="OID"
+                                        Width="2*" />
+                    <DataGridTextColumn Header="{x:Static Member=localization:Strings.Mode}" 
+                                        Binding="{Binding (network:SNMPOIDProfileInfo.Mode)}"
+                                        SortMemberPath="Mode"
+                                        Width="1*" />
                 </DataGrid.Columns>
                 <DataGrid.InputBindings>
-                    <KeyBinding Command="{Binding OKCommand}" Key="Return" />
+                    <KeyBinding Command="{Binding Path=OKCommand}" Key="Return" />
                 </DataGrid.InputBindings>
                 <DataGrid.RowStyle>
-                    <Style TargetType="{x:Type DataGridRow}" BasedOn="{StaticResource MahApps.Styles.DataGridRow}">
+                    <Style TargetType="{x:Type TypeName=DataGridRow}" BasedOn="{StaticResource ResourceKey=MahApps.Styles.DataGridRow}">
                         <EventSetter Event="MouseDoubleClick" Handler="DataGridRow_MouseDoubleClick" />
                     </Style>
                 </DataGrid.RowStyle>
             </DataGrid>
         </Grid>
         <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Content="{x:Static localization:Strings.OK}" Command="{Binding OKCommand}" IsDefault="True" Margin="0,0,10,0">
+            <Button Content="{x:Static Member=localization:Strings.OK}" Command="{Binding Path=OKCommand}" IsDefault="True" Margin="0,0,10,0">
                 <Button.Style>
-                    <Style TargetType="{x:Type Button}" BasedOn="{StaticResource HighlightedButton}">
+                    <Style TargetType="{x:Type TypeName=Button}" BasedOn="{StaticResource ResourceKey=HighlightedButton}">
                         <Setter Property="IsEnabled" Value="True" />
                         <Style.Triggers>
                             <MultiDataTrigger>
@@ -51,7 +64,7 @@
                     </Style>
                 </Button.Style>
             </Button>
-            <Button Content="{x:Static localization:Strings.Cancel}" Command="{Binding CancelCommand}" IsCancel="True" Style="{StaticResource DefaultButton}" />
+            <Button Content="{x:Static Member=localization:Strings.Cancel}" Command="{Binding Path=CancelCommand}" IsCancel="True" Style="{StaticResource ResourceKey=DefaultButton}" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Source/NETworkManager/Views/SNMPOIDProfilesDialog.xaml
+++ b/Source/NETworkManager/Views/SNMPOIDProfilesDialog.xaml
@@ -11,7 +11,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="10" />
-            <RowDefinition MinHeight="150" Height="*" />
+            <RowDefinition Height="300" />
             <RowDefinition Height="10" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -21,7 +21,13 @@
                  Text="{Binding Path=Search, UpdateSourceTrigger=PropertyChanged}"
                  Style="{StaticResource ResourceKey=SearchTextBox}" />
         <Grid Grid.Column="0" Grid.Row="2">
-            <DataGrid x:Name="DataGridPortProfiles" ItemsSource="{Binding Path=OIDProfiles}" SelectedItem="{Binding Path=SelectedOIDProfile}">
+            <DataGrid x:Name="DataGridProfiles"
+                      ItemsSource="{Binding Path=OIDProfiles}" 
+                      SelectedItem="{Binding Path=SelectedOIDProfile}"
+                      SelectionMode="Single">
+                <DataGrid.Resources>
+                    <Style TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource DataGridScrollBar}" />
+                </DataGrid.Resources>
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="{x:Static Member=localization:Strings.Name}" 
                                         Binding="{Binding Path=(network:SNMPOIDProfileInfo.Name)}"
@@ -54,7 +60,7 @@
                         <Style.Triggers>
                             <MultiDataTrigger>
                                 <MultiDataTrigger.Conditions>
-                                    <Condition Binding="{Binding ElementName=DataGridPortProfiles, Path=SelectedItems.Count}" Value="0" />
+                                    <Condition Binding="{Binding ElementName=DataGridProfiles, Path=SelectedItems.Count}" Value="0" />
                                 </MultiDataTrigger.Conditions>
                                 <MultiDataTrigger.Setters>
                                     <Setter Property="IsEnabled" Value="False"/>

--- a/Source/NETworkManager/Views/SNMPView.xaml
+++ b/Source/NETworkManager/Views/SNMPView.xaml
@@ -587,7 +587,8 @@
         </TextBlock>
         <controls:MultiSelectDataGrid Grid.Row="5" Grid.ColumnSpan="3" Grid.Column="0" 
                                       ItemsSource="{Binding ResultsView}" 
-                                      SelectedItem="{Binding SelectedResult}" 
+                                      SelectedItem="{Binding SelectedResult}"
+                                      Sorting="DataGrid_OnSorting"
                                       SelectedItemsList="{Binding SelectedResults, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
             <controls:MultiSelectDataGrid.Resources>
                 <Style TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource DataGridScrollBar}" />
@@ -649,8 +650,13 @@
                 </Style>
             </controls:MultiSelectDataGrid.RowStyle>
             <DataGrid.Columns>
-                <DataGridTextColumn Header="{x:Static localization:Strings.OID}" Binding="{Binding (network:SNMPInfo.OID)}" SortMemberPath="OID" MinWidth="200" />
-                <DataGridTextColumn Header="{x:Static localization:Strings.Data}" Binding="{Binding (network:SNMPInfo.Data)}" SortMemberPath="Data" MinWidth="300" />
+                <DataGridTextColumn Header="{x:Static localization:Strings.OID}"
+                                    Binding="{Binding (network:SNMPInfo.OID)}"
+                                    SortMemberPath="OID" 
+                                    MinWidth="200" />
+                <DataGridTextColumn Header="{x:Static localization:Strings.Data}" 
+                                    Binding="{Binding (network:SNMPInfo.Data)}"
+                                    SortMemberPath="Data" MinWidth="300" />
             </DataGrid.Columns>
         </controls:MultiSelectDataGrid>
         <TextBox Grid.Row="5" Grid.Column="0" Text="{Binding Data}">

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -45,11 +45,14 @@ Experimental features can be enabled in the settings under [`Settings > Update`]
   - Scan is no longer aborted if the IP of a single host in a series of hosts cannot be resolved (the host is skipped and an error is displayed) [#2573](https://github.com/BornToBeRoot/NETworkManager/pull/2573){:target="\_blank"}
   - Hostname added to group [#2573](https://github.com/BornToBeRoot/NETworkManager/pull/2573){:target="\_blank"}
   - Sort improved [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
+  - Port profile column sort fixed [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
 - Ping Monitor
   - Scan is no longer aborted if the IP of a single host in a series of hosts cannot be resolved (the host is skipped and an error is displayed) [#2573](https://github.com/BornToBeRoot/NETworkManager/pull/2573){:target="\_blank"}
 - DNS Lookup
   - Hostname of the nameserver added to group [#2573](https://github.com/BornToBeRoot/NETworkManager/pull/2573){:target="\_blank"}
   - Sort improved [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
+- SNMP
+  OID profile column sort fixed [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
 
 ## Bugfixes
 

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -53,14 +53,18 @@ Experimental features can be enabled in the settings under [`Settings > Update`]
   - Sort improved [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
 - SNMP
   OID profile column sort fixed [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
+- ARP Table
+  - Sort by IP address & MAC address improved / fixed [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
 
 ## Bugfixes
 
 - SNMP
   - Detect EndOfMibView in v1 and v2c walk [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
+- Lookup
+  - Fix sort by MAC address [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
 
 ## Other
 
-- Code cleanup & Refactoring
+- Code cleanup & Refactoring [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
 - Language files updated [#transifex](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Ftransifex-integration){:target="\_blank"}
 - Dependencies updated [#dependencies](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Fdependabot){:target="\_blank"}

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -53,6 +53,10 @@ Experimental features can be enabled in the settings under [`Settings > Update`]
   - Sort improved [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
 - SNMP
   OID profile column sort fixed [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
+- Connections
+  - Sort by IP address improved / fixed [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
+- Listeners
+  - Sort by IP address improved / fixed [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
 - ARP Table
   - Sort by IP address & MAC address improved / fixed [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
 

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -40,13 +40,16 @@ Experimental features can be enabled in the settings under [`Settings > Update`]
 
 - IP Scanner
   - Scan is no longer aborted if the IP of a single host in a series of hosts cannot be resolved (the host is skipped and an error is displayed) [#2573](https://github.com/BornToBeRoot/NETworkManager/pull/2573){:target="\_blank"}
+  - Sort by IP address & MAC address improved / fixed [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
 - Port Scanner
   - Scan is no longer aborted if the IP of a single host in a series of hosts cannot be resolved (the host is skipped and an error is displayed) [#2573](https://github.com/BornToBeRoot/NETworkManager/pull/2573){:target="\_blank"}
   - Hostname added to group [#2573](https://github.com/BornToBeRoot/NETworkManager/pull/2573){:target="\_blank"}
+  - Sort improved [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
 - Ping Monitor
   - Scan is no longer aborted if the IP of a single host in a series of hosts cannot be resolved (the host is skipped and an error is displayed) [#2573](https://github.com/BornToBeRoot/NETworkManager/pull/2573){:target="\_blank"}
 - DNS Lookup
   - Hostname of the nameserver added to group [#2573](https://github.com/BornToBeRoot/NETworkManager/pull/2573){:target="\_blank"}
+  - Sort improved [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
 
 ## Bugfixes
 

--- a/docs/Changelog/next-release.md
+++ b/docs/Changelog/next-release.md
@@ -56,6 +56,9 @@ Experimental features can be enabled in the settings under [`Settings > Update`]
 
 ## Bugfixes
 
+- SNMP
+  - Detect EndOfMibView in v1 and v2c walk [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583){:target="\_blank"}
+
 ## Other
 
 - Code cleanup & Refactoring


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Improve sort in DNS & Port Scanner
- IP Scanner compare IP address by bytes (not just Int32 for IPv4)
- IP Scanner sort MAC address by bytes
- Port Scanner - Port profile sort fixed
- SNMP - OID profile sort fixed
- Detect EndOfMibView in v1 and v2c walk

ToDo:
- [x] SNMP - Click on column to sort
- [x] ARP (vm & click)
- [x] Connections (vm & click)
- [x] Listener (vm & click)

Fix #2569 
Fix #2584 

**ToDo:**

- [x] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Documentation) to reflect this changes
- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).