### PR TITLE
Feature: HostsFileEditor Debug Log + Create Entry

### DIFF
--- a/Source/NETworkManager.Models/HostsFileEditor/HostsFileEntry.cs
+++ b/Source/NETworkManager.Models/HostsFileEditor/HostsFileEntry.cs
@@ -52,6 +52,15 @@ public class HostsFileEntry
         IPAddress = ipAddress;
         Hostname = hostname;
         Comment = comment;
+        
+        var line = isEnabled ? "" : "# ";
+
+        line += $"{ipAddress}    {hostname}";
+
+        if (!string.IsNullOrWhiteSpace(comment))
+            line += $"        # {comment}";
+        
+        Line = line;
     }
     
     /// <summary>
@@ -62,8 +71,21 @@ public class HostsFileEntry
     /// <param name="hostname">Host name(s) of the host.</param>
     /// <param name="comment">Comment of the host.</param>
     /// <param name="line">Line of the entry in the hosts file.</param>
-    public HostsFileEntry(bool isEnabled, string ipAddress, string hostname, string comment, string line) : this(isEnabled, ipAddress, hostname, comment)
+    public HostsFileEntry(bool isEnabled, string ipAddress, string hostname, string comment, string line)
     {
+        IsEnabled = isEnabled;
+        IPAddress = ipAddress;
+        Hostname = hostname;
+        Comment = comment;
         Line = line;
+    }
+    
+    /// <summary>
+    /// Overrides the ToString method to return the line of the entry in the hosts file.
+    /// </summary>
+    /// <returns>Line of the entry in the hosts file.</returns>
+    public override string ToString()
+    {
+        return Line;
     }
 }

--- a/Source/NETworkManager/ViewModels/HostsFileEditorViewModel.cs
+++ b/Source/NETworkManager/ViewModels/HostsFileEditorViewModel.cs
@@ -23,6 +23,7 @@ namespace NETworkManager.ViewModels;
 public class HostsFileEditorViewModel : ViewModelBase
 {
     #region Variables
+
     private static readonly ILog Log = LogManager.GetLogger(typeof(HostsFileEditorViewModel));
 
     private readonly IDialogCoordinator _dialogCoordinator;
@@ -30,6 +31,7 @@ public class HostsFileEditorViewModel : ViewModelBase
     private readonly bool _isLoading;
 
     private string _search;
+
     public string Search
     {
         get => _search;
@@ -183,10 +185,7 @@ public class HostsFileEditorViewModel : ViewModelBase
         // Watch hosts file for changes
         HostsFileEditor.HostsFileChanged += (_, _) =>
         {
-            Application.Current.Dispatcher.Invoke(() =>
-            {
-                Refresh().ConfigureAwait(false);
-            });
+            Application.Current.Dispatcher.Invoke(() => { Refresh().ConfigureAwait(false); });
         };
 
         _isLoading = false;
@@ -194,12 +193,12 @@ public class HostsFileEditorViewModel : ViewModelBase
 
     private void LoadSettings()
     {
-
     }
 
     #endregion
 
     #region ICommands & Actions
+
     public ICommand RefreshCommand => new RelayCommand(_ => RefreshAction().ConfigureAwait(false), Refresh_CanExecute);
 
     private bool Refresh_CanExecute(object parameter)
@@ -223,38 +222,40 @@ public class HostsFileEditorViewModel : ViewModelBase
         var childWindow = new ExportChildWindow();
 
         var childWindowViewModel = new ExportViewModel(async instance =>
-        {
-            childWindow.IsOpen = false;
-            ConfigurationManager.Current.IsChildWindowOpen = false;
-
-            try
             {
-                ExportManager.Export(instance.FilePath, instance.FileType,
-                     instance.ExportAll
-                         ? Results
-                         : new ObservableCollection<HostsFileEntry>(SelectedResults.Cast<HostsFileEntry>().ToArray()));
-            }
-            catch (Exception ex)
+                childWindow.IsOpen = false;
+                ConfigurationManager.Current.IsChildWindowOpen = false;
+
+                try
+                {
+                    ExportManager.Export(instance.FilePath, instance.FileType,
+                        instance.ExportAll
+                            ? Results
+                            : new ObservableCollection<HostsFileEntry>(SelectedResults.Cast<HostsFileEntry>()
+                                .ToArray()));
+                }
+                catch (Exception ex)
+                {
+                    Log.Error("Error while exporting data as " + instance.FileType, ex);
+
+                    var settings = AppearanceManager.MetroDialog;
+                    settings.AffirmativeButtonText = Strings.OK;
+
+                    await _dialogCoordinator.ShowMessageAsync(this, Strings.Error,
+                        Strings.AnErrorOccurredWhileExportingTheData + Environment.NewLine +
+                        Environment.NewLine + ex.Message, MessageDialogStyle.Affirmative, settings);
+                }
+
+                SettingsManager.Current.HostsFileEditor_ExportFileType = instance.FileType;
+                SettingsManager.Current.HostsFileEditor_ExportFilePath = instance.FilePath;
+            }, _ =>
             {
-                Log.Error("Error while exporting data as " + instance.FileType, ex);
-
-                var settings = AppearanceManager.MetroDialog;
-                settings.AffirmativeButtonText = Strings.OK;
-
-                await _dialogCoordinator.ShowMessageAsync(this, Strings.Error,
-                    Strings.AnErrorOccurredWhileExportingTheData + Environment.NewLine +
-                    Environment.NewLine + ex.Message, MessageDialogStyle.Affirmative, settings);
-            }
-
-            SettingsManager.Current.HostsFileEditor_ExportFileType = instance.FileType;
-            SettingsManager.Current.HostsFileEditor_ExportFilePath = instance.FilePath;
-        }, _ =>
-        {
-            childWindow.IsOpen = false;
-            ConfigurationManager.Current.IsChildWindowOpen = false;
-        }, [
-            ExportFileType.Csv, ExportFileType.Xml, ExportFileType.Json
-        ], true, SettingsManager.Current.HostsFileEditor_ExportFileType, SettingsManager.Current.HostsFileEditor_ExportFilePath);
+                childWindow.IsOpen = false;
+                ConfigurationManager.Current.IsChildWindowOpen = false;
+            }, [
+                ExportFileType.Csv, ExportFileType.Xml, ExportFileType.Json
+            ], true, SettingsManager.Current.HostsFileEditor_ExportFileType,
+            SettingsManager.Current.HostsFileEditor_ExportFilePath);
 
         childWindow.Title = Strings.Export;
 
