### PR TITLE
Fix: NullException in IPScanner Ping & NETBIOS for some addresses / cases

### DIFF
--- a/Source/NETworkManager.Models/Network/NetBIOSInfo.cs
+++ b/Source/NETworkManager.Models/Network/NetBIOSInfo.cs
@@ -10,9 +10,10 @@ public class NetBIOSInfo
     /// <summary>
     ///     Constructor for an unreachable host.
     /// </summary>
-    public NetBIOSInfo()
+    public NetBIOSInfo(IPAddress ipAddress)
     {
         IsReachable = false;
+        IPAddress = ipAddress;
     }
 
     /// <summary>
@@ -20,7 +21,7 @@ public class NetBIOSInfo
     /// </summary>
     /// <param name="ipAddress">IP address of the host.</param>
     /// <param name="computerName">Computer name of the host.</param>
-    /// <param name="userName">User name of the host.</param>
+    /// <param name="userName">Username of the host.</param>
     /// <param name="groupName">Group name or domain of the host.</param>
     /// <param name="macAddress">MAC address of the host.</param>
     /// <param name="vendor">Vendor of the host based on the MAC address.</param>
@@ -52,7 +53,7 @@ public class NetBIOSInfo
     public string ComputerName { get; set; }
 
     /// <summary>
-    ///     User name of the host.
+    ///     Username of the host.
     /// </summary>
     public string UserName { get; set; }
 

--- a/Source/NETworkManager.Models/Network/NetBIOSResolver.cs
+++ b/Source/NETworkManager.Models/Network/NetBIOSResolver.cs
@@ -59,17 +59,17 @@ public static class NetBIOSResolver
             var receiveTask = udpClient.ReceiveAsync();
 
             if (!receiveTask.Wait(timeout, cancellationToken))
-                return new NetBIOSInfo();
+                return new NetBIOSInfo(ipAddress);
 
             var response = receiveTask.Result;
 
             if (response.Buffer.Length < ResponseBaseLen || response.Buffer[ResponseTypePos] != ResponseTypeNbstat)
-                return new NetBIOSInfo(); // response was too short
+                return new NetBIOSInfo(ipAddress); // response was too short
 
             var count = response.Buffer[ResponseBaseLen - 1] & 0xFF;
 
             if (response.Buffer.Length < ResponseBaseLen + ResponseBlockLen * count)
-                return new NetBIOSInfo(); // data was truncated or something is wrong
+                return new NetBIOSInfo(ipAddress); // data was truncated or something is wrong
 
             var result = ExtractNames(response.Buffer, count);
 
