### PR TITLE
Fix: Dialog unlock size

### DIFF
--- a/Source/NETworkManager/MainWindow.xaml
+++ b/Source/NETworkManager/MainWindow.xaml
@@ -16,9 +16,10 @@
                  xmlns:networkManager="clr-namespace:NETworkManager"
                  xmlns:models="clr-namespace:NETworkManager.Models;assembly=NETworkManager.Models"
                  mc:Ignorable="d"
-                 Style="{DynamicResource DefaultWindow}"
-                 dialogs:DialogParticipation.Register="{Binding}"
-                 MinWidth="800" Width="1024" Height="768" MinHeight="600"
+                 Style="{DynamicResource ResourceKey=DefaultWindow}"
+                 dialogs:DialogParticipation.Register="{Binding }"
+                 MinWidth="800" MinHeight="600"
+                 Width="1024" Height="768" 
                  SaveWindowPosition="True" TitleAlignment="Left"
                  ContentRendered="MetroMainWindow_ContentRendered" StateChanged="MetroWindowMain_StateChanged"
                  Activated="MetroMainWindow_Activated" Closing="MetroWindowMain_Closing"
@@ -26,40 +27,41 @@
     <!-- MetroDialogStyles.xaml must be adjusted if MinWidth/MinHeight is changed -->
     <mah:MetroWindow.Resources>
         <converters:BooleanToVisibilityCollapsedConverter x:Key="BooleanToVisibilityCollapsedConverter" />
+        <converters:BooleanReverseConverter x:Key="BooleanReverseConverter"></converters:BooleanReverseConverter>
         <converters:ApplicationNameToTranslatedStringConverter x:Key="ApplicationNameToTranslatedStringConverter" />
         <converters:ApplicationNameToIconConverter x:Key="ApplicationNameToIconConverter" />
         <converters:IntZeroToVisibilityCollapsedConverter x:Key="IntZeroToVisibilityCollapsedConverter" />
         <converters:BooleanReverseToVisibilityCollapsedConverter x:Key="BooleanReverseToVisibilityCollapsedConverter" />
         <!-- ReSharper disable once Xaml.RedundantResource - Used in TrayIcon -->
         <ContextMenu x:Key="ContextMenuNotifyIcon" MinWidth="200" Opened="ContextMenu_Opened" x:Shared="False">
-            <MenuItem Header="{x:Static localization:Strings.Show}" Command="{Binding ShowWindowCommand}">
+            <MenuItem Header="{x:Static Member=localization:Strings.Show}" Command="{Binding Path=ShowWindowCommand}">
                 <MenuItem.Icon>
-                    <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
+                    <Rectangle Width="16" Height="16" Fill="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}">
                         <Rectangle.OpacityMask>
                             <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=OpenInNew}" />
                         </Rectangle.OpacityMask>
                     </Rectangle>
                 </MenuItem.Icon>
             </MenuItem>
-            <MenuItem Header="{x:Static localization:Strings.Status}" Command="{Binding OpenStatusWindowCommand}">
+            <MenuItem Header="{x:Static Member=localization:Strings.Status}" Command="{Binding Path=OpenStatusWindowCommand}">
                 <MenuItem.Icon>
-                    <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
+                    <Rectangle Width="16" Height="16" Fill="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}">
                         <Rectangle.OpacityMask>
                             <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=Pulse}" />
                         </Rectangle.OpacityMask>
                     </Rectangle>
                 </MenuItem.Icon>
             </MenuItem>
-            <MenuItem Header="{x:Static localization:Strings.Settings}" Command="{Binding OpenSettingsFromTrayCommand}">
+            <MenuItem Header="{x:Static Member=localization:Strings.Settings}" Command="{Binding Path=OpenSettingsFromTrayCommand}">
                 <MenuItem.Icon>
-                    <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
+                    <Rectangle Width="16" Height="16" Fill="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}">
                         <Rectangle.OpacityMask>
                             <VisualBrush Stretch="Uniform" Visual="{iconPacks:MaterialLight Kind=Cog}" />
                         </Rectangle.OpacityMask>
                     </Rectangle>
                 </MenuItem.Icon>
             </MenuItem>
