### PR TITLE
Feature: Migrate loading indicators to NETworkManager

### DIFF
--- a/Source/NETworkManager/App.xaml
+++ b/Source/NETworkManager/App.xaml
@@ -17,21 +17,8 @@
                     Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.FlatButton.xaml" />
                 <ResourceDictionary
                     Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.FlatSlider.xaml" />
-
                 <!-- Dragablz -->
                 <ResourceDictionary Source="pack://application:,,,/Dragablz;component/Themes/MahApps.xaml" />
-                <!-- LoadingIndicators.WPF -->
-                <ResourceDictionary Source="pack://application:,,,/LoadingIndicators.WPF;component/Styles.xaml" />
-                <ResourceDictionary
-                    Source="pack://application:,,,/LoadingIndicators.WPF;component/Styles/LoadingWave.xaml" />
-                <ResourceDictionary
-                    Source="pack://application:,,,/LoadingIndicators.WPF;component/Styles/LoadingThreeDots.xaml" />
-                <ResourceDictionary
-                    Source="pack://application:,,,/LoadingIndicators.WPF;component/Styles/LoadingFlipPlane.xaml" />
-                <ResourceDictionary
-                    Source="pack://application:,,,/LoadingIndicators.WPF;component/Styles/LoadingPulse.xaml" />
-                <ResourceDictionary
-                    Source="pack://application:,,,/LoadingIndicators.WPF;component/Styles/LoadingDoubleBounce.xaml" />
                 <!-- Context menu (import berfore styles)-->
                 <ResourceDictionary Source="/Resources/ContextMenu/ContextMenu.xaml" />
                 <!-- Control templates (import before styles) -->
@@ -44,6 +31,8 @@
                 <ResourceDictionary Source="/Resources/Styles/DropDownButtonStyles.xaml" />
                 <ResourceDictionary Source="/Resources/Styles/GridSplitterStyles.xaml" />
                 <ResourceDictionary Source="/Resources/Styles/GroupBoxStyles.xaml" />
+                <ResourceDictionary Source="/Resources/Styles/LoadingIndicatorArcsStyle.xaml" />
+                <ResourceDictionary Source="/Resources/Styles/LoadingIndicatorPulseStyle.xaml" />
                 <ResourceDictionary Source="/Resources/Styles/MenuItemStyles.xaml" />
                 <ResourceDictionary Source="/Resources/Styles/MetroDialogStyles.xaml" />
                 <ResourceDictionary Source="/Resources/Styles/NumericUpDownStyles.xaml" />

