### PR TITLE
Fix: Ping monitor crash when dns not configured

### DIFF
--- a/Source/NETworkManager.Models/Network/Ping.cs
+++ b/Source/NETworkManager.Models/Network/Ping.cs
@@ -10,7 +10,7 @@ namespace NETworkManager.Models.Network;
 
 public sealed class Ping
 {
-    #region Varaibles
+    #region Variables
 
     public int WaitTime = 1000;
     public int Timeout = 4000;

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -30,6 +30,9 @@ Release date: **xx.xx.2024**
 
 ## Bugfixes
 
+- **Ping Monitor**
+  - A problem has been fixed where the ping does not start if the DNS server is not configured. This can occur if the network interface via which the Windows DNS server was configured is deactivated/disconnected. [#2876](https://github.com/BornToBeRoot/NETworkManager/pull/2876)
+
 - TextBox content not centered because of ScrollViewer issue. [#2763](https://github.com/BornToBeRoot/NETworkManager/pull/2763)
 
 ## Dependencies, Refactoring & Documentation


### PR DESCRIPTION
**Please provide some details about this pull request:**
- A problem has been fixed where the ping does not start if the DNS server is not configured. This can occur if the network interface via which the Windows DNS server was configured is deactivated/disconnected. 


Fixes #2875 

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).