-            <MenuItem Header="{x:Static localization:Strings.Close}" Command="{Binding CloseApplicationCommand}">
+            <MenuItem Header="{x:Static Member=localization:Strings.Close}" Command="{Binding Path=CloseApplicationCommand}">
                 <MenuItem.Icon>
                     <Rectangle Width="16" Height="16" Fill="Red">
                         <Rectangle.OpacityMask>
@@ -71,27 +73,27 @@
         </ContextMenu>
     </mah:MetroWindow.Resources>
     <mah:MetroWindow.InputBindings>
-        <KeyBinding Command="{Binding OpenRunCommand}" Modifiers="Control+Shift" Key="P" />
+        <KeyBinding Command="{Binding Path=OpenRunCommand}" Modifiers="Control+Shift" Key="P" />
     </mah:MetroWindow.InputBindings>
     <mah:MetroWindow.WindowButtonCommands>
-        <mah:WindowButtonCommands Template="{DynamicResource MahApps.Templates.WindowButtonCommands.Win10}" />
+        <mah:WindowButtonCommands Template="{DynamicResource ResourceKey=MahApps.Templates.WindowButtonCommands.Win10}" />
     </mah:MetroWindow.WindowButtonCommands>
     <mah:MetroWindow.LeftWindowCommands>
         <mah:WindowCommands ShowSeparators="False">
             <!-- Fix some design issues with margin -2 and -1 -->
-            <Grid Background="{DynamicResource MahApps.Brushes.Gray10}"
-                  Visibility="{Binding Source={x:Static settings:ConfigurationManager.Current}, Path=IsAdmin, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
+            <Grid Background="{DynamicResource ResourceKey=MahApps.Brushes.Gray10}"
+                  Visibility="{Binding Source={x:Static Member=settings:ConfigurationManager.Current}, Path=IsAdmin, Converter={StaticResource ResourceKey=BooleanToVisibilityCollapsedConverter}}"
                   Margin="-2,-1,0,0">
-                <TextBlock Text="Administrator" Foreground="{DynamicResource MahApps.Brushes.Gray3}"
-                           Style="{StaticResource CenterTextBlock}" Margin="10,0" />
+                <TextBlock Text="Administrator" Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}"
+                           Style="{StaticResource ResourceKey=CenterTextBlock}" Margin="10,0" />
             </Grid>
         </mah:WindowCommands>
     </mah:MetroWindow.LeftWindowCommands>
     <mah:MetroWindow.RightWindowCommands>
-        <mah:WindowCommands ShowSeparators="False" Visibility="{Binding Source={x:Static settings:ConfigurationManager.Current}, Path=IsChildWindowOpen, Converter={StaticResource BooleanReverseToVisibilityCollapsedConverter}}">
-            <Button Command="{Binding OpenRunCommand}"
+        <mah:WindowCommands ShowSeparators="False" IsEnabled="{Binding Source={x:Static Member=settings:ConfigurationManager.Current}, Path=IsChildWindowOpen, Converter={StaticResource ResourceKey=BooleanReverseConverter}}">
+            <Button Command="{Binding Path=OpenRunCommand}"
                     Visibility="{Binding Path=FlyoutRunCommandIsOpen, Converter={StaticResource ResourceKey=BooleanReverseToVisibilityCollapsedConverter}}"
-                    ToolTip="{x:Static localization:Strings.ToolTip_RunCommandWithHotKey}"
+                    ToolTip="{x:Static Member=localization:Strings.ToolTip_RunCommandWithHotKey}"
                     Cursor="Hand"
                     Focusable="False">
                 <StackPanel Orientation="Horizontal">
@@ -103,56 +105,60 @@
                     </Rectangle>
                 </StackPanel>
             </Button>
-            <Button Command="{Binding RestartApplicationCommand}"
+            <Button Command="{Binding Path=RestartApplicationCommand}"
                     Opacity="1"
-                    Visibility="{Binding IsRestartRequired, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
-                    ToolTip="{x:Static localization:Strings.RestartRequired}"
+                    Visibility="{Binding Path=IsRestartRequired, Converter={StaticResource ResourceKey=BooleanToVisibilityCollapsedConverter}}"
+                    ToolTip="{x:Static Member=localization:Strings.RestartRequired}"
                     Cursor="Hand">
                 <Rectangle Width="20" Height="20"