--- a/Source/NETworkManager/LoadingIndicators.cs
+++ b/Source/NETworkManager/LoadingIndicators.cs
@@ -1,0 +1,139 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+
+namespace NETworkManager;
+
+/// <summary>
+/// A control featuring a range of loading indicating animations.
+/// Source: https://github.com/zeluisping/LoadingIndicators.WPF
+/// </summary>
+[TemplatePart(Name = "Border", Type = typeof(Border))]
+public class LoadingIndicator : Control
+{
+    /// <summary>
+    /// Identifies the <see cref="NETworkManager.LoadingIndicator.SpeedRatio"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty SpeedRatioProperty =
+        DependencyProperty.Register(nameof(SpeedRatio), typeof(double), typeof(LoadingIndicator), new PropertyMetadata(1d, (o, e) =>
+        {
+            LoadingIndicator li = (LoadingIndicator)o;
+
+            if (li.PART_Border == null || li.IsActive == false)
+            {
+                return;
+            }
+
+            foreach (VisualStateGroup group in VisualStateManager.GetVisualStateGroups(li.PART_Border))
+            {
+                if (group.Name == "ActiveStates")
+                {
+                    foreach (VisualState state in group.States)
+                    {
+                        if (state.Name == "Active")
+                        {
+                            state.Storyboard.SetSpeedRatio(li.PART_Border, (double)e.NewValue);
+                        }
+                    }
+                }
+            }
+        }));
+
+    /// <summary>
+    /// Identifies the <see cref="NETworkManager.LoadingIndicator.IsActive"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty IsActiveProperty =
+        DependencyProperty.Register(nameof(IsActive), typeof(bool), typeof(LoadingIndicator), new PropertyMetadata(true, (o, e) =>
+        {
+            LoadingIndicator li = (LoadingIndicator)o;
+
+            if (li.PART_Border == null)
+            {
+                return;
+            }
+
+            if ((bool)e.NewValue == false)
+            {
+                VisualStateManager.GoToElementState(li.PART_Border, "Inactive", false);
+                li.PART_Border.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                VisualStateManager.GoToElementState(li.PART_Border, "Active", false);
+                li.PART_Border.Visibility = Visibility.Visible;
+
+                foreach (VisualStateGroup group in VisualStateManager.GetVisualStateGroups(li.PART_Border))
+                {
+                    if (group.Name == "ActiveStates")
+                    {
+                        foreach (VisualState state in group.States)
+                        {
+                            if (state.Name == "Active")
+                            {
+                                state.Storyboard.SetSpeedRatio(li.PART_Border, li.SpeedRatio);
+                            }
+                        }
+                    }
+                }
+            }
+        }));
+
+    // Variables
+    protected Border PART_Border;
+
+    /// <summary>
+    /// Get/set the speed ratio of the animation.
+    /// </summary>
+    public double SpeedRatio
+    {
+        get { return (double)GetValue(SpeedRatioProperty); }
+        set { SetValue(SpeedRatioProperty, value); }
+    }
+
+    /// <summary>
+    /// Get/set whether the loading indicator is active.
+    /// </summary>
+    public bool IsActive
+    {
+        get { return (bool)GetValue(IsActiveProperty); }
+        set { SetValue(IsActiveProperty, value); }
+    }
+
+    /// <summary>
+    /// When overridden in a derived class, is invoked whenever application code
+    /// or internal processes call System.Windows.FrameworkElement.ApplyTemplate().
+    /// </summary>
+    public override void OnApplyTemplate()
+    {
+        base.OnApplyTemplate();
+
+        PART_Border = (Border)GetTemplateChild("PART_Border");
+
+        if (PART_Border != null)
+        {
+            VisualStateManager.GoToElementState(PART_Border, (this.IsActive ? "Active" : "Inactive"), false);
+            foreach (VisualStateGroup group in VisualStateManager.GetVisualStateGroups(PART_Border))
+            {
+                if (group.Name == "ActiveStates")
+                {
+                    foreach (VisualState state in group.States)
+                    {
+                        if (state.Name == "Active")
+                        {
+                            state.Storyboard.SetSpeedRatio(PART_Border, this.SpeedRatio);
+                        }
+                    }
+                }
+            }
+
+            PART_Border.Visibility = (IsActive ? Visibility.Visible : Visibility.Collapsed);
+        }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NETworkManager.LoadingIndicator"/> class.
+    /// </summary>
+    public LoadingIndicator()
+    {
+
+    }
+}

--- a/Source/NETworkManager/NETworkManager.csproj
+++ b/Source/NETworkManager/NETworkManager.csproj
@@ -66,7 +66,6 @@
         <PackageReference Include="IPNetwork2" Version="3.0.667" />
         <PackageReference Include="Lextm.SharpSnmpLib" Version="12.5.5" />
         <PackageReference Include="LiveCharts.Wpf" Version="0.9.7" />
-        <PackageReference Include="LoadingIndicators.WPF" Version="0.0.1" />
         <PackageReference Include="log4net" Version="3.0.3" />
         <PackageReference Include="MahApps.Metro" Version="2.4.10" />
         <PackageReference Include="MahApps.Metro.IconPacks.FontAwesome" Version="5.1.0" />

--- a/Source/NETworkManager/Resources/Styles/LoadingIndicatorArcsStyle.xaml
+++ b/Source/NETworkManager/Resources/Styles/LoadingIndicatorArcsStyle.xaml
@@ -1,0 +1,110 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:networkManager="clr-namespace:NETworkManager">
+    <!--
+        Source: https://github.com/BornToBeRoot/NETworkManager/issues/2949
+    -->
+    <Style x:Key="LoadingIndicatorArcsStyleKey" TargetType="{x:Type networkManager:LoadingIndicator}">
+        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=MahApps.Brushes.Accent}"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="HorizontalAlignment" Value="Center"/>
+        <Setter Property="Width" Value="40"/>
+        <Setter Property="Height" Value="40"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type networkManager:LoadingIndicator}">
+                    <Border x:Name="PART_Border" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="SizeStates">
+                                <VisualState x:Name="Large" />
+                                <VisualState x:Name="Small" />
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="ActiveStates">
+                                <VisualState x:Name="Inactive"/>
+                                <VisualState x:Name="Active">
+                                    <Storyboard SpeedRatio="{TemplateBinding SpeedRatio}">
+                                        <DoubleAnimationUsingKeyFrames RepeatBehavior="Forever" Storyboard.TargetName="PART_Canvas0" Storyboard.TargetProperty="(UIElement.RenderTransform).(RotateTransform.Angle)">
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.000" Value="0"/>
+                                            <LinearDoubleKeyFrame KeyTime="0:0:3.000" Value="360"/>
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <DoubleAnimationUsingKeyFrames RepeatBehavior="Forever" Storyboard.TargetName="PART_Canvas1" Storyboard.TargetProperty="(UIElement.RenderTransform).(RotateTransform.Angle)">
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.000" Value="0"/>
+                                            <LinearDoubleKeyFrame KeyTime="0:0:2.000" Value="-360"/>
+                                        </DoubleAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+
+                        <Border.Resources>
+                            <Style TargetType="{x:Type Canvas}">
+                                <Setter Property="RenderTransformOrigin" Value="0.5,0.5"/>
+                                <Setter Property="RenderTransform">
+                                    <Setter.Value>
+                                        <RotateTransform/>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </Border.Resources>
+
+                        <Grid Background="Transparent">
+                            <Grid.RenderTransform>
+                                <TransformGroup>
+                                    <ScaleTransform ScaleX="0.5" ScaleY="0.5"/>
+                                    <TranslateTransform X="10" Y="10"/>
+                                </TransformGroup>
+                            </Grid.RenderTransform>
+                            <Canvas x:Name="PART_Canvas0" Opacity="1.0">
+                                <Path Stroke="{TemplateBinding Foreground}" StrokeThickness="10">
+                                    <Path.Data>
+                                        <PathGeometry>
+                                            <PathGeometry.Transform>
+                                                <TranslateTransform X="20" Y="-20"/>
+                                            </PathGeometry.Transform>
+                                            <PathGeometry.Figures>
+                                                <PathFigureCollection>
+                                                    <PathFigure StartPoint="0,0">
+                                                        <PathFigure.Segments>
+                                                            <PathSegmentCollection>
+                                                                <ArcSegment Size="40,40" IsLargeArc="True" SweepDirection="CounterClockwise" Point="40,40" />
+                                                            </PathSegmentCollection>
+                                                        </PathFigure.Segments>
+                                                    </PathFigure>
+                                                </PathFigureCollection>
+                                            </PathGeometry.Figures>
+                                        </PathGeometry>
+                                    </Path.Data>
+                                </Path>
+                            </Canvas>
+
+                            <Canvas x:Name="PART_Canvas1" Opacity="0.3">
+                                <Path Stroke="{TemplateBinding Foreground}" StrokeThickness="10">
+                                    <Path.Data>
+                                        <PathGeometry>
+                                            <PathGeometry.Transform>
+                                                <TranslateTransform X="-7" Y="7"/>
+                                            </PathGeometry.Transform>
+                                            <PathGeometry.Figures>
+                                                <PathFigureCollection>
+                                                    <PathFigure StartPoint="0,0">
+                                                        <PathFigure.Segments>
+                                                            <PathSegmentCollection>
+                                                                <ArcSegment Size="30,30" IsLargeArc="True" SweepDirection="Clockwise" Point="40,40" />
+                                                            </PathSegmentCollection>
+                                                        </PathFigure.Segments>
+                                                    </PathFigure>
+                                                </PathFigureCollection>
+                                            </PathGeometry.Figures>
+                                        </PathGeometry>
+                                    </Path.Data>
+                                </Path>
+                            </Canvas>
+                        </Grid>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    
+    <Style x:Key="LoadingIndicatorArcsStyle" TargetType="{x:Type networkManager:LoadingIndicator}" BasedOn="{StaticResource LoadingIndicatorArcsStyleKey}"/>
+</ResourceDictionary>

