### PR TITLE
Feature: HostsFileEditor delete entry added

### DIFF
--- a/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
+++ b/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
@@ -2592,6 +2592,17 @@ namespace NETworkManager.Localization.Resources {
         }
         
         /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die The selected entry is permanently deleted:
+        ///
+        ///{0} {1} {2} ähnelt.
+        /// </summary>
+        public static string DeleteHostsFileEntryMessage {
+            get {
+                return ResourceManager.GetString("DeleteHostsFileEntryMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die Delete OID profile ähnelt.
         /// </summary>
         public static string DeleteOIDProfile {

--- a/Source/NETworkManager.Localization/Resources/Strings.resx
+++ b/Source/NETworkManager.Localization/Resources/Strings.resx
@@ -3933,4 +3933,9 @@ Right-click for more options.</value>
   <data name="Entries" xml:space="preserve">
     <value>Entries</value>
   </data>
+  <data name="DeleteHostsFileEntryMessage" xml:space="preserve">
+    <value>The selected entry is permanently deleted:
+
+{0} {1} {2}</value>
+  </data>
 </root>

--- a/Source/NETworkManager.Models/HostsFileEditor/HostsFileEntryModifyResult.cs
+++ b/Source/NETworkManager.Models/HostsFileEditor/HostsFileEntryModifyResult.cs
@@ -1,0 +1,28 @@
+﻿namespace NETworkManager.Models.HostsFileEditor
+{
+    /// <summary>
+    ///     Represents the result of an attempt to modify a hosts file entry.
+    /// </summary>
+    public enum HostsFileEntryModifyResult
+    {
+        /// <summary>
+        ///     The entry was modified successfully and the hosts file was updated.
+        /// </summary>
+        Success,
+
+        /// <summary>
+        ///     The entry was not found in the hosts file.
+        /// </summary>
+        NotFound,
+
+        /// <summary>
+        ///     An error occurred while writing to the hosts file.
+        /// </summary>
+        WriteError,
+
+        /// <summary>
+        ///     An error occurred while backing up the hosts file.
+        /// </summary>
+        BackupError,
+    }
+}

--- a/Source/NETworkManager/ViewModels/SNTPLookupSettingsViewModel.cs
+++ b/Source/NETworkManager/ViewModels/SNTPLookupSettingsViewModel.cs
@@ -1,17 +1,17 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Data;
-using System.Windows.Input;
-using MahApps.Metro.Controls.Dialogs;
+﻿using MahApps.Metro.Controls.Dialogs;
 using MahApps.Metro.SimpleChildWindow;
 using NETworkManager.Localization.Resources;
 using NETworkManager.Models.Network;
 using NETworkManager.Settings;
 using NETworkManager.Utilities;
 using NETworkManager.Views;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Input;
 
 namespace NETworkManager.ViewModels;
 
@@ -188,7 +188,6 @@ public class SNTPLookupSettingsViewModel : ViewModelBase
     private Task DeleteServer()
     {
         var childWindow = new OKCancelInfoMessageChildWindow();
-
 
         var childWindowViewModel = new OKCancelInfoMessageViewModel(_ =>
             {

--- a/Source/NETworkManager/Views/ExportChildWindow.xaml
+++ b/Source/NETworkManager/Views/ExportChildWindow.xaml
@@ -30,7 +30,7 @@
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
-            <RowDefinition Height="10" />
+            <RowDefinition Height="20" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Grid Grid.Row="0">

--- a/Source/NETworkManager/Views/GroupChildWindow.xaml
+++ b/Source/NETworkManager/Views/GroupChildWindow.xaml
@@ -43,7 +43,7 @@
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
-            <RowDefinition Height="10" />
+            <RowDefinition Height="20" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Grid Row="0">

--- a/Source/NETworkManager/Views/OKCancelInfoMessageChildWindow.xaml
+++ b/Source/NETworkManager/Views/OKCancelInfoMessageChildWindow.xaml
@@ -17,12 +17,12 @@
              AllowMove="True"
              TitleForeground="{DynamicResource MahApps.Brushes.Gray3}"
              CloseByEscape="False"                               
-             OverlayBrush="{DynamicResource ResourceKey=MahApps.Brushes.Gray.SemiTransparent}"
+             OverlayBrush="{DynamicResource ResourceKey=MahApps.Brushes.Gray.SemiTransparent}"                               
              mc:Ignorable="d" d:DataContext="{d:DesignInstance viewModels:OKCancelInfoMessageViewModel}">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
-            <RowDefinition Height="10" />
+            <RowDefinition Height="20" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <ScrollViewer Grid.Column="0" Grid.Row="0" 
@@ -40,8 +40,7 @@
                 <TextBlock Grid.Column="2" Grid.Row="0"
                            VerticalAlignment="Center"
                            Text="{Binding Message}"
-                           Style="{StaticResource ResourceKey=WrapTextBlock}"
-                           Foreground="{DynamicResource MahApps.Brushes.Gray3}"/>
+                           Style="{StaticResource ResourceKey=WrapTextBlock}"/>                
             </Grid>
         </ScrollViewer>
         <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">

--- a/Source/NETworkManager/Views/ProfileChildWindow.xaml
+++ b/Source/NETworkManager/Views/ProfileChildWindow.xaml
@@ -46,7 +46,7 @@
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
-            <RowDefinition Height="10" />
+            <RowDefinition Height="20" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Grid Row="0">

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -23,7 +23,7 @@ Release date: **xx.xx.2025**
 
 **Hosts File Editor**
 
-- New feature to display (and edit) the `hosts` file. (See [documentation](https://borntoberoot.net/NETworkManager/docs/application/hosts-file-editor) for more details) [#3012](https://github.com/BornToBeRoot/NETworkManager/pull/3012) [#3092](https://github.com/BornToBeRoot/NETworkManager/pull/3092) 
+- New feature to display (and edit) the `hosts` file. (See [documentation](https://borntoberoot.net/NETworkManager/docs/application/hosts-file-editor) for more details) [#3012](https://github.com/BornToBeRoot/NETworkManager/pull/3012) [#3092](https://github.com/BornToBeRoot/NETworkManager/pull/3092) [#3094](https://github.com/BornToBeRoot/NETworkManager/pull/3094)
 
   :::info
 


### PR DESCRIPTION
## Changes proposed in this pull request

- HostsFileEditor delete entry
-

## Related issue(s)

- #1840 

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request introduces enhancements to the `HostsFileEditor` functionality, refines user interface elements, and improves code maintainability. Key changes include the addition of a new enum for operation results, asynchronous methods for modifying hosts file entries, and updates to child window styling.

### Hosts File Editor Enhancements:
* Added `HostsFileEntryModifyResult` enum to represent operation outcomes such as success, not found, write error, and backup error. (`Source/NETworkManager.Models/HostsFileEditor/HostsFileEntryModifyResult.cs`)
* Refactored `EnableEntry`, `DisableEntry`, and `DeleteEntry` methods to return `HostsFileEntryModifyResult` instead of a boolean, improving error handling and logging. (`Source/NETworkManager.Models/HostsFileEditor/HostsFileEditor.cs`) [[1]](diffhunk://#diff-76f3b834f3e286e450db8d121a95d460ab1d9f9552424504ab6f9efe6d19f4e3L167-R212) [[2]](diffhunk://#diff-76f3b834f3e286e450db8d121a95d460ab1d9f9552424504ab6f9efe6d19f4e3L198-R273) [[3]](diffhunk://#diff-76f3b834f3e286e450db8d121a95d460ab1d9f9552424504ab6f9efe6d19f4e3R284-R352)
* Implemented asynchronous methods for enabling, disabling, and deleting hosts file entries (`EnableEntryAsync`, `DisableEntryAsync`, `DeleteEntryAsync`). (`Source/NETworkManager.Models/HostsFileEditor/HostsFileEditor.cs`) [[1]](diffhunk://#diff-76f3b834f3e286e450db8d121a95d460ab1d9f9552424504ab6f9efe6d19f4e3L167-R212) [[2]](diffhunk://#diff-76f3b834f3e286e450db8d121a95d460ab1d9f9552424504ab6f9efe6d19f4e3R284-R352)

### ViewModel Updates:
* Introduced `IsModifying` property in `HostsFileEditorViewModel` to track modification state and prevent concurrent operations. (`Source/NETworkManager/ViewModels/HostsFileEditorViewModel.cs`)
* Updated `ModifyEntry_CanExecute` and `Refresh_CanExecute` methods to account for the `IsModifying` state. (`Source/NETworkManager/ViewModels/HostsFileEditorViewModel.cs`) [[1]](diffhunk://#diff-b3600f52de0ebf5aa38b90debf2d6db9eafe36f151ba0facb7281d25b4c08795L195-R211) [[2]](diffhunk://#diff-b3600f52de0ebf5aa38b90debf2d6db9eafe36f151ba0facb7281d25b4c08795L293-R344)
* Implemented `DeleteEntryAction` with a confirmation dialog to delete hosts file entries. (`Source/NETworkManager/ViewModels/HostsFileEditorViewModel.cs`)

### Localization and UI Refinements:
* Added localization support for delete entry confirmation message (`DeleteHostsFileEntryMessage`). (`Source/NETworkManager.Localization/Resources/Strings.Designer.cs`, `Source/NETworkManager.Localization/Resources/Strings.resx`) [[1]](diffhunk://#diff-fd26c2c2130e727ae40f1060c182242ce89c894d95f0168fa6443e230da8e4e0R2594-R2604) [[2]](diffhunk://#diff-aa5828c7aa59a68d20ce70a1088e4bd1038a53bac7f9eac6398a7b6e466f9df8R3936-R3940)
* Increased spacing between rows in child windows for better readability. (`Source/NETworkManager/Views/ExportChildWindow.xaml`, `Source/NETworkManager/Views/GroupChildWindow.xaml`, `Source/NETworkManager/Views/ProfileChildWindow.xaml`, `Source/NETworkManager/Views/OKCancelInfoMessageChildWindow.xaml`) [[1]](diffhunk://#diff-e216e539a72dad0b4d7357fee55db5d9ffa0bfa6aa1d0e67d285954367c61acfL33-R33) [[2]](diffhunk://#diff-64b54aed298c57e0cdffbf47d8fb71ed6693c2eecf83e40943c746617ae452fbL46-R46) [[3]](diffhunk://#diff-1ddae73c246921902cc71fc45944172f33516382dd797d6ba567e278a3488682L25-R25) [[4]](diffhunk://#diff-3da85e5d4c9919e69f59ababf7ec8d1ccf5acd2b2965571d68dbd704a90c12b1L49-R49)
* Removed unnecessary foreground styling from `OKCancelInfoMessageChildWindow.xaml`. (`Source/NETworkManager/Views/OKCancelInfoMessageChildWindow.xaml`)

</details>

## To-Do

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