@@ -265,7 +266,8 @@ public class HostsFileEditorViewModel : ViewModelBase
         return (Application.Current.MainWindow as MainWindow).ShowChildWindowAsync(childWindow);
     }
 
-    public ICommand EnableEntryCommand => new RelayCommand(_ => EnableEntryAction().ConfigureAwait(false), ModifyEntry_CanExecute);
+    public ICommand EnableEntryCommand =>
+        new RelayCommand(_ => EnableEntryAction().ConfigureAwait(false), ModifyEntry_CanExecute);
 
     private async Task EnableEntryAction()
     {
@@ -279,7 +281,8 @@ public class HostsFileEditorViewModel : ViewModelBase
         IsModifying = false;
     }
 
-    public ICommand DisableEntryCommand => new RelayCommand(_ => DisableEntryAction().ConfigureAwait(false), ModifyEntry_CanExecute);
+    public ICommand DisableEntryCommand =>
+        new RelayCommand(_ => DisableEntryAction().ConfigureAwait(false), ModifyEntry_CanExecute);
 
     private async Task DisableEntryAction()
     {
@@ -293,7 +296,8 @@ public class HostsFileEditorViewModel : ViewModelBase
         IsModifying = false;
     }
 
-    public ICommand AddEntryCommand => new RelayCommand(_ => AddEntryAction().ConfigureAwait(false), ModifyEntry_CanExecute);
+    public ICommand AddEntryCommand =>
+        new RelayCommand(_ => AddEntryAction().ConfigureAwait(false), ModifyEntry_CanExecute);
 
     private async Task AddEntryAction()
     {
@@ -307,12 +311,13 @@ public class HostsFileEditorViewModel : ViewModelBase
             ConfigurationManager.Current.IsChildWindowOpen = false;
 
             var result = await HostsFileEditor.AddEntryAsync(new HostsFileEntry
-            {
-                IsEnabled = instance.IsEnabled,
-                IPAddress = instance.IPAddress,
-                Hostname = instance.Hostname,
-                Comment = instance.Comment
-            });
+                (
+                    instance.IsEnabled,
+                    instance.IPAddress,
+                    instance.Hostname,
+                    instance.Comment
+                )
+            );
 
             if (result != HostsFileEntryModifyResult.Success)
                 await ShowErrorMessageAsync(result);
@@ -335,35 +340,8 @@ public class HostsFileEditorViewModel : ViewModelBase
         await (Application.Current.MainWindow as MainWindow).ShowChildWindowAsync(childWindow);
     }
 