--- a/Source/NETworkManager/Resources/Styles/LoadingIndicatorPulseStyle.xaml
+++ b/Source/NETworkManager/Resources/Styles/LoadingIndicatorPulseStyle.xaml
@@ -1,0 +1,55 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:networkManager="clr-namespace:NETworkManager">
+    <!--
+        Source: https://github.com/BornToBeRoot/NETworkManager/issues/2949
+    -->
+    
+    <Style x:Key="LoadingIndicatorPulseStyleKey" TargetType="{x:Type networkManager:LoadingIndicator}">
+        <Setter Property="Foreground" Value="{DynamicResource ResourceKey=MahApps.Brushes.Accent}"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="HorizontalAlignment" Value="Center"/>
+        <Setter Property="Width" Value="40"/>
+        <Setter Property="Height" Value="40"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type networkManager:LoadingIndicator}">
+                    <Border x:Name="PART_Border" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="SizeStates">
+                                <VisualState x:Name="Large" />
+                                <VisualState x:Name="Small" />
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="ActiveStates">
+                                <VisualState x:Name="Inactive"/>
+                                <VisualState x:Name="Active">
+                                    <Storyboard SpeedRatio="{TemplateBinding SpeedRatio}" RepeatBehavior="Forever" Duration="0:0:1.500">
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_Ellipse" Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)">
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.000" Value="0"/>
+                                            <LinearDoubleKeyFrame KeyTime="0:0:1.500" Value="1"/>
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_Ellipse" Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)">
+                                            <LinearDoubleKeyFrame KeyTime="0:0:0.000" Value="0"/>
+                                            <LinearDoubleKeyFrame KeyTime="0:0:1.500" Value="1"/>
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <DoubleAnimation From="1" To="0" Duration="0:0:1.500" Storyboard.TargetName="PART_Ellipse" Storyboard.TargetProperty="(UIElement.Opacity)"/>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+
+                        <Grid Background="Transparent">
+                            <Ellipse x:Name="PART_Ellipse" RenderTransformOrigin="0.5,0.5" Fill="{TemplateBinding Foreground}">
+                                <Ellipse.RenderTransform>
+                                    <ScaleTransform/>
+                                </Ellipse.RenderTransform>
+                            </Ellipse>
+                        </Grid>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="LoadingIndicatorPulseStyle" TargetType="{x:Type networkManager:LoadingIndicator}" BasedOn="{StaticResource LoadingIndicatorPulseStyleKey}"/>
+</ResourceDictionary>

