### PR TITLE
Feature: Scale RDP session based on per monitor DPI & make reconnect faster

### DIFF
--- a/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
+++ b/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
@@ -212,7 +212,7 @@ public sealed partial class DragablzTabHostWindow : INotifyPropertyChanged
     private void RemoteDesktop_AdjustScreenAction(object view)
     {
         if (view is RemoteDesktopControl control)
-            control.AdjustScreen();
+            control.AdjustScreen(force:true);
     }
 
     public ICommand RemoteDesktop_SendCtrlAltDelCommand =>

--- a/Source/NETworkManager/Controls/IDragablzTabItem.cs
+++ b/Source/NETworkManager/Controls/IDragablzTabItem.cs
@@ -13,5 +13,6 @@ public interface IDragablzTabItem
     /// </summary>
     public void CloseTab()
     {
+        
     }
 }

--- a/Source/NETworkManager/Controls/RemoteDesktopControl.xaml
+++ b/Source/NETworkManager/Controls/RemoteDesktopControl.xaml
@@ -9,7 +9,6 @@
                        xmlns:localization="clr-namespace:NETworkManager.Localization.Resources;assembly=NETworkManager.Localization"
                        xmlns:local="clr-namespace:NETworkManager.Controls"
                        xmlns:settings="clr-namespace:NETworkManager.Settings;assembly=NETworkManager.Settings"
-                       xmlns:windowsForms="clr-namespace:System.Windows.Forms;assembly=System.Windows.Forms"
                        mc:Ignorable="d" Loaded="UserControl_Loaded"                       
                        d:DataContext="{d:DesignInstance local:RemoteDesktopControl}">
     <local:UserControlBase.Resources>

--- a/Source/NETworkManager/Controls/RemoteDesktopControl.xaml
+++ b/Source/NETworkManager/Controls/RemoteDesktopControl.xaml
@@ -20,7 +20,8 @@
     <Grid x:Name="RdpGrid" SizeChanged="RdpGrid_SizeChanged">
         <WindowsFormsHost MaxWidth="{Binding RdpClientWidth, Mode=OneWay}"
                           MaxHeight="{Binding RdpClientHeight, Mode=OneWay}"
-                          Background="{DynamicResource ResourceKey=MahApps.Brushes.Window.Background}">
+                          Background="{DynamicResource ResourceKey=MahApps.Brushes.Window.Background}"
+                          DpiChanged="WindowsFormsHost_DpiChanged">            
             <WindowsFormsHost.Style>
                 <Style TargetType="{x:Type WindowsFormsHost}">
                     <Style.Triggers>
@@ -38,7 +39,7 @@
                     </Style.Triggers>
                 </Style>
             </WindowsFormsHost.Style>
-            <mstsc:AxMsRdpClient9NotSafeForScripting x:Name="RdpClient" />
+            <mstsc:AxMsRdpClient10NotSafeForScripting x:Name="RdpClient" />
         </WindowsFormsHost>
         <Grid VerticalAlignment="Center" HorizontalAlignment="Center" TextBlock.TextAlignment="Center"
               Visibility="{Binding IsConnected, Converter={StaticResource BooleanReverseToVisibilityCollapsedConverter}}">

--- a/Source/NETworkManager/Controls/RemoteDesktopControl.xaml
+++ b/Source/NETworkManager/Controls/RemoteDesktopControl.xaml
@@ -9,7 +9,8 @@
                        xmlns:localization="clr-namespace:NETworkManager.Localization.Resources;assembly=NETworkManager.Localization"
                        xmlns:local="clr-namespace:NETworkManager.Controls"
                        xmlns:settings="clr-namespace:NETworkManager.Settings;assembly=NETworkManager.Settings"
