### PR TITLE
Feature: RDP session resize event in dragged out tab / split view

### DIFF
--- a/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
+++ b/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Input;
+using System.Windows.Interop;
 using Dragablz;
 using MahApps.Metro.Controls.Dialogs;
 using NETworkManager.Localization;
@@ -60,13 +62,8 @@ public sealed partial class DragablzTabHostWindow : INotifyPropertyChanged
         if (!_embeddedWindowApplicationNames.Contains(ApplicationName))
             return;
 
-        var window = Application.Current.Windows.OfType<Window>().FirstOrDefault(x => x.IsActive);
-
-        if (window == null)
-            return;
-
         // Find all TabablzControl in the active window
-        foreach (var tabablzControl in VisualTreeHelper.FindVisualChildren<TabablzControl>(window))
+        foreach (var tabablzControl in VisualTreeHelper.FindVisualChildren<TabablzControl>(this))
         {
             // Skip if no items
             if (tabablzControl.Items.Count == 0)
@@ -74,7 +71,7 @@ public sealed partial class DragablzTabHostWindow : INotifyPropertyChanged
 
             // Focus embedded window in the selected tab
             (((DragablzTabItem)tabablzControl.SelectedItem)?.View as IEmbeddedWindow)?.FocusEmbeddedWindow();
-
+            
             break;
         }
     }
@@ -212,7 +209,7 @@ public sealed partial class DragablzTabHostWindow : INotifyPropertyChanged
     private void RemoteDesktop_AdjustScreenAction(object view)
     {
         if (view is RemoteDesktopControl control)
-            control.AdjustScreen(force:true);
+            control.AdjustScreen(force: true);
     }
 
     public ICommand RemoteDesktop_SendCtrlAltDelCommand =>
@@ -377,14 +374,8 @@ public sealed partial class DragablzTabHostWindow : INotifyPropertyChanged
 
     private void DragablzTabHostWindow_OnClosing(object sender, CancelEventArgs e)
     {
-        // Close all tabs properly when the window is closing
-        var window = Application.Current.Windows.OfType<Window>().FirstOrDefault(x => x.IsActive);
-
-        if (window == null)
-            return;
-
         // Find all TabablzControl in the active window
-        foreach (var tabablzControl in VisualTreeHelper.FindVisualChildren<TabablzControl>(window))
+        foreach (var tabablzControl in VisualTreeHelper.FindVisualChildren<TabablzControl>(this))
         foreach (var tabItem in tabablzControl.Items.OfType<DragablzTabItem>())
             ((IDragablzTabItem)tabItem.View).CloseTab();
 
@@ -435,6 +426,74 @@ public sealed partial class DragablzTabHostWindow : INotifyPropertyChanged
             case ApplicationName.WebConsole:
                 ConfigurationManager.Current.IsWebConsoleWindowDragging = e.NewValue;
                 break;
+        }
+    }
+
+    #endregion
+
+    #region Handle WndProc messages (handle window size events)
+
+    private HwndSource _hwndSource;
+
+    private const int WmExitSizeMove = 0x232;
+    private const int WmSysCommand = 0x0112;
+    private const int ScMaximize = 0xF030;
+    private const int ScRestore = 0xF120;
+
+    protected override void OnSourceInitialized(EventArgs e)
+    {
+        base.OnSourceInitialized(e);
+
+        _hwndSource = HwndSource.FromHwnd(new WindowInteropHelper(this).Handle);
+        _hwndSource?.AddHook(HwndHook);
+    }
+
+    [DebuggerStepThrough]
+    private IntPtr HwndHook(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+    {
+        // Window size events
+        switch (msg)
+        {
+            // Handle window resize and move events
+            case WmExitSizeMove:
+                UpdateOnWindowResize();
+                break;
+
+            // Handle system commands (like maximize and restore)
+            case WmSysCommand:
+
+                switch (wParam.ToInt32())
+                {
+                    // Window is maximized
+                    case ScMaximize:
+                    // Window is restored (back to normal size from maximized state)
+                    case ScRestore:
+                        UpdateOnWindowResize();
+                        break;
+                }
+
+                break;
+        }
+
+        handled = false;
+
+        return IntPtr.Zero;
+    }
+
+    private void UpdateOnWindowResize()
+    { 
+        // Find all TabablzControl
+        foreach (var tabablzControl in VisualTreeHelper.FindVisualChildren<TabablzControl>(this))
+        {
+            // Skip if no items
+            if (tabablzControl.Items.Count == 0)
+                continue;
+            
+            foreach (var item in tabablzControl.Items.OfType<DragablzTabItem>())
+            {
+                if (item.View is RemoteDesktopControl control)
+                    control.UpdateOnWindowResize();
+            }
         }
     }
 

--- a/Source/NETworkManager/Controls/IEmbeddedWindow.cs
+++ b/Source/NETworkManager/Controls/IEmbeddedWindow.cs
@@ -11,5 +11,6 @@ public interface IEmbeddedWindow
     /// </summary>
     public void FocusEmbeddedWindow()
     {
+        
     }
 }