--- a/Source/NETworkManager/Views/DiscoveryProtocolView.xaml
+++ b/Source/NETworkManager/Views/DiscoveryProtocolView.xaml
@@ -4,9 +4,9 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:networkManager="clr-namespace:NETworkManager"
              xmlns:converters="clr-namespace:NETworkManager.Converters;assembly=NETworkManager.Converters"
              xmlns:dialog="clr-namespace:MahApps.Metro.Controls.Dialogs;assembly=MahApps.Metro"
-             xmlns:loadingIndicators="clr-namespace:LoadingIndicators.WPF;assembly=LoadingIndicators.WPF"
              xmlns:viewModels="clr-namespace:NETworkManager.ViewModels"
              xmlns:localization="clr-namespace:NETworkManager.Localization.Resources;assembly=NETworkManager.Localization"
              xmlns:settings="clr-namespace:NETworkManager.Settings;assembly=NETworkManager.Settings"
@@ -260,7 +260,7 @@
                         </TextBlock>
                         <StackPanel Grid.Column="0" Grid.Row="6" VerticalAlignment="Center"
                                     Visibility="{Binding IsCapturing, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
-                            <loadingIndicators:LoadingIndicator IsActive="True"
+                            <networkManager:LoadingIndicator IsActive="True"
                                                                 Style="{DynamicResource LoadingIndicatorArcsStyle}"
                                                                 SpeedRatio="1" Margin="0,0,0,10" />
                             <TextBlock Text="{x:Static localization:Strings.CapturingNetworkPackagesDots}"

--- a/Source/NETworkManager/Views/IPApiDNSResolverWidgetView.xaml
+++ b/Source/NETworkManager/Views/IPApiDNSResolverWidgetView.xaml
@@ -6,7 +6,7 @@
              xmlns:localization="clr-namespace:NETworkManager.Localization.Resources;assembly=NETworkManager.Localization"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:loadingIndicators="clr-namespace:LoadingIndicators.WPF;assembly=LoadingIndicators.WPF"