-                           Fill="{DynamicResource MahApps.Brushes.Accent}">
+                           Fill="{DynamicResource ResourceKey=MahApps.Brushes.Accent}">
                     <Rectangle.OpacityMask>
                         <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=ReloadAlert}" />
                     </Rectangle.OpacityMask>
                 </Rectangle>
             </Button>
-            <Button Command="{Binding OpenWebsiteCommand}"
+            <Button Command="{Binding Path=OpenWebsiteCommand}"
                     Opacity="1"
-                    Visibility="{Binding IsUpdateAvailable, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
-                    CommandParameter="{Binding UpdateReleaseUrl, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                    Visibility="{Binding Path=IsUpdateAvailable, Converter={StaticResource ResourceKey=BooleanToVisibilityCollapsedConverter}}"
+                    CommandParameter="{Binding Path=UpdateReleaseUrl, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
                     Cursor="Hand"
-                    ToolTip="{x:Static localization:Strings.UpdateAvailable}"
+                    ToolTip="{x:Static Member=localization:Strings.UpdateAvailable}"
                     Focusable="False">
                 <Rectangle Width="20" Height="20"
-                           Fill="{DynamicResource MahApps.Brushes.Accent}">
+                           Fill="{DynamicResource ResourceKey=MahApps.Brushes.Accent}">
                     <Rectangle.OpacityMask>
                         <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=RocketLaunchOutline}" />
                     </Rectangle.OpacityMask>
                 </Rectangle>
             </Button>
-            <Button Command="{Binding UnlockProfileCommand}"
+            <Button Command="{Binding Path=UnlockProfileCommand}"
                     Opacity="1"
-                    Visibility="{Binding Source={x:Static settings:ConfigurationManager.Current}, Path=ProfileManagerShowUnlock, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
-                    CommandParameter="{Binding UpdateReleaseUrl, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                    Visibility="{Binding Source={x:Static Member=settings:ConfigurationManager.Current}, Path=ProfileManagerShowUnlock, Converter={StaticResource ResourceKey=BooleanToVisibilityCollapsedConverter}}"
+                    CommandParameter="{Binding Path=UpdateReleaseUrl, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
                     Cursor="Hand"
-                    ToolTip="{x:Static localization:Strings.UnlockProfile}"
+                    ToolTip="{x:Static Member=localization:Strings.UnlockProfile}"
                     Focusable="False">
                 <Rectangle Width="20" Height="20"
-                           Fill="{DynamicResource MahApps.Brushes.Accent}">
+                           Fill="{DynamicResource ResourceKey=MahApps.Brushes.Accent}">
                     <Rectangle.OpacityMask>
                         <VisualBrush Stretch="Uniform" Visual="{iconPacks:Modern Kind=InterfacePassword}" />
                     </Rectangle.OpacityMask>
                 </Rectangle>
             </Button>
-            <ComboBox ItemsSource="{Binding ProfileFiles}"
-                      SelectedItem="{Binding SelectedProfileFile, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                      IsDropDownOpen="{Binding IsProfileFileDropDownOpened}"
-                      Background="{DynamicResource MahApps.Brushes.Gray10}"
+            <ComboBox ItemsSource="{Binding Path=ProfileFiles}"
+                      SelectedItem="{Binding Path=SelectedProfileFile, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                      IsDropDownOpen="{Binding Path=IsProfileFileDropDownOpened}"
+                      Background="{DynamicResource ResourceKey=MahApps.Brushes.Gray10}"
                       BorderThickness="0"
                       MinWidth="180"
                       HorizontalAlignment="Left"
                       Focusable="False"
                       VerticalAlignment="Center"
                       Height="30">
+                <ComboBox.Resources>
+                    <!-- ReSharper disable once Xaml.RedundantResource - Override MahApps default style -->
+                    <SolidColorBrush x:Key="MahApps.Brushes.Control.Disabled" Color="{DynamicResource ResourceKey=MahApps.Colors.Gray8}" />
+                </ComboBox.Resources>
                 <ComboBox.ItemTemplate>
                     <DataTemplate>
                         <Grid>
@@ -162,7 +168,7 @@
                                 <ColumnDefinition MinWidth="70" />
                             </Grid.ColumnDefinitions>
                             <Rectangle Grid.Column="0" Grid.Row="0" Width="20" Height="20"