-                       mc:Ignorable="d" Loaded="UserControl_Loaded"
+                       xmlns:windowsForms="clr-namespace:System.Windows.Forms;assembly=System.Windows.Forms"
+                       mc:Ignorable="d" Loaded="UserControl_Loaded"                       
                        d:DataContext="{d:DesignInstance local:RemoteDesktopControl}">
     <local:UserControlBase.Resources>
         <converters:BooleanReverseConverter x:Key="BooleanReverseConverter" />
@@ -17,10 +18,10 @@
         <converters:BooleanReverseToVisibilityHiddenConverter x:Key="BooleanReverseToVisibilityHiddenConverter" />
         <converters:BooleanToVisibilityCollapsedConverter x:Key="BooleanToVisibilityCollapsedConverter" />
     </local:UserControlBase.Resources>
-    <Grid x:Name="RdpGrid" SizeChanged="RdpGrid_SizeChanged">
-        <WindowsFormsHost MaxWidth="{Binding RdpClientWidth, Mode=OneWay}"
-                          MaxHeight="{Binding RdpClientHeight, Mode=OneWay}"
-                          Background="{DynamicResource ResourceKey=MahApps.Brushes.Window.Background}"
+    <Grid x:Name="RdpGrid">
+        <WindowsFormsHost MaxWidth="{Binding WindowsFormsHostMaxWidth, Mode=OneWay}"
+                          MaxHeight="{Binding WindowsFormsHostMaxHeight, Mode=OneWay}"
+                          Background="{DynamicResource ResourceKey=MahApps.Brushes.Window.Background}"                          
                           DpiChanged="WindowsFormsHost_DpiChanged">            
             <WindowsFormsHost.Style>
                 <Style TargetType="{x:Type WindowsFormsHost}">
@@ -32,10 +33,7 @@
                         </DataTrigger>
                         <DataTrigger Binding="{Binding IsConnected}" Value="False">
                             <Setter Property="Visibility" Value="Hidden" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding IsReconnecting}" Value="True">
-                            <Setter Property="Visibility" Value="Hidden" />
-                        </DataTrigger>
+                        </DataTrigger>                        
                     </Style.Triggers>
                 </Style>
             </WindowsFormsHost.Style>
@@ -66,18 +64,6 @@
             <TextBlock Grid.Row="3" Text="{x:Static localization:Strings.ConnectingDots}"
                        Style="{StaticResource MessageTextBlock}"
                        Visibility="{Binding IsConnecting, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
-        </Grid>
-        <Grid VerticalAlignment="Center" HorizontalAlignment="Center" TextBlock.TextAlignment="Center"
-              Visibility="{Binding IsReconnecting, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="20" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-            <mah:ProgressRing Grid.Row="0" Grid.RowSpan="2" Height="50" Width="50" />
-            <TextBlock Grid.Row="3" Text="{x:Static localization:Strings.ConnectingDots}"
-                       Style="{StaticResource MessageTextBlock}" />
-        </Grid>
+        </Grid>        
     </Grid>
 </local:UserControlBase>

--- a/Source/NETworkManager/Controls/RemoteDesktopControl.xaml.cs
+++ b/Source/NETworkManager/Controls/RemoteDesktopControl.xaml.cs
@@ -371,7 +371,7 @@ public partial class RemoteDesktopControl : UserControlBase, IDragablzTabItem
         RdpClient.FullScreen = true;
     }
 
-    public async void AdjustScreen()
+    public void AdjustScreen()
     {
         if (IsConnecting)
             return;

--- a/Source/NETworkManager/ViewModels/RemoteDesktopHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/RemoteDesktopHostViewModel.cs
@@ -1,4 +1,14 @@
-﻿using System;
+﻿using Dragablz;
+using MahApps.Metro.Controls.Dialogs;
+using NETworkManager.Controls;
+using NETworkManager.Localization.Resources;
+using NETworkManager.Models;
+using NETworkManager.Models.RemoteDesktop;
+using NETworkManager.Profiles;
+using NETworkManager.Settings;
+using NETworkManager.Utilities;
+using NETworkManager.Views;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -9,16 +19,6 @@ using System.Windows;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Threading;
-using Dragablz;
-using MahApps.Metro.Controls.Dialogs;
-using NETworkManager.Controls;
-using NETworkManager.Localization.Resources;
-using NETworkManager.Models;
-using NETworkManager.Models.RemoteDesktop;
-using NETworkManager.Profiles;
-using NETworkManager.Settings;
-using NETworkManager.Utilities;
-using NETworkManager.Views;
 using RemoteDesktop = NETworkManager.Profiles.Application.RemoteDesktop;
 
 namespace NETworkManager.ViewModels;
@@ -574,6 +574,12 @@ public class RemoteDesktopHostViewModel : ViewModelBase, IProfileManager
         _isViewActive = false;
     }
 