+             xmlns:networkManager="clr-namespace:NETworkManager"
              xmlns:settings="clr-namespace:NETworkManager.Settings;assembly=NETworkManager.Settings"
              xmlns:viewModels="clr-namespace:NETworkManager.ViewModels"
              xmlns:system="clr-namespace:System;assembly=mscorlib"
@@ -128,7 +128,7 @@
                     <!-- Loading indicator -->
                     <StackPanel Grid.Column="0" Grid.Row="0" VerticalAlignment="Center"
                                 Visibility="{Binding IsRunning, Converter={StaticResource BooleanToVisibilityHiddenConverter}}">
-                        <loadingIndicators:LoadingIndicator IsActive="True"
+                        <networkManager:LoadingIndicator IsActive="True"
                                                             Style="{DynamicResource LoadingIndicatorArcsStyle}"
                                                             SpeedRatio="1" Margin="0,0,0,10" />
                         <TextBlock Text="{x:Static localization:Strings.CheckingDNSResolverDots}"

--- a/Source/NETworkManager/Views/IPApiIPGeolocationWidgetView.xaml
+++ b/Source/NETworkManager/Views/IPApiIPGeolocationWidgetView.xaml
@@ -1,12 +1,12 @@
 ﻿<UserControl x:Class="NETworkManager.Views.IPApiIPGeolocationWidgetView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:networkManager="clr-namespace:NETworkManager"
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:converters="clr-namespace:NETworkManager.Converters;assembly=NETworkManager.Converters"
              xmlns:localization="clr-namespace:NETworkManager.Localization.Resources;assembly=NETworkManager.Localization"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:loadingIndicators="clr-namespace:LoadingIndicators.WPF;assembly=LoadingIndicators.WPF"
              xmlns:viewModels="clr-namespace:NETworkManager.ViewModels"
              xmlns:settings="clr-namespace:NETworkManager.Settings;assembly=NETworkManager.Settings"
              xmlns:system="clr-namespace:System;assembly=mscorlib"
@@ -249,7 +249,7 @@
                     <!-- Loading indicator -->
                     <StackPanel Grid.Column="0" Grid.Row="0" VerticalAlignment="Center"
                                 Visibility="{Binding IsRunning, Converter={StaticResource BooleanToVisibilityHiddenConverter}}">
-                        <loadingIndicators:LoadingIndicator IsActive="True"
+                        <networkManager:LoadingIndicator IsActive="True"
                                                             Style="{DynamicResource LoadingIndicatorArcsStyle}"
                                                             SpeedRatio="1" Margin="0,0,0,10" />
                         <TextBlock Text="{x:Static localization:Strings.CheckingIPGeolocationDots}"

--- a/Source/NETworkManager/Views/WiFiConnectDialog.xaml
+++ b/Source/NETworkManager/Views/WiFiConnectDialog.xaml
@@ -3,13 +3,13 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:networkManager="clr-namespace:NETworkManager"
              xmlns:wpfHelpers="clr-namespace:NETworkManager.Utilities.WPF;assembly=NETworkManager.Utilities.WPF"
              xmlns:validators="clr-namespace:NETworkManager.Validators;assembly=NETworkManager.Validators"
              xmlns:interactivity="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
              xmlns:converters="clr-namespace:NETworkManager.Converters;assembly=NETworkManager.Converters"
              xmlns:viewModels="clr-namespace:NETworkManager.ViewModels"
-             xmlns:loadingIndicators="clr-namespace:LoadingIndicators.WPF;assembly=LoadingIndicators.WPF"
              xmlns:localization="clr-namespace:NETworkManager.Localization.Resources;assembly=NETworkManager.Localization"
              mc:Ignorable="d" Loaded="UserControl_Loaded"
              d:DataContext="{d:DesignInstance viewModels:WiFiConnectViewModel}">
@@ -174,10 +174,11 @@
             <WrapPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center"
                        HorizontalAlignment="Center"
                        Visibility="{Binding IsWpsChecking,Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
-                <loadingIndicators:LoadingIndicator IsActive="True"
-                                                    Foreground="{DynamicResource MahApps.Brushes.Accent}"
-                                                    Style="{DynamicResource LoadingIndicatorPulseStyle}" Width="24"
-                                                    Height="24" VerticalAlignment="Center" SpeedRatio="1" />
+                <networkManager:LoadingIndicator IsActive="True"
+                                                    Style="{DynamicResource ResourceKey=LoadingIndicatorPulseStyle}"
+                                                    Width="24"
+                                                    Height="24" 
+                                                    SpeedRatio="1" />
                 <TextBlock Style="{StaticResource AccentTextBlock}"
                            Text="{x:Static localization:Strings.CheckingWPSDots}" VerticalAlignment="Center"
                            Margin="10,0,0,0" />