-                                       Fill="{DynamicResource MahApps.Brushes.Gray3}">
+                                       Fill="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}">
                                 <Rectangle.Style>
                                     <Style TargetType="Rectangle">
                                         <Setter Property="OpacityMask">
@@ -172,7 +178,7 @@
                                             </Setter.Value>
                                         </Setter>
                                         <Style.Triggers>
-                                            <DataTrigger Binding="{Binding IsEncrypted}" Value="True">
+                                            <DataTrigger Binding="{Binding Path=IsEncrypted}" Value="True">
                                                 <Setter Property="OpacityMask">
                                                     <Setter.Value>
                                                         <VisualBrush Stretch="Uniform"
@@ -184,14 +190,14 @@
                                     </Style>
                                 </Rectangle.Style>
                             </Rectangle>
-                            <TextBlock Grid.Column="2" Grid.Row="0" Text="{Binding Name}" />
+                            <TextBlock Grid.Column="2" Grid.Row="0" Text="{Binding Path=Name}" />
                         </Grid>
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>           
-            <Button Command="{Binding OpenWebsiteCommand}"
-                    ToolTip="{x:Static localization:Strings.ToolTip_StarForkProjectOnGitHub}"
-                    CommandParameter="{x:Static resources:Resources.NETworkManager_GitHubRepoUrl}"
+            <Button Command="{Binding Path=OpenWebsiteCommand}"
+                    ToolTip="{x:Static Member=localization:Strings.ToolTip_StarForkProjectOnGitHub}"
+                    CommandParameter="{x:Static Member=resources:Resources.NETworkManager_GitHubRepoUrl}"
                     Cursor="Hand"
                     Focusable="False">
                 <StackPanel Orientation="Horizontal">
@@ -204,9 +210,9 @@
                 </StackPanel>
             </Button>
           
-            <Button Command="{Binding OpenWebsiteCommand}"
-                    ToolTip="{x:Static localization:Strings.ToolTip_ReportIssueOrCreateFeatureRequest}"
-                    CommandParameter="{x:Static resources:Resources.NETworkManager_GitHubNewIssueUrl}"
+            <Button Command="{Binding Path=OpenWebsiteCommand}"
+                    ToolTip="{x:Static Member=localization:Strings.ToolTip_ReportIssueOrCreateFeatureRequest}"
+                    CommandParameter="{x:Static Member=resources:Resources.NETworkManager_GitHubNewIssueUrl}"
                     Cursor="Hand"
                     Focusable="False">
                 <StackPanel Orientation="Horizontal">

--- a/Source/NETworkManager/ViewModels/NetworkInterfaceViewModel.cs
+++ b/Source/NETworkManager/ViewModels/NetworkInterfaceViewModel.cs
@@ -938,6 +938,8 @@ public class NetworkInterfaceViewModel : ViewModelBase, IProfileManager
 
     private async void ReloadNetworkInterfaces()
     {
+        Debug.WriteLine("ReloadNetworkInterfaces.............");
+        
         // Avoid multiple reloads
         if(IsNetworkInterfaceLoading)
             return;

--- a/Source/NETworkManager/Views/CredentialsPasswordProfileFileChildWindow.xaml
+++ b/Source/NETworkManager/Views/CredentialsPasswordProfileFileChildWindow.xaml
@@ -11,11 +11,11 @@
              xmlns:simpleChildWindow="clr-namespace:MahApps.Metro.SimpleChildWindow;assembly=MahApps.Metro.SimpleChildWindow"
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              ShowTitleBar="False" 
-             ChildWindowMaxWidth="650"
-             ChildWindowMaxHeight="800"                
+             ChildWindowWidth="450"
+             ChildWindowMaxHeight="500"                
              Padding="20"
              CloseByEscape="False"                               
-             OverlayBrush="{DynamicResource MahApps.Brushes.Gray.SemiTransparent}"
+             OverlayBrush="{DynamicResource ResourceKey=MahApps.Brushes.Gray.SemiTransparent}"
              mc:Ignorable="d" d:DataContext="{d:DesignInstance viewModels:CredentialsPasswordProfileFileViewModel}">
     <simpleChildWindow:ChildWindow.Resources>
         <converters:BooleanToVisibilityCollapsedConverter x:Key="BooleanToVisibilityCollapsedConverter" />
@@ -31,29 +31,29 @@
             <RowDefinition Height="20" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <Grid>
+        <Grid Grid.Column="0" Grid.Row="0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="10" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <Rectangle Width="24" Height="24"
-                       Fill="{DynamicResource MahApps.Brushes.Gray3}">
+            <Rectangle Grid.Column="0" Grid.Row="0" Width="24" Height="24"
+                                      Fill="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}">
                 <Rectangle.OpacityMask>
                     <VisualBrush Stretch="Uniform" Visual="{iconPacks:FontAwesome Kind=UserLockSolid}" />
                 </Rectangle.OpacityMask>
             </Rectangle>
             <TextBlock Grid.Column="2" Grid.Row="0" 
-                       Text="{x:Static localization:Strings.UnlockProfileFile}"
-                       Style="{DynamicResource HeaderTextBlock}"
+                       Text="{x:Static Member=localization:Strings.UnlockProfileFile}"
+                       Style="{DynamicResource ResourceKey=HeaderTextBlock}"
                        Margin="0" />
         </Grid>
-        <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static localization:Strings.EnterMasterPasswordToUnlockProfile}"
-                Style="{StaticResource DefaultTextBlock}" />
+        <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static Member=localization:Strings.EnterMasterPasswordToUnlockProfile}"
+                Style="{StaticResource ResourceKey=DefaultTextBlock}" />
         <Grid Grid.Column="0" Grid.Row="4">
             <Grid.Resources>