+    public void UpdateOnWindowResize()
+    {
+        foreach (var tab in TabItems)
+            (tab.View as RemoteDesktopControl)?.UpdateOnWindowResize();
+    }
+
     private void SetProfilesView(ProfileInfo profile = null)
     {
         Profiles = new CollectionViewSource
@@ -652,4 +658,6 @@ public class RemoteDesktopHostViewModel : ViewModelBase, IProfileManager
     }
 
     #endregion
+
+
 }

--- a/Source/NETworkManager/ViewModels/RemoteDesktopHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/RemoteDesktopHostViewModel.cs
@@ -281,7 +281,7 @@ public class RemoteDesktopHostViewModel : ViewModelBase, IProfileManager
     private void AdjustScreenAction(object view)
     {
         if (view is RemoteDesktopControl control)
-            control.AdjustScreen();
+            control.AdjustScreen(force:true);
     }
 
     public ICommand SendCtrlAltDelCommand => new RelayCommand(SendCtrlAltDelAction, IsConnected_CanExecute);

--- a/Source/NETworkManager/Views/RemoteDesktopHostView.xaml.cs
+++ b/Source/NETworkManager/Views/RemoteDesktopHostView.xaml.cs
@@ -1,9 +1,9 @@
-﻿using System.Threading.Tasks;
+﻿using MahApps.Metro.Controls.Dialogs;
+using NETworkManager.ViewModels;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using MahApps.Metro.Controls.Dialogs;
-using NETworkManager.ViewModels;
 
 namespace NETworkManager.Views;
 
@@ -53,5 +53,10 @@ public partial class RemoteDesktopHostView
     public void OnViewVisible()
     {
         _viewModel.OnViewVisible();
+    }
+
+    public void UpdateOnWindowResize()
+    {
+        _viewModel.UpdateOnWindowResize();
     }
 }

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -17,7 +17,9 @@ Release date: **xx.xx.2024**
 
 ## Breaking Changes
 