--- a/Source/NETworkManager/Views/WiFiView.xaml
+++ b/Source/NETworkManager/Views/WiFiView.xaml
@@ -8,10 +8,10 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:viewModels="clr-namespace:NETworkManager.ViewModels"
-             xmlns:liveChart="clr-namespace:LiveCharts.Wpf;assembly=LiveCharts.Wpf"
+             xmlns:liveChart="clr-namespace:LiveCharts.Wpf;assembly=LiveCharts.Wpf" 
+             xmlns:networkManager="clr-namespace:NETworkManager"
              xmlns:controls="clr-namespace:NETworkManager.Controls"
-             xmlns:controls2="clr-namespace:NETworkManager.Controls;assembly=NETworkManager.Controls"
-             xmlns:loadingIndicators="clr-namespace:LoadingIndicators.WPF;assembly=LoadingIndicators.WPF"
+             xmlns:controls2="clr-namespace:NETworkManager.Controls;assembly=NETworkManager.Controls"             
              xmlns:dialogs="clr-namespace:MahApps.Metro.Controls.Dialogs;assembly=MahApps.Metro"
              xmlns:utilities="clr-namespace:NETworkManager.Utilities;assembly=NETworkManager.Utilities"
              dialogs:DialogParticipation.Register="{Binding}"
@@ -631,7 +631,7 @@
                                     <StackPanel Grid.Column="0" Grid.Row="2"
                                                 VerticalAlignment="Center"
                                                 Visibility="{Binding Path=IsNetworksLoading, Converter={StaticResource ResourceKey=BooleanToVisibilityCollapsedConverter}}">
-                                        <loadingIndicators:LoadingIndicator IsActive="True"
+                                        <networkManager:LoadingIndicator IsActive="True"
                                                                             Style="{DynamicResource ResourceKey=LoadingIndicatorArcsStyle}"
                                                                             SpeedRatio="1"
                                                                             Margin="0,0,0,10" />
@@ -770,8 +770,7 @@
                                Orientation="Horizontal"
                                VerticalAlignment="Center"
                                HorizontalAlignment="Center">
-                        <loadingIndicators:LoadingIndicator IsActive="True"
-                                                            Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Accent}"
+                        <networkManager:LoadingIndicator IsActive="True"
                                                             Style="{DynamicResource ResourceKey=LoadingIndicatorPulseStyle}"
                                                             Visibility="{Binding Path=IsBackgroundSearchRunning, Converter={StaticResource ResourceKey=BooleanToVisibilityCollapsedConverter}}"
                                                             Width="24" Height="24"
@@ -790,9 +789,8 @@
                             <Rectangle Width="1"
                                        Stroke="{DynamicResource ResourceKey=MahApps.Brushes.Accent}"
                                        VerticalAlignment="Stretch" />
-                            <loadingIndicators:LoadingIndicator IsActive="True"
-                                                                Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Accent}"
-                                                                Style="{DynamicResource LoadingIndicatorPulseStyle}"
+                            <networkManager:LoadingIndicator IsActive="True"
+                                                                Style="{DynamicResource ResourceKey=LoadingIndicatorPulseStyle}"
                                                                 Visibility="{Binding IsConnecting, Converter={StaticResource ResourceKey=BooleanToVisibilityCollapsedConverter}}"
                                                                 Width="24" Height="24"
                                                                 VerticalAlignment="Center"
@@ -920,8 +918,7 @@
                 </Button>
                 <StackPanel VerticalAlignment="Center"
                             Visibility="{Binding Path=IsAdaptersLoading, Converter={StaticResource ResourceKey=BooleanToVisibilityCollapsedConverter}}">
-                    <loadingIndicators:LoadingIndicator IsActive="True"
-                                                        Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Accent}"
+                    <networkManager:LoadingIndicator IsActive="True"                                                        
                                                         Style="{DynamicResource ResourceKey=LoadingIndicatorArcsStyle}"
                                                         SpeedRatio="1"
                                                         Margin="0,0,0,10" />

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -43,6 +43,7 @@ Release date: **xx.xx.2024**
 
 ## Dependencies, Refactoring & Documentation
 