@@ -96,7 +96,7 @@ public static class NetBIOSResolver
         }
         catch (Exception)
         {
-            return null;
+            return new NetBIOSInfo(ipAddress);
         }
         finally
         {

--- a/Source/NETworkManager/Views/IPScannerView.xaml
+++ b/Source/NETworkManager/Views/IPScannerView.xaml
@@ -632,7 +632,7 @@
                                     <ListViewItem>
                                         <Grid>
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="100" />
+                                                <ColumnDefinition MinWidth="100" Width="Auto" />
                                                 <ColumnDefinition Width="10" />
                                                 <ColumnDefinition Width="*" />
                                             </Grid.ColumnDefinitions>
@@ -645,7 +645,7 @@
                                     <ListViewItem>
                                         <Grid>
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="100" />
+                                                <ColumnDefinition MinWidth="100" Width="Auto" />
                                                 <ColumnDefinition Width="10" />
                                                 <ColumnDefinition Width="*" />
                                             </Grid.ColumnDefinitions>
@@ -664,7 +664,7 @@
                                     <ListViewItem>
                                         <Grid>
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="100" />
+                                                <ColumnDefinition MinWidth="100" Width="Auto" />
                                                 <ColumnDefinition Width="10" />
                                                 <ColumnDefinition Width="*" />
                                             </Grid.ColumnDefinitions>
@@ -677,7 +677,7 @@
                                     <ListViewItem>
                                         <Grid>
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="100" />
+                                                <ColumnDefinition MinWidth="100" Width="Auto" />
                                                 <ColumnDefinition Width="10" />
                                                 <ColumnDefinition Width="*" />
                                             </Grid.ColumnDefinitions>
@@ -817,7 +817,7 @@
                                     <ListViewItem>
                                         <Grid>
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="100" />
+                                                <ColumnDefinition MinWidth="150" Width="Auto" />
                                                 <ColumnDefinition Width="10" />
                                                 <ColumnDefinition Width="*" />
                                             </Grid.ColumnDefinitions>
@@ -830,7 +830,7 @@
                                     <ListViewItem>
                                         <Grid>
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="100" />
+                                                <ColumnDefinition MinWidth="150" Width="Auto" />
                                                 <ColumnDefinition Width="10" />
                                                 <ColumnDefinition Width="*" />
                                             </Grid.ColumnDefinitions>
@@ -843,7 +843,7 @@
                                     <ListViewItem>
                                         <Grid>
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="100" />
+                                                <ColumnDefinition MinWidth="150" Width="Auto" />
                                                 <ColumnDefinition Width="10" />
                                                 <ColumnDefinition Width="*" />
                                             </Grid.ColumnDefinitions>
@@ -856,7 +856,7 @@
                                     <ListViewItem>
                                         <Grid>
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="100" />
+                                                <ColumnDefinition MinWidth="150" Width="Auto" />
                                                 <ColumnDefinition Width="10" />
                                                 <ColumnDefinition Width="*" />
                                             </Grid.ColumnDefinitions>
@@ -869,7 +869,7 @@
                                     <ListViewItem>
                                         <Grid>
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="100" />
+                                                <ColumnDefinition MinWidth="150" Width="Auto" />
                                                 <ColumnDefinition Width="10" />
                                                 <ColumnDefinition Width="*" />
                                             </Grid.ColumnDefinitions>
@@ -929,7 +929,7 @@
                                     <ListViewItem>
                                         <Grid>
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="100" />
+                                                <ColumnDefinition MinWidth="150" Width="Auto" />
                                                 <ColumnDefinition Width="10" />
                                                 <ColumnDefinition Width="*" />
                                             </Grid.ColumnDefinitions>
@@ -977,7 +977,7 @@
                                     <ListViewItem>
                                         <Grid>
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="100" />
+                                                <ColumnDefinition MinWidth="150" Width="Auto" />
                                                 <ColumnDefinition Width="10" />
                                                 <ColumnDefinition Width="*" />
                                             </Grid.ColumnDefinitions>
@@ -990,7 +990,7 @@
                                     <ListViewItem>
                                         <Grid>
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="100" />
+                                                <ColumnDefinition MinWidth="150" Width="Auto" />
                                                 <ColumnDefinition Width="10" />
                                                 <ColumnDefinition Width="*" />
                                             </Grid.ColumnDefinitions>

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -45,7 +45,7 @@ Release date: **xx.xx.2024**
 
 - **IP Scanner**
 
-  - NullReferenceException in ICMP & NETBIOS fixed for some IP addresses. [#2964](https://github.com/BornToBeRoot/NETworkManager/pull/2964)
+  - Fixed two `NullReferenceException` in ICMP & NETBIOS for some IP addresses. [#2964](https://github.com/BornToBeRoot/NETworkManager/pull/2964)
 
 ## Dependencies, Refactoring & Documentation
 

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -22,6 +22,7 @@ Release date: **xx.xx.2024**
 ## What's new?
 
 - **WiFi**
+
   - 6 GHz networks are not supported. [#2912](https://github.com/BornToBeRoot/NETworkManager/pull/2912) [#2928](https://github.com/BornToBeRoot/NETworkManager/pull/2928)
   - `WPA3 Personal (SAE)`, `WPA3 Enterprise` and `WPA3 Enterprise (192-bit)` are now supported. [#2912](https://github.com/BornToBeRoot/NETworkManager/pull/2912)
   - `802.11be` (`EHT`) is now supported. [#2912](https://github.com/BornToBeRoot/NETworkManager/pull/2912)
@@ -39,11 +40,16 @@ Release date: **xx.xx.2024**
 - Changed the Welcome dialog from `MahApps.Metro.Controls.Dialogs` to `MahApps.Metro.SimpleChildWindow`, so the main window can be dragged and resized on the first start. [#2914](https://github.com/BornToBeRoot/NETworkManager/pull/2914)
 
 - **WiFi**
+
   - Fixed a bug that caused the scan process to crash when a 6 GHz network was found. [#2912](https://github.com/BornToBeRoot/NETworkManager/pull/2912)
+
+- **IP Scanner**
+
+  - NullReferenceException in ICMP & NETBIOS fixed for some IP addresses. [#2964](https://github.com/BornToBeRoot/NETworkManager/pull/2964)
 
 ## Dependencies, Refactoring & Documentation
 
-Migrated code for some loading indicators from the library [LoadingIndicators.WPF] (https://github.com/zeluisping/LoadingIndicators.WPF) to the NETworkManager repo, as the original repo looks unmaintained and has problems with MahApps.Metro version 2 and later. [#2963](https://github.com/BornToBeRoot/NETworkManager/pull/2963)
+- Migrated code for some loading indicators from the library [LoadingIndicators.WPF] (https://github.com/zeluisping/LoadingIndicators.WPF) to the NETworkManager repo, as the original repo looks unmaintained and has problems with MahApps.Metro version 2 and later. [#2963](https://github.com/BornToBeRoot/NETworkManager/pull/2963)
 - Code cleanup & refactoring [#2940](https://github.com/BornToBeRoot/NETworkManager/pull/2940)
 - Language files updated via [#transifex](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Ftransifex-integration)
 - Dependencies updated via [#dependabot](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Fdependabot)


### PR DESCRIPTION
## Changes proposed in this pull request

- NullException in PING for some addresses fixed
- NullException in NETBIOS for some addresses fixed
- IP Scanner view improved

## Related issue(s)

- Fixes #2788

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request includes a series of changes to the `NETworkManager` project, focusing on improving the IP scanner functionality and updating the UI layout. The key changes involve modifying the `NetBIOSInfo` class to include an IP address, updating the `PingAsync` method for better error handling, and adjusting the layout of list view items in the `IPScannerView.xaml` file.

### Improvements to IP Scanner functionality:

* [`Source/NETworkManager.Models/Network/IPScanner.cs`](diffhunk://#diff-cdb9f5d1fb8890963922bd4d9847d75104c24d4f843c7f084cd4fe064c2fc215L96-R96): Updated the `ScanAsync` method to pass the IP address to the `NetBIOSInfo` constructor when NetBIOS lookup is not enabled.
* [`Source/NETworkManager.Models/Network/IPScanner.cs`](diffhunk://#diff-cdb9f5d1fb8890963922bd4d9847d75104c24d4f843c7f084cd4fe064c2fc215L216-R263): Enhanced the `PingAsync` method to handle different address families using a switch statement and added error handling for unknown ping statuses.

### Enhancements to `NetBIOSInfo` and `NetBIOSResolver`:

* [`Source/NETworkManager.Models/Network/NetBIOSInfo.cs`](diffhunk://#diff-7c55b5a121f2636e3062f72afc7cce031ef3cbb9c9a0519ff639def46d48e904L13-R16): Modified the `NetBIOSInfo` constructor to accept an `IPAddress` parameter and set it as a property.
* [`Source/NETworkManager.Models/Network/NetBIOSResolver.cs`](diffhunk://#diff-1a58333383937918493ad81dc801be4ccb25c3f82d8167ab23e1ced15264db59L62-R72): Updated the `ResolveAsync` method to return a `NetBIOSInfo` object with the IP address in various error handling scenarios. [[1]](diffhunk://#diff-1a58333383937918493ad81dc801be4ccb25c3f82d8167ab23e1ced15264db59L62-R72) [[2]](diffhunk://#diff-1a58333383937918493ad81dc801be4ccb25c3f82d8167ab23e1ced15264db59L99-R99)

### UI layout adjustments:

* [`Source/NETworkManager/Views/IPScannerView.xaml`](diffhunk://#diff-2abe8b94765df22bf4c72b246cad6ddea39d5c7029bc2d141dcb77ddd18a80a5L635-R635): Changed the column definitions of multiple `ListViewItem` elements to have a `MinWidth` of `100` or `150` and a `Width` of `Auto` for better layout flexibility. [[1]](diffhunk://#diff-2abe8b94765df22bf4c72b246cad6ddea39d5c7029bc2d141dcb77ddd18a80a5L635-R635) [[2]](diffhunk://#diff-2abe8b94765df22bf4c72b246cad6ddea39d5c7029bc2d141dcb77ddd18a80a5L648-R648) [[3]](diffhunk://#diff-2abe8b94765df22bf4c72b246cad6ddea39d5c7029bc2d141dcb77ddd18a80a5L667-R667) [[4]](diffhunk://#diff-2abe8b94765df22bf4c72b246cad6ddea39d5c7029bc2d141dcb77ddd18a80a5L680-R680) [[5]](diffhunk://#diff-2abe8b94765df22bf4c72b246cad6ddea39d5c7029bc2d141dcb77ddd18a80a5L820-R820) [[6]](diffhunk://#diff-2abe8b94765df22bf4c72b246cad6ddea39d5c7029bc2d141dcb77ddd18a80a5L833-R833) [[7]](diffhunk://#diff-2abe8b94765df22bf4c72b246cad6ddea39d5c7029bc2d141dcb77ddd18a80a5L846-R846) [[8]](diffhunk://#diff-2abe8b94765df22bf4c72b246cad6ddea39d5c7029bc2d141dcb77ddd18a80a5L859-R859) [[9]](diffhunk://#diff-2abe8b94765df22bf4c72b246cad6ddea39d5c7029bc2d141dcb77ddd18a80a5L872-R872) [[10]](diffhunk://#diff-2abe8b94765df22bf4c72b246cad6ddea39d5c7029bc2d141dcb77ddd18a80a5L932-R932) [[11]](diffhunk://#diff-2abe8b94765df22bf4c72b246cad6ddea39d5c7029bc2d141dcb77ddd18a80a5L980-R980) [[12]](diffhunk://#diff-2abe8b94765df22bf4c72b246cad6ddea39d5c7029bc2d141dcb77ddd18a80a5L993-R993)

</details>

## To-Do

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