-                <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource CenterTextBlock}" />
-                <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource DefaultTextBox}" />
+                <Style TargetType="{x:Type TypeName=TextBlock}" BasedOn="{StaticResource ResourceKey=CenterTextBlock}" />
+                <Style TargetType="{x:Type TypeName=TextBox}" BasedOn="{StaticResource ResourceKey=DefaultTextBox}" />
             </Grid.Resources>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
@@ -61,42 +61,42 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="1*" />
+                <ColumnDefinition MinWidth="150" Width="Auto" />
                 <ColumnDefinition Width="10" />
-                <ColumnDefinition Width="1*" />
+                <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" Grid.Row="0" Text="{x:Static localization:Strings.ProfileFile}" />
-            <TextBlock Grid.Column="2" Grid.Row="0" Text="{Binding ProfileName}" Style="{StaticResource InfoTextBlock}" />
-            <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static localization:Strings.Password}" />            
+            <TextBlock Grid.Column="0" Grid.Row="0" Text="{x:Static Member=localization:Strings.ProfileFile}" />
+            <TextBlock Grid.Column="2" Grid.Row="0" Text="{Binding Path=ProfileName}" Style="{StaticResource ResourceKey=InfoTextBlock}" />
+            <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static Member=localization:Strings.Password}" />            
             <PasswordBox x:Name="PasswordBoxPassword" Grid.Column="2" Grid.Row="2"                    
-                      Style="{StaticResource DefaultPasswordBox}">
+                      Style="{StaticResource ResourceKey=DefaultPasswordBox}">
                 <interactivity:Interaction.Behaviors>
                     <wpfHelpers:PasswordBoxBindingBehavior