-- Minimum supported Windows version increased to `22H2`. [#2912](https://github.com/BornToBeRoot/NETworkManager/pull/2912)
+- Minimum supported Windows version increased to `22H2` to support:
+  - WiFi 6 GHz, WPA3, 802.11be [#2912](https://github.com/BornToBeRoot/NETworkManager/pull/2912)
+  - Remote Desktop high DPI, scaling and resizing [#2968](https://github.com/BornToBeRoot/NETworkManager/pull/2968)
 
 ## What's new?
 
@@ -26,6 +28,17 @@ Release date: **xx.xx.2024**
   - 6 GHz networks are not supported. [#2912](https://github.com/BornToBeRoot/NETworkManager/pull/2912) [#2928](https://github.com/BornToBeRoot/NETworkManager/pull/2928)
   - `WPA3 Personal (SAE)`, `WPA3 Enterprise` and `WPA3 Enterprise (192-bit)` are now supported. [#2912](https://github.com/BornToBeRoot/NETworkManager/pull/2912)
   - `802.11be` (`EHT`) is now supported. [#2912](https://github.com/BornToBeRoot/NETworkManager/pull/2912)
+
+- **Remote Desktop**
+
+  - Scale rdp session and control to support high DPI (e.g. per Monitor DPI like 125%, 150%, etc.). [#2968](https://github.com/BornToBeRoot/NETworkManager/pull/2968)
+  - Resizing now uses [`IMsRdpClient9::UpdateSessionDisplaySettings`](<https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/mt703457(v=vs.85)>) instead of [`IMsRdpClient::Reconnect`](https://learn.microsoft.com/en-us/windows/win32/termserv/imsrdpclient8-reconnect) to support scaling and faster resizing (without the need of reconnecting). [#2968](https://github.com/BornToBeRoot/NETworkManager/pull/2968).
+
+  :::warning
+
+  The new features for high DPI, scaling and resizing may cause issues or doesn't work with legacy servers/clients. Please report any issues you find here: [#2911](https://github.com/BornToBeRoot/NETworkManager/issues/2911)
+
+  :::
 
 ## Improvements
 

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -19,7 +19,7 @@ Release date: **xx.xx.2024**
 
 - Minimum supported Windows version increased to `22H2` to support:
   - WiFi 6 GHz, WPA3, 802.11be [#2912](https://github.com/BornToBeRoot/NETworkManager/pull/2912)
-  - Remote Desktop high DPI, scaling and resizing [#2968](https://github.com/BornToBeRoot/NETworkManager/pull/2968)
+  - Remote Desktop high DPI, scaling and fast resizing [#2968](https://github.com/BornToBeRoot/NETworkManager/pull/2968)
 
 ## What's new?
 


### PR DESCRIPTION
## Changes proposed in this pull request

- Use per Monitor DPI to scale RDP session
- Use DesktopScaleFactor & DeviceScaleFactor
- Use UpdateSessionDisplaySettings instead of Reconnect()

## Known issues / to do

- [x] When connecting with a fixed size... the control (not the session) doesn't size correct:

<details>
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/30ed0122-dea2-4838-82e9-4b58959a2d13)
</details>

- https://github.com/BornToBeRoot/NETworkManager/issues/2971
- https://github.com/BornToBeRoot/NETworkManager/issues/2972

## Related issue(s)

- #2911

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>


This pull request includes several improvements to the `RemoteDesktopControl` component in the `NETworkManager` project. The changes focus on enhancing DPI scaling support, improving screen adjustment logic, and updating dependencies.

### Enhancements to DPI scaling and screen adjustment:

* Added `WindowsFormsHost_DpiChanged` event handler in `RemoteDesktopControl.xaml` to handle DPI changes dynamically.
* Introduced methods `GetDesktopScaleFactor`, `GetDeviceScaleFactor`, and `GetDpiScaleFactor` to calculate appropriate scaling factors based on DPI in `RemoteDesktopControl.xaml.cs`.
* Updated the `Connect`, `Reconnect`, and `AdjustScreen` methods to apply DPI scaling factors and adjust the screen size accordingly. [[1]](diffhunk://#diff-12cd39721d86b0dfa0e88a33ab58efdb58f74b01b9b722ddcf7901c7cdd82e32R210-R234) [[2]](diffhunk://#diff-12cd39721d86b0dfa0e88a33ab58efdb58f74b01b9b722ddcf7901c7cdd82e32L320-R363) [[3]](diffhunk://#diff-12cd39721d86b0dfa0e88a33ab58efdb58f74b01b9b722ddcf7901c7cdd82e32L340-R450)

### Dependency updates:

* Replaced `AxMsRdpClient9NotSafeForScripting` with `AxMsRdpClient10NotSafeForScripting` in `RemoteDesktopControl.xaml` to use a more recent version of the RDP client.

### Logging and debugging improvements:

* Added log4net logging to `RemoteDesktopControl.xaml.cs` for better error tracking and debugging.

These changes collectively improve the handling of high-DPI displays and ensure that the remote desktop control adjusts its size and scaling dynamically based on the current DPI settings.

</details>

## To-Do

- [x] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Documentation) to reflect this changes
- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