-    private async Task ShowErrorMessageAsync(HostsFileEntryModifyResult result)
-    {
-        string message = result switch
-        {
-            HostsFileEntryModifyResult.ReadError => Strings.HostsFileReadErrorMessage,
-            HostsFileEntryModifyResult.WriteError => Strings.HostsFileWriteErrorMessage,
-            HostsFileEntryModifyResult.NotFound => Strings.HostsFileEntryNotFoundMessage,
-            HostsFileEntryModifyResult.BackupError => Strings.HostsFileBackupErrorMessage,
-            _ => Strings.UnkownError
-        };
-
-        var childWindow = new OKMessageChildWindow();
-
-        var childWindowViewModel = new OKMessageViewModel(_ =>
-         {
-             childWindow.IsOpen = false;
-             ConfigurationManager.Current.IsChildWindowOpen = false;
-         }, message);
-
-        childWindow.Title = Strings.Error;
-
-        childWindow.DataContext = childWindowViewModel;
-
-        ConfigurationManager.Current.IsChildWindowOpen = true;
-
-        await (Application.Current.MainWindow as MainWindow).ShowChildWindowAsync(childWindow);
-    }
-
-    public ICommand EditEntryCommand => new RelayCommand(_ => EditEntryAction().ConfigureAwait(false), ModifyEntry_CanExecute);
+    public ICommand EditEntryCommand =>
+        new RelayCommand(_ => EditEntryAction().ConfigureAwait(false), ModifyEntry_CanExecute);
 
     private async Task EditEntryAction()
     {
@@ -377,12 +355,13 @@ public class HostsFileEditorViewModel : ViewModelBase
             ConfigurationManager.Current.IsChildWindowOpen = false;
 
             var result = await HostsFileEditor.EditEntryAsync(instance.Entry, new HostsFileEntry
-            {
-                IsEnabled = instance.IsEnabled,
-                IPAddress = instance.IPAddress,
-                Hostname = instance.Hostname,
-                Comment = instance.Comment
-            });
+                (
+                    instance.IsEnabled,
+                    instance.IPAddress,
+                    instance.Hostname,
+                    instance.Comment
+                )
+            );
 
             if (result != HostsFileEntryModifyResult.Success)
                 await ShowErrorMessageAsync(result);
@@ -405,7 +384,8 @@ public class HostsFileEditorViewModel : ViewModelBase
         await (Application.Current.MainWindow as MainWindow).ShowChildWindowAsync(childWindow);
     }
 
-    public ICommand DeleteEntryCommand => new RelayCommand(_ => DeleteEntryAction().ConfigureAwait(false), ModifyEntry_CanExecute);
+    public ICommand DeleteEntryCommand =>
+        new RelayCommand(_ => DeleteEntryAction().ConfigureAwait(false), ModifyEntry_CanExecute);
 
     private async Task DeleteEntryAction()
     {
@@ -414,24 +394,25 @@ public class HostsFileEditorViewModel : ViewModelBase
         var childWindow = new OKCancelInfoMessageChildWindow();
 
         var childWindowViewModel = new OKCancelInfoMessageViewModel(async _ =>
-        {
-            childWindow.IsOpen = false;
-            ConfigurationManager.Current.IsChildWindowOpen = false;
+            {
+                childWindow.IsOpen = false;
+                ConfigurationManager.Current.IsChildWindowOpen = false;
 
-            var result = await HostsFileEditor.DeleteEntryAsync(SelectedResult);
+                var result = await HostsFileEditor.DeleteEntryAsync(SelectedResult);
 
-            if (result != HostsFileEntryModifyResult.Success)
-                await ShowErrorMessageAsync(result);
+                if (result != HostsFileEntryModifyResult.Success)
+                    await ShowErrorMessageAsync(result);
 
-            IsModifying = false;
-        }, _ =>
-        {
-            childWindow.IsOpen = false;
-            ConfigurationManager.Current.IsChildWindowOpen = false;
+                IsModifying = false;
+            }, _ =>
+            {
+                childWindow.IsOpen = false;
+                ConfigurationManager.Current.IsChildWindowOpen = false;
 
-            IsModifying = false;
-        },
-            string.Format(Strings.DeleteHostsFileEntryMessage, SelectedResult.IPAddress, SelectedResult.Hostname, string.IsNullOrEmpty(SelectedResult.Comment) ? "" : $"# {SelectedResult.Comment}"),
+                IsModifying = false;
+            },
+            string.Format(Strings.DeleteHostsFileEntryMessage, SelectedResult.IPAddress, SelectedResult.Hostname,
+                string.IsNullOrEmpty(SelectedResult.Comment) ? "" : $"# {SelectedResult.Comment}"),
             Strings.Delete
         );
 
@@ -447,11 +428,39 @@ public class HostsFileEditorViewModel : ViewModelBase
     private bool ModifyEntry_CanExecute(object obj)
     {
         return ConfigurationManager.Current.IsAdmin &&
-            Application.Current.MainWindow != null &&
-            !((MetroWindow)Application.Current.MainWindow).IsAnyDialogOpen &&
-            !ConfigurationManager.Current.IsChildWindowOpen &&
-            !IsRefreshing &&
-            !IsModifying;
+               Application.Current.MainWindow != null &&
+               !((MetroWindow)Application.Current.MainWindow).IsAnyDialogOpen &&
+               !ConfigurationManager.Current.IsChildWindowOpen &&
+               !IsRefreshing &&
+               !IsModifying;
+    }
+
+    private async Task ShowErrorMessageAsync(HostsFileEntryModifyResult result)
+    {
+        var message = result switch
+        {
+            HostsFileEntryModifyResult.ReadError => Strings.HostsFileReadErrorMessage,
+            HostsFileEntryModifyResult.WriteError => Strings.HostsFileWriteErrorMessage,
+            HostsFileEntryModifyResult.NotFound => Strings.HostsFileEntryNotFoundMessage,
+            HostsFileEntryModifyResult.BackupError => Strings.HostsFileBackupErrorMessage,
+            _ => Strings.UnkownError
+        };
+
+        var childWindow = new OKMessageChildWindow();
+
+        var childWindowViewModel = new OKMessageViewModel(_ =>
+        {
+            childWindow.IsOpen = false;
+            ConfigurationManager.Current.IsChildWindowOpen = false;
+        }, message);
+
+        childWindow.Title = Strings.Error;
+
+        childWindow.DataContext = childWindowViewModel;
+
+        ConfigurationManager.Current.IsChildWindowOpen = true;
+
+        await (Application.Current.MainWindow as MainWindow).ShowChildWindowAsync(childWindow);
     }
 
     public ICommand RestartAsAdminCommand => new RelayCommand(_ => RestartAsAdminAction().ConfigureAwait(false));
@@ -468,6 +477,7 @@ public class HostsFileEditorViewModel : ViewModelBase
                 MessageDialogStyle.Affirmative, AppearanceManager.MetroDialog);
         }
     }