-                     Password="{Binding Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                     Password="{Binding Path=Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </interactivity:Interaction.Behaviors>
             </PasswordBox>
         </Grid>
         <Grid Grid.Column="0" Grid.Row="5" Margin="0,10,0,0"
-           Visibility="{Binding ShowWrongPassword, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
-            <TextBlock Text="{x:Static localization:Strings.WrongPasswordDecryptionFailedMessage}"
-                    Style="{StaticResource ErrorTextBlock}" />
+           Visibility="{Binding Path=ShowWrongPassword, Converter={StaticResource ResourceKey=BooleanToVisibilityCollapsedConverter}}">
+            <TextBlock Text="{x:Static Member=localization:Strings.WrongPasswordDecryptionFailedMessage}"
+                    Style="{StaticResource ResourceKey=ErrorTextBlock}" />
         </Grid>
         <StackPanel Grid.Column="0" Grid.Row="7" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Content="{x:Static localization:Strings.OK}" Command="{Binding OKCommand}" IsDefault="True"
+            <Button Content="{x:Static Member=localization:Strings.OK}" Command="{Binding Path=OKCommand}" IsDefault="True"
                  Margin="0,0,10,0">
                 <Button.Style>
-                    <Style TargetType="{x:Type Button}" BasedOn="{StaticResource HighlightedButton}">
+                    <Style TargetType="{x:Type TypeName=Button}" BasedOn="{StaticResource ResourceKey=HighlightedButton}">
                         <Setter Property="IsEnabled" Value="False" />
                         <Style.Triggers>
-                            <DataTrigger Binding="{Binding IsPasswordEmpty}" Value="False">
+                            <DataTrigger Binding="{Binding Path=IsPasswordEmpty}" Value="False">
                                 <Setter Property="IsEnabled" Value="True" />
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
                 </Button.Style>
             </Button>
-            <Button Content="{x:Static localization:Strings.Cancel}" Command="{Binding CancelCommand}" IsCancel="True"
-                 Style="{StaticResource DefaultButton}" />
+            <Button Content="{x:Static Member=localization:Strings.Cancel}" Command="{Binding Path=CancelCommand}" IsCancel="True"
+                 Style="{StaticResource ResourceKey=DefaultButton}" />
         </StackPanel>
     </Grid>
 </simpleChildWindow:ChildWindow>


### PR DESCRIPTION
## Changes proposed in this pull request

- Fix dialog unlock size
-

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request includes several changes to the `Source/NETworkManager/MainWindow.xaml` file, focusing on improving the clarity and consistency of resource references and bindings. Additionally, there are minor adjustments to other files to improve the user interface and add debugging information.

Changes to resource references and bindings:

* Updated `DynamicResource` references to include `ResourceKey` for better clarity and consistency. (`Source/NETworkManager/MainWindow.xaml`, [[1]](diffhunk://#diff-c97b55fa5f797636ea5d60de55ad4114bc287a9251d91355c1f91637b2684c13L19-R64) [[2]](diffhunk://#diff-c97b55fa5f797636ea5d60de55ad4114bc287a9251d91355c1f91637b2684c13L74-R96) [[3]](diffhunk://#diff-c97b55fa5f797636ea5d60de55ad4114bc287a9251d91355c1f91637b2684c13L106-R161) [[4]](diffhunk://#diff-c97b55fa5f797636ea5d60de55ad4114bc287a9251d91355c1f91637b2684c13L165-R171) [[5]](diffhunk://#diff-c97b55fa5f797636ea5d60de55ad4114bc287a9251d91355c1f91637b2684c13L187-R200)
* Changed `Binding` paths to explicitly use `Path` for improved readability. (`Source/NETworkManager/MainWindow.xaml`, [[1]](diffhunk://#diff-c97b55fa5f797636ea5d60de55ad4114bc287a9251d91355c1f91637b2684c13L74-R96) [[2]](diffhunk://#diff-c97b55fa5f797636ea5d60de55ad4114bc287a9251d91355c1f91637b2684c13L175-R181) [[3]](diffhunk://#diff-c97b55fa5f797636ea5d60de55ad4114bc287a9251d91355c1f91637b2684c13L187-R200)
* Added new converters and updated existing converter references to include `ResourceKey`. (`Source/NETworkManager/MainWindow.xaml`, [Source/NETworkManager/MainWindow.xamlL19-R64](diffhunk://#diff-c97b55fa5f797636ea5d60de55ad4114bc287a9251d91355c1f91637b2684c13L19-R64))

User interface adjustments:

* Modified the `ChildWindow` dimensions in `CredentialsPasswordProfileFileChildWindow.xaml` for a better fit. (`Source/NETworkManager/Views/CredentialsPasswordProfileFileChildWindow.xaml`, [Source/NETworkManager/Views/CredentialsPasswordProfileFileChildWindow.xamlL14-R18](diffhunk://#diff-340219a7e3bbb5c25d6d63875e72c94242bc884ffe15ba3a9c114b03a3757635L14-R18))

Debugging improvements:

* Added a debug print statement in `ReloadNetworkInterfaces` to help with troubleshooting. (`Source/NETworkManager/ViewModels/NetworkInterfaceViewModel.cs`, [Source/NETworkManager/ViewModels/NetworkInterfaceViewModel.csR941-R942](diffhunk://#diff-0adad424ea36de9ff07caa5c418fa740b575cc88d1fde35811a2dd0ef744e99aR941-R942))

</details>

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
