### PR TITLE
Fix: Set PowerShell console color

### DIFF
--- a/Source/NETworkManager/ViewModels/PowerShellHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PowerShellHostViewModel.cs
@@ -696,7 +696,7 @@ public class PowerShellHostViewModel : ViewModelBase, IProfileManager
 
         PowerShell.WriteDefaultProfileToRegistry(
             SettingsManager.Current.Appearance_Theme,
-            SettingsManager.Current.AWSSessionManager_ApplicationFilePath);
+            SettingsManager.Current.PowerShell_ApplicationFilePath);
     }
 
     #endregion

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -43,6 +43,10 @@ Release date: **xx.xx.2025**
 
 - Re-select the network interface after a network change or configuration update. Thanks to [@Ghislain1](https://github.com/Ghislain1) [#3004](https://github.com/BornToBeRoot/NETworkManager/pull/3004) [#2962](https://github.com/BornToBeRoot/NETworkManager/pull/2962)
 
+**PowerShell**
+
+- Set PowerShell console color for correct path... [#3023](https://github.com/BornToBeRoot/NETworkManager/pull/3023)
+
 ## Dependencies, Refactoring & Documentation
 
 - Code cleanup & refactoring


### PR DESCRIPTION
## Changes proposed in this pull request

- Set PowerShell console color for correct path
-

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request includes a small change to the `Source/NETworkManager/ViewModels/PowerShellHostViewModel.cs` file. The change updates the `WriteDefaultProfileToRegistry` method to use the correct application file path setting.

</details>

## To-Do

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
