### PR TITLE
Fix: DNS server resolve is finished too early if queries are timed out

### DIFF
--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -43,6 +43,7 @@ Release date: **xx.xx.2023**
   - Scan is no longer aborted if the IP of a single host in a series of hosts cannot be resolved (the host is skipped and an error is displayed) [#2573](https://github.com/BornToBeRoot/NETworkManager/pull/2573)
 - DNS Lookup
   - Hostname of the nameserver added to group [#2573](https://github.com/BornToBeRoot/NETworkManager/pull/2573)
+  - Resolve was finished too early if a request timed [#2612](https://github.com/BornToBeRoot/NETworkManager/pull/2612)
   - Sort improved [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583)
 - SNMP
   OID profile column sort fixed [#2583](https://github.com/BornToBeRoot/NETworkManager/pull/2583)


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Resolve is finished too early if queries are timed out

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).