--- a/Source/NETworkManager/Controls/RemoteDesktopControl.xaml.cs
+++ b/Source/NETworkManager/Controls/RemoteDesktopControl.xaml.cs
@@ -100,7 +100,6 @@ public partial class RemoteDesktopControl : UserControlBase, IDragablzTabItem
             OnPropertyChanged();
         }
     }
-
     #endregion
 
     #region Constructor, load

--- a/Source/NETworkManager/ViewModels/AWSSessionManagerHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/AWSSessionManagerHostViewModel.cs
@@ -943,6 +943,7 @@ public class AWSSessionManagerHostViewModel : ViewModelBase, IProfileManager
 
             // Focus embedded window in the selected tab
             (((DragablzTabItem)tabablzControl.SelectedItem)?.View as IEmbeddedWindow)?.FocusEmbeddedWindow();
+            
             break;
         }
     }

--- a/Source/NETworkManager/ViewModels/PowerShellHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PowerShellHostViewModel.cs
@@ -594,6 +594,7 @@ public class PowerShellHostViewModel : ViewModelBase, IProfileManager
 
             // Focus embedded window in the selected tab
             (((DragablzTabItem)tabablzControl.SelectedItem)?.View as IEmbeddedWindow)?.FocusEmbeddedWindow();
+            
             break;
         }
     }

--- a/Source/NETworkManager/ViewModels/PuTTYHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PuTTYHostViewModel.cs
@@ -678,6 +678,7 @@ public class PuTTYHostViewModel : ViewModelBase, IProfileManager
 
             // Focus embedded window in the selected tab
             (((DragablzTabItem)tabablzControl.SelectedItem)?.View as IEmbeddedWindow)?.FocusEmbeddedWindow();
+            
             break;
         }
     }

--- a/Source/NETworkManager/ViewModels/RemoteDesktopHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/RemoteDesktopHostViewModel.cs
@@ -574,12 +574,6 @@ public class RemoteDesktopHostViewModel : ViewModelBase, IProfileManager
         _isViewActive = false;
     }
 
