### PR TITLE
Fix: DPI scaling for multiple monitors

### DIFF
--- a/Source/NETworkManager/NETworkManager.csproj
+++ b/Source/NETworkManager/NETworkManager.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+	
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
         <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
@@ -8,15 +9,16 @@
         <!-- Publish a single file can't be used when accessing assembly file path
         <PublishSingleFile>true</PublishSingleFile>
         <PublishReadyToRun>true</PublishReadyToRun>
-        -->
+        -->		
         <CsWinRTWindowsMetadata>sdk</CsWinRTWindowsMetadata>
         <RootNamespace>NETworkManager</RootNamespace>
         <AssemblyName>NETworkManager</AssemblyName>
         <UseWPF>true</UseWPF>
-        <UseWindowsForms>true</UseWindowsForms>
+        <UseWindowsForms>true</UseWindowsForms>		
         <StartupObject>NETworkManager.App</StartupObject>
-        <ApplicationIcon>NETworkManager.ico</ApplicationIcon>
-        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<ApplicationManifest>app.manifest</ApplicationManifest>
+		<ApplicationIcon>NETworkManager.ico</ApplicationIcon>		
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
         <Authors>BornToBeRoot</Authors>
         <PackageProjectUrl>https://github.com/BornToBeRoot/NETworkManager</PackageProjectUrl>

--- a/Source/NETworkManager/app.manifest
+++ b/Source/NETworkManager/app.manifest
@@ -16,11 +16,12 @@
             <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
         </application>
     </compatibility>
-
+	
     <application xmlns="urn:schemas-microsoft-com:asm.v3">
         <windowsSettings>
-            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor</dpiAwareness>
-            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>            
         </windowsSettings>
     </application>
+
 </assembly>

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -33,6 +33,7 @@ Release date: **xx.xx.2024**
 
 ## Bugfixes
 
+- Fixed an issue with DPI scaling where the application was blurry if a second monitor had a different dpi setting than the main monitor. [#2941](https://github.com/BornToBeRoot/NETworkManager/pull/2941)
 - Changed the Welcome dialog from `MahApps.Metro.Controls.Dialogs` to `MahApps.Metro.SimpleChildWindow`, so the main window can be dragged and resized on the first start. [#2914](https://github.com/BornToBeRoot/NETworkManager/pull/2914)
 
 - **WiFi**


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Fixed an issue with DPI scaling where the application was blurry if a second monitor had a different dpi setting than the main monitor.

Issue found while troubleshooting #2911 

**ToDo:**

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).