+
     #endregion
 
     #region Methods
@@ -509,7 +519,8 @@ public class HostsFileEditorViewModel : ViewModelBase
                 StatusMessage = string.Format(Strings.FailedToLoadHostsFileMessage, ex.Message);
 
                 if (i < 3)
-                    StatusMessage += Environment.NewLine + string.Format(Strings.RetryingInXSecondsDots, GlobalStaticConfiguration.ApplicationUIRefreshInterval / 1000);
+                    StatusMessage += Environment.NewLine + string.Format(Strings.RetryingInXSecondsDots,
+                        GlobalStaticConfiguration.ApplicationUIRefreshInterval / 1000);
 
                 IsStatusMessageDisplayed = true;
 
@@ -522,12 +533,11 @@ public class HostsFileEditorViewModel : ViewModelBase
 
     public void OnViewVisible()
     {
-
     }
 
     public void OnViewHide()
     {
-
     }
+
     #endregion
 }

--- a/Source/NETworkManager/log4net.config
+++ b/Source/NETworkManager/log4net.config
@@ -1,8 +1,7 @@
 ﻿<log4net>
     <root>
         <!-- Log level: ALL, DEBUG, INFO, WARN, ERROR, FATAL, OFF -->
-        <level value="INFO"/>
-        <!--<level value="DEBUG"/>-->
+        <level value="INFO"/>        
         <appender-ref ref="console"/>
         <appender-ref ref="file"/>
     </root>

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -23,7 +23,7 @@ Release date: **xx.xx.2025**
 
 **Hosts File Editor**
 
