### PR TITLE
Feature: Network Interface - dhcpstaticipcoexistence

### DIFF
--- a/Source/NETworkManager.Models/Network/NetworkInterfaceConfig.cs
+++ b/Source/NETworkManager.Models/Network/NetworkInterfaceConfig.cs
@@ -2,12 +2,48 @@
 
 public class NetworkInterfaceConfig
 {
-    public string Name { get; set; }
-    public bool EnableStaticIPAddress { get; set; }
-    public string IPAddress { get; set; }
-    public string Subnetmask { get; set; }
-    public string Gateway { get; set; }
-    public bool EnableStaticDNS { get; set; }
-    public string PrimaryDNSServer { get; set; }
-    public string SecondaryDNSServer { get; set; }
+    /// <summary>
+    /// Name of the network adapter to configure (e.g. "Ethernet", "Wi-Fi", "Local Area Connection")
+    /// </summary>
+    public string Name { get; init; }
+    
+    /// <summary>
+    /// Enable or disable static IP address configuration (otherwise DHCP is used).
+    /// </summary>
+    public bool EnableStaticIPAddress { get; init; }
+    
+    /// <summary>
+    /// Enable or disable DHCP static IP coexistence.
+    /// </summary>
+    public bool EnableDhcpStaticIpCoexistence { get; init; }
+    
+    /// <summary>
+    /// Static or additional IP address to configure.
+    /// </summary>
+    public string IPAddress { get; init; }
+    
+    /// <summary>
+    /// Subnet mask to use for the static or additional IP address configuration.
+    /// </summary>
+    public string Subnetmask { get; init; }
+    
+    /// <summary>
+    /// Gateway to use for the static IP address configuration.
+    /// </summary>
+    public string Gateway { get; init; }
+    
+    /// <summary>
+    /// Enable or disable static DNS server configuration (otherwise DHCP is used).
+    /// </summary>
+    public bool EnableStaticDNS { get; init; }
+    
+    /// <summary>
+    /// Primary DNS server to use for the static DNS server configuration.
+    /// </summary>
+    public string PrimaryDNSServer { get; init; }
+    
+    /// <summary>
+    /// Secondary DNS server to use for the static DNS server configuration.
+    /// </summary>
+    public string SecondaryDNSServer { get; init; }
 }

--- a/Source/NETworkManager.sln.DotSettings
+++ b/Source/NETworkManager.sln.DotSettings
@@ -50,10 +50,12 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cccccc/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Controlz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dccp/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=dhcpstaticipcoexistence/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dragablz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=EDNS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Espa_00F1ol/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=FFFFFF/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=flushdns/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Fran_00E7ais/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Freezed/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=HKCU/@EntryIndexedValue">True</s:Boolean>
@@ -81,6 +83,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Smartcards/@EntryIndexedValue">True</s:Boolean>
 	
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sntp/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Sservers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Subnetmask/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Subnetting/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Supernetting/@EntryIndexedValue">True</s:Boolean>
@@ -88,6 +91,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=tigervnc/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Transifex/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Twork/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=unicast/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Userpass/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=_010Ce_0161tina/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=_0420_0443_0441_0441_043A_0438_0439/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Source/NETworkManager/ViewModels/NetworkInterfaceViewModel.cs
+++ b/Source/NETworkManager/ViewModels/NetworkInterfaceViewModel.cs
@@ -707,7 +707,8 @@ public class NetworkInterfaceViewModel : ViewModelBase, IProfileManager
             [
                 ExportFileType.Csv, ExportFileType.Xml, ExportFileType.Json
             ], true,
-            SettingsManager.Current.NetworkInterface_ExportFileType, SettingsManager.Current.NetworkInterface_ExportFilePath);
+            SettingsManager.Current.NetworkInterface_ExportFileType,
+            SettingsManager.Current.NetworkInterface_ExportFilePath);
 
         customDialog.Content = new ExportDialog
         {
@@ -716,7 +717,7 @@ public class NetworkInterfaceViewModel : ViewModelBase, IProfileManager
 
         await _dialogCoordinator.ShowMetroDialogAsync(this, customDialog);
     }
-    
+
     public ICommand ApplyConfigurationCommand =>
         new RelayCommand(_ => ApplyConfigurationAction(), ApplyConfiguration_CanExecute);
 