-    public void UpdateOnWindowResize()
-    {
-        foreach (var tab in TabItems)
-            (tab.View as RemoteDesktopControl)?.UpdateOnWindowResize();
-    }
-
     private void SetProfilesView(ProfileInfo profile = null)
     {
         Profiles = new CollectionViewSource

--- a/Source/NETworkManager/Views/RemoteDesktopHostView.xaml.cs
+++ b/Source/NETworkManager/Views/RemoteDesktopHostView.xaml.cs
@@ -54,9 +54,4 @@ public partial class RemoteDesktopHostView
     {
         _viewModel.OnViewVisible();
     }
-
-    public void UpdateOnWindowResize()
-    {
-        _viewModel.UpdateOnWindowResize();
-    }
 }

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -63,6 +63,6 @@ Release date: **xx.xx.2024**
 ## Dependencies, Refactoring & Documentation
 
 - Migrated code for some loading indicators from the library [LoadingIndicators.WPF] (https://github.com/zeluisping/LoadingIndicators.WPF) to the NETworkManager repo, as the original repo looks unmaintained and has problems with MahApps.Metro version 2 and later. [#2963](https://github.com/BornToBeRoot/NETworkManager/pull/2963)
-- Code cleanup & refactoring [#2940](https://github.com/BornToBeRoot/NETworkManager/pull/2940)
+- Code cleanup & refactoring [#2940](https://github.com/BornToBeRoot/NETworkManager/pull/2940) [#2976](https://github.com/BornToBeRoot/NETworkManager/pull/2976)
 - Language files updated via [#transifex](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Ftransifex-integration)
 - Dependencies updated via [#dependabot](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Fdependabot)


### PR DESCRIPTION
## Changes proposed in this pull request

- Update desktop size if view is split in dragablz
- Added size changed event in dragged out window

## Related issue(s)

- Fix #2971
- Fix #2972

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request includes significant changes to handle window resize events and improve the focus and closure of embedded windows. The most important changes include adding a new method to handle window size events, modifying the logic for focusing embedded windows, and cleaning up unnecessary code.

Enhancements to window size handling:

* [`Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs`](diffhunk://#diff-1df06ffe3e7e8d00cff91456190920240b86ffc6413a9c47441e467c01397d09R433-R500): Added a new method `UpdateOnWindowResize` to handle window resize events, and integrated it with the `HwndHook` method to handle system commands like maximize and restore.
* [`Source/NETworkManager/MainWindow.xaml.cs`](diffhunk://#diff-8eb3369dc576dfdb97b9259dd4693297a85e4ecaf629a48d95b8e6ab8b8c697dR1594-R1610): Added a similar `UpdateOnWindowResize` method and integrated it into the `HwndHook` method to handle window resize and system commands. [[1]](diffhunk://#diff-8eb3369dc576dfdb97b9259dd4693297a85e4ecaf629a48d95b8e6ab8b8c697dR1594-R1610) [[2]](diffhunk://#diff-8eb3369dc576dfdb97b9259dd4693297a85e4ecaf629a48d95b8e6ab8b8c697dR1620-R1635)

Improvements to embedded window focus:

* [`Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs`](diffhunk://#diff-1df06ffe3e7e8d00cff91456190920240b86ffc6413a9c47441e467c01397d09L63-R66): Modified the `FocusEmbeddedWindow` method to find `TabablzControl` in the current window instead of the active window.
* `Source/NETworkManager/ViewModels/AWSSessionManagerHostViewModel.cs`, `Source/NETworkManager/ViewModels/PowerShellHostViewModel.cs`, `Source/NETworkManager/ViewModels/PuTTYHostViewModel.cs`: Added whitespace for better readability in the `FocusEmbeddedWindow` method. [[1]](diffhunk://#diff-5de81dade43206c739bb5a060216c87326954e9246add19eb1475458b1e9990cR946) [[2]](diffhunk://#diff-0a216588b4c5da978a7f923c2641527b8b683001f63747b19cd57a8433791fecR597) [[3]](diffhunk://#diff-9d56843236450c40460e6454926ee2c367e54f026317778b8211299c1bdcbedcR681)

Code cleanup:

* [`Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs`](diffhunk://#diff-1df06ffe3e7e8d00cff91456190920240b86ffc6413a9c47441e467c01397d09L380-R378): Removed redundant code for finding the active window in the `MetroWindow_Activated` method.
* `Source/NETworkManager/ViewModels/RemoteDesktopHostViewModel.cs`, `Source/NETworkManager/Views/RemoteDesktopHostView.xaml.cs`: Removed the `UpdateOnWindowResize` method as it is now handled in the main window class. [[1]](diffhunk://#diff-8a50666e850b4c9082aff517feb48fc5331901f588b7ece6a7771d22e914e8f9L577-L582) [[2]](diffhunk://#diff-5b16f512b0e4c0f9c4e16b51a88768f14415e5df774ed099788bf33d5e97220eL57-L61)

</details>

## To-Do

- [ ] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Documentation) to reflect this changes
- [ ] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/docs/Changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/Contributors.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
