### PR TITLE
Fix: Use ObservableCollection / avoid multiple calls

### DIFF
--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -27,13 +27,17 @@ Release date: **xx.xx.2025**
 
 **PuTTY**
 
-- Find `putty.exe` and `powershell.exe` executable by path, similar to `where.exe`. [#2962](https://github.com/BornToBeRoot/NETworkManager/pull/2962)
+- Find `putty.exe` executable by path, similar to `where.exe`. [#2962](https://github.com/BornToBeRoot/NETworkManager/pull/2962)
 
 **AWS Session Manager**
 
 - Find `pwsh.exe` and `powershell.exe` executable by path, similar to `where.exe`. [#2962](https://github.com/BornToBeRoot/NETworkManager/pull/2962)
 
 ## Bugfixes
+
+**Network Interface**
+
+- Re-select the network interface after a network change or configuration update. Thanks to [@Ghislain1](https://github.com/Ghislain1) [#3004](https://github.com/BornToBeRoot/NETworkManager/pull/3004) [#2962](https://github.com/BornToBeRoot/NETworkManager/pull/2962)
 
 ## Dependencies, Refactoring & Documentation
 


### PR DESCRIPTION
## Changes proposed in this pull request

- Re-select the network interface after a network change or configuration update.
-

## Related issue(s)

- Fixes #2657

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request includes several changes to the `NetworkInterfaceViewModel` class in the `Source/NETworkManager/ViewModels/NetworkInterfaceViewModel.cs` file. The main improvements are the transition from `List` to `ObservableCollection` for network interfaces, and the addition of checks to prevent multiple reloads of network interfaces.

Changes to data structures and initialization:

* Changed `_networkInterfaces` from `List<NetworkInterfaceInfo>` to `ObservableCollection<NetworkInterfaceInfo>` to better support dynamic updates in the UI.
* Updated the `NetworkInterfaces` property to use `ObservableCollection<NetworkInterfaceInfo>`.

Improvements to network interface loading:

* Modified `LoadNetworkInterfaces` to add network interfaces directly to the `ObservableCollection` instead of replacing the entire collection.
* Added a check in `ReloadNetworkInterfaces` to prevent multiple reloads if a reload is already in progress.
* Enhanced `ReloadNetworkInterfaces` to clear and repopulate the `ObservableCollection` on the UI thread to ensure thread safety and UI consistency.

</details>

## To-Do

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