@@ -1154,6 +1155,7 @@ public class NetworkInterfaceViewModel : ViewModelBase, IProfileManager
         var config = new NetworkInterfaceConfig
         {
             Name = SelectedNetworkInterface.Name,
+            EnableDhcpStaticIpCoexistence = SelectedNetworkInterface.DhcpEnabled,
             IPAddress = ipAddress,
             Subnetmask = subnetmask
         };

--- a/Website/docs/application/network-interface.md
+++ b/Website/docs/application/network-interface.md
@@ -67,7 +67,7 @@ In addition, further actions can be performed using the buttons at the bottom le
     :::note
 
     If a static IP address is added to a network adapter that is configured for DHCP, the `netsh` option `dhcpstaticipcoexistence` is also activated.
-    
+
     The following command is executed in an elevated PowerShell to enable the `dhcpstaticipcoexistence` option:
 
     ```PowerShell
@@ -81,7 +81,6 @@ In addition, further actions can be performed using the buttons at the bottom le
     `dhcpstaticipcoexistence` allows the network adapter to use a static IP address and still receive DHCP options (e.g. DNS server) from the DHCP server. This is useful if you want to use a static IP address but still want to receive DNS server addresses from the DHCP server. This feature is available since Windows 10 version 1703 (Creators Update).
 
     :::
-
 
   - **Remove IPv4 addres...** - Opens a dialog where you can select an IPv4 address to remove from the selected network adapter.
 

--- a/Website/docs/application/network-interface.md
+++ b/Website/docs/application/network-interface.md
@@ -61,8 +61,41 @@ The options you can set correspond to the network adapter properties `Internetpr
 In addition, further actions can be performed using the buttons at the bottom left:
 
 - **Additional config...**
+
   - **Add IPv4 address...** - Opens a dialog to add an IPv4 address with a subnet mask or CIDR to the selected network adapter.
+
+    :::note
+
+    If a static IP address is added to a network adapter that is configured for DHCP, the `netsh` option `dhcpstaticipcoexistence` is also activated.
+    
+    The following command is executed in an elevated PowerShell to enable the `dhcpstaticipcoexistence` option:
+
+    ```PowerShell
+    netsh interface ipv4 set interface interface="Ethernet" dhcpstaticipcoexistence=enabled
+    ```
+
+    :::
+
+    :::info
+
+    `dhcpstaticipcoexistence` allows the network adapter to use a static IP address and still receive DHCP options (e.g. DNS server) from the DHCP server. This is useful if you want to use a static IP address but still want to receive DNS server addresses from the DHCP server. This feature is available since Windows 10 version 1703 (Creators Update).
+
+    :::
+
+
   - **Remove IPv4 addres...** - Opens a dialog where you can select an IPv4 address to remove from the selected network adapter.
+
+    :::note
+
+    You can only remove IPv4 addresses that are not assigned via DHCP.
+
+    The `netsh` option `dhcpstaticipcoexistence` remains active. You can disable it by executing the following command in an elevated PowerShell:
+
+    ```PowerShell
+    netsh interface ipv4 set interface interface="Ethernet" dhcpstaticipcoexistence=disabled
+    ```
+
+    :::
 
 :::note
 

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -19,21 +19,30 @@ Release date: **xx.xx.2023**
 
 ## What's new?
 
+**Network Interfaces**
+
+- Adding an additional IPv4 address to the network adapter will enable the `netsh` option `dhcpstaticipcoexistence` if the network adapter is configured to use DHCP [#2656](https://github.com/BornToBeRoot/NETworkManager/pull/2656)
+
 ## Improvements
 
 - **Network Interfaces**
+
   - Export to CSV, XML and JSON added [#2626](https://github.com/BornToBeRoot/NETworkManager/pull/2626)
 
 - **Ping Monitor**
+
   - Grouping of hosts added. Hosts are now grouped based on the profile or added to the default group [#2645](https://github.com/BornToBeRoot/NETworkManager/pull/2645)
 
 - **Discovery Protocol**
+
   - Export to CSV, XML and JSON added [#2626](https://github.com/BornToBeRoot/NETworkManager/pull/2626)
 
 - **IP Geolocation**
+
   - Export to CSV, XML and JSON added [#2626](https://github.com/BornToBeRoot/NETworkManager/pull/2626)
 
 - **Bit Calculator**
+
   - Export to CSV, XML and JSON added [#2626](https://github.com/BornToBeRoot/NETworkManager/pull/2626)
 
 ## Bugfixes


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Add netsh dhcpstaticipcoexistence to interfaces with dhcp to add a static ip address
-
-

Fixes #2264 

**ToDo:**

- [x] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Documentation) to reflect this changes
- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).