-- New feature to display (and edit) the `hosts` file. (See [documentation](https://borntoberoot.net/NETworkManager/docs/application/hosts-file-editor) for more details) [#3012](https://github.com/BornToBeRoot/NETworkManager/pull/3012) [#3092](https://github.com/BornToBeRoot/NETworkManager/pull/3092) [#3094](https://github.com/BornToBeRoot/NETworkManager/pull/3094) [#3098](https://github.com/BornToBeRoot/NETworkManager/pull/3098)
+- New feature to display (and edit) the `hosts` file. (See [documentation](https://borntoberoot.net/NETworkManager/docs/application/hosts-file-editor) for more details) [#3012](https://github.com/BornToBeRoot/NETworkManager/pull/3012) [#3092](https://github.com/BornToBeRoot/NETworkManager/pull/3092) [#3094](https://github.com/BornToBeRoot/NETworkManager/pull/3094) [#3098](https://github.com/BornToBeRoot/NETworkManager/pull/3098) [#3103](https://github.com/BornToBeRoot/NETworkManager/pull/3103)
 
   :::info
 


### PR DESCRIPTION
## Changes proposed in this pull request

- Create hosts file entry
- Debug log

## Related issue(s)

- Fixes #3100

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request introduces several changes to improve code readability, simplify logic, and refactor the handling of `HostsFileEntry` objects in the `HostsFileEditor` module. Key updates include removing redundant methods, consolidating logic for creating host file entries, and improving logging and error handling.

### Refactoring and Simplification:

* Removed the `CreateEntryLine` method from `HostsFileEditor.cs` and integrated its logic directly into the `HostsFileEntry` constructor, simplifying the creation of host file entries. [[1]](diffhunk://#diff-76f3b834f3e286e450db8d121a95d460ab1d9f9552424504ab6f9efe6d19f4e3L524-L542) [[2]](diffhunk://#diff-f80f31342eefd744678db525dd7798df2a58430f26d3318e47f3ae84def21a7aR55-R63)
* Updated the `HostsFileEntry` constructor to generate the `Line` property internally, ensuring consistency and eliminating the need for external line creation.
* Replaced explicit object initialization with tuple-based initialization for `HostsFileEntry` objects across various methods, reducing verbosity. [[1]](diffhunk://#diff-76f3b834f3e286e450db8d121a95d460ab1d9f9552424504ab6f9efe6d19f4e3L135-R144) [[2]](diffhunk://#diff-b3600f52de0ebf5aa38b90debf2d6db9eafe36f151ba0facb7281d25b4c08795L310-R320) [[3]](diffhunk://#diff-b3600f52de0ebf5aa38b90debf2d6db9eafe36f151ba0facb7281d25b4c08795L380-R364)

### Enhanced Logging:

* Improved logging by using interpolated strings (`$"{expression}"`) instead of concatenation for better readability and performance. [[1]](diffhunk://#diff-76f3b834f3e286e450db8d121a95d460ab1d9f9552424504ab6f9efe6d19f4e3L135-R144) [[2]](diffhunk://#diff-76f3b834f3e286e450db8d121a95d460ab1d9f9552424504ab6f9efe6d19f4e3L160-R160) [[3]](diffhunk://#diff-76f3b834f3e286e450db8d121a95d460ab1d9f9552424504ab6f9efe6d19f4e3L204-R231)
* Added detailed debug logs to track operations like enabling, disabling, editing, and deleting entries, improving traceability. [[1]](diffhunk://#diff-76f3b834f3e286e450db8d121a95d460ab1d9f9552424504ab6f9efe6d19f4e3L204-R231) [[2]](diffhunk://#diff-76f3b834f3e286e450db8d121a95d460ab1d9f9552424504ab6f9efe6d19f4e3L284-L304) [[3]](diffhunk://#diff-76f3b834f3e286e450db8d121a95d460ab1d9f9552424504ab6f9efe6d19f4e3L418-L431)

### Error Handling and UI Improvements:

* Refactored the `ShowErrorMessageAsync` method to handle error messages centrally, improving modularity and reusability.
* Enhanced error message display logic to provide clearer feedback to users when operations fail. [[1]](diffhunk://#diff-b3600f52de0ebf5aa38b90debf2d6db9eafe36f151ba0facb7281d25b4c08795L338-R344) [[2]](diffhunk://#diff-b3600f52de0ebf5aa38b90debf2d6db9eafe36f151ba0facb7281d25b4c08795R438-R465)

### Code Style and Formatting:

* Simplified lambda expressions and reformatted code to adhere to consistent styling practices, improving readability. [[1]](diffhunk://#diff-b3600f52de0ebf5aa38b90debf2d6db9eafe36f151ba0facb7281d25b4c08795L186-R201) [[2]](diffhunk://#diff-b3600f52de0ebf5aa38b90debf2d6db9eafe36f151ba0facb7281d25b4c08795L257-R258)
* Adjusted command definitions to align with the project's coding standards. [[1]](diffhunk://#diff-b3600f52de0ebf5aa38b90debf2d6db9eafe36f151ba0facb7281d25b4c08795L268-R270) [[2]](diffhunk://#diff-b3600f52de0ebf5aa38b90debf2d6db9eafe36f151ba0facb7281d25b4c08795L282-R285)

These changes collectively enhance the maintainability and functionality of the `HostsFileEditor` module while ensuring a cleaner and more efficient codebase.

</details>

## To-Do

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