+Migrated code for some loading indicators from the library [LoadingIndicators.WPF] (https://github.com/zeluisping/LoadingIndicators.WPF) to the NETworkManager repo, as the original repo looks unmaintained and has problems with MahApps.Metro version 2 and later. [#2963](https://github.com/BornToBeRoot/NETworkManager/pull/2963)
 - Code cleanup & refactoring [#2940](https://github.com/BornToBeRoot/NETworkManager/pull/2940)
 - Language files updated via [#transifex](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Ftransifex-integration)
 - Dependencies updated via [#dependabot](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Fdependabot)


### PR DESCRIPTION
**Please provide some details about this pull request:**
- Migrated the loading indicator from https://github.com/zeluisping/LoadingIndicators.WPF to this repo, because the repo looks unmaintained and has problems with the latest MahApps version.

Copilot:
<details>
This pull request includes significant changes to the `NETworkManager` project, focusing on the removal of an external dependency and the introduction of a custom loading indicator control. The most important changes include the removal of `LoadingIndicators.WPF` references, the addition of new loading indicator styles, and the implementation of a custom `LoadingIndicator` control.

Removal of external dependency:

* [`Source/NETworkManager/App.xaml`](diffhunk://#diff-a63735a3274126c74d95fd0fe98ae7d210c86af4b015679b9b3639f88c861b46L20-L34): Removed references to `LoadingIndicators.WPF` resource dictionaries.
* [`Source/NETworkManager/NETworkManager.csproj`](diffhunk://#diff-68f652162500df3a93957a90cdb687c0365b807e2e93282d981ae7bf89954992L69): Removed `LoadingIndicators.WPF` package reference.

Addition of custom loading indicator:

* [`Source/NETworkManager/LoadingIndicators.cs`](diffhunk://#diff-75f91a7ad7138c02c1085232be8db0fac9932c53e5792f76aba91943efb2c161R1-R139): Implemented a custom `LoadingIndicator` control with dependency properties for `SpeedRatio` and `IsActive`.
* [`Source/NETworkManager/Resources/Styles/LoadingIndicatorArcsStyle.xaml`](diffhunk://#diff-6e1e0978a6f4d6e3077ffefdce6905a01c80e3eb0ee80f00928d176a3a966c19R1-R110): Added a new style for the custom loading indicator with arc animations.
* [`Source/NETworkManager/Resources/Styles/LoadingIndicatorPulseStyle.xaml`](diffhunk://#diff-917318c404dd3b5ffb081a0e9fd51e1f0a96f0650e414e95427cf8012b17920fR1-R55): Added a new style for the custom loading indicator with pulse animations.

Namespace updates:

* [`Source/NETworkManager/Views/DiscoveryProtocolView.xaml`](diffhunk://#diff-5152ab55d492685137bdb591fc535019d95673f74394824762f57b46e5df3f6aR7-L9): Updated XAML to use the custom `LoadingIndicator` control. [[1]](diffhunk://#diff-5152ab55d492685137bdb591fc535019d95673f74394824762f57b46e5df3f6aR7-L9) [[2]](diffhunk://#diff-5152ab55d492685137bdb591fc535019d95673f74394824762f57b46e5df3f6aL263-R263)
* [`Source/NETworkManager/Views/IPApiDNSResolverWidgetView.xaml`](diffhunk://#diff-2c3485b8631573e0aadf5163dc2a9ea8b91227945e7359380aa99c63c2103c77L9-R9): Updated XAML to use the custom `LoadingIndicator` control. [[1]](diffhunk://#diff-2c3485b8631573e0aadf5163dc2a9ea8b91227945e7359380aa99c63c2103c77L9-R9) [[2]](diffhunk://#diff-2c3485b8631573e0aadf5163dc2a9ea8b91227945e7359380aa99c63c2103c77L131-R131)
* [`Source/NETworkManager/Views/IPApiIPGeolocationWidgetView.xaml`](diffhunk://#diff-1b81b2b5df2fc31e1dad500c01b9e3003cec75e86a008c18d130020be509474bR4-L9): Updated XAML to use the custom `LoadingIndicator` control.

</details>

**ToDo:**

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

---

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).