### PR TITLE
Introducing NETworkManager Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@
     <a href="https://github.com/BornToBeRoot/NETworkManager/issues/new?labels=Issue&template=Bug_report.md">
       <img alt="Bug report" src="https://img.shields.io/badge/github-bug_report-red.svg?style=for-the-badge&logo=github" />
     </a>     
+    <a href="https://gurubase.io/g/networkmanager">
+      <img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20NETworkManager%20Guru-006BFF?style=for-the-badge" />
+    </a>
   </p>
   <p>
     <a href="#-download">Download</a> • <a href="#-changelog">Changelog</a> • <a href="#-documentation">Documentation</a> • <a href="#-contributing">Contributing</a> • <a href="#-build">Build</a> • <a href="#-license">License</a>


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [NETworkManager Guru](https://gurubase.io/g/networkmanager) to Gurubase. NETworkManager Guru uses the data from this repo and data from the [docs](https://borntoberoot.net/NETworkManager/) to answer questions by leveraging the LLM.

In this PR, I showcased the "NETworkManager Guru", which highlights that NETworkManager now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable NETworkManager Guru in Gurubase, just let me know that's totally fine.
