### PR TITLE
Fix: 3099

### DIFF
--- a/Source/NETworkManager.Converters/ChildWindowIconToRectangleStyleConverter.cs
+++ b/Source/NETworkManager.Converters/ChildWindowIconToRectangleStyleConverter.cs
@@ -1,0 +1,33 @@
+﻿using NETworkManager.Utilities;
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace NETworkManager.Converters;
+
+public sealed class ChildWindowIconToRectangleStyleConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is not ChildWindowIcon icon)
+            return null;
+
+        switch (icon)
+        {
+            case ChildWindowIcon.Info:
+                return Application.Current.FindResource("InfoImageRectangle");
+            case ChildWindowIcon.Warn:
+                return Application.Current.FindResource("WarnImageRectangle");
+            case ChildWindowIcon.Error:
+                return Application.Current.FindResource("ErrorImageRectangle");
+            default:
+                return null;
+        }
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Source/NETworkManager.Utilities/ChildWindowIcon.cs
+++ b/Source/NETworkManager.Utilities/ChildWindowIcon.cs
@@ -1,0 +1,22 @@
+﻿namespace NETworkManager.Utilities;
+
+/// <summary>
+/// Ions for child dialogs.
+/// </summary>
+public enum ChildWindowIcon
+{
+    /// <summary>
+    /// Information icon.
+    /// </summary>
+    Info,
+
+    /// <summary>
+    /// Warning icon.
+    /// </summary>
+    Warn,
+
+    /// <summary>
+    /// Error icon.
+    /// </summary>
+    Error,
+}

--- a/Source/NETworkManager/Resources/Templates/ValidationErrorTemplates.xaml
+++ b/Source/NETworkManager/Resources/Templates/ValidationErrorTemplates.xaml
@@ -11,7 +11,7 @@
           -->
         <Grid>
             <Polygon x:Name="ToolTipCorner" Grid.ZIndex="1" Margin="0" Points="12,12 12,0 0,0"
-                     Fill="{DynamicResource MahApps.Brushes.Accent}" HorizontalAlignment="Right"
+                     Fill="#b95353" HorizontalAlignment="Right"
                      VerticalAlignment="Top" IsHitTestVisible="True" />
             <AdornedElementPlaceholder x:Name="Adorner" />
             <Popup PlacementTarget="{Binding ElementName=Adorner}" PopupAnimation="Fade" HorizontalOffset="5">

--- a/Source/NETworkManager/ViewModels/HostsFileEditorViewModel.cs
+++ b/Source/NETworkManager/ViewModels/HostsFileEditorViewModel.cs
@@ -452,7 +452,7 @@ public class HostsFileEditorViewModel : ViewModelBase
         {
             childWindow.IsOpen = false;
             ConfigurationManager.Current.IsChildWindowOpen = false;
-        }, message);
+        }, message, Strings.OK, ChildWindowIcon.Error);
 
         childWindow.Title = Strings.Error;
 

--- a/Source/NETworkManager/ViewModels/OKMessageViewModel.cs
+++ b/Source/NETworkManager/ViewModels/OKMessageViewModel.cs
@@ -6,13 +6,14 @@ namespace NETworkManager.ViewModels;
 
 public class OKMessageViewModel : ViewModelBase
 {
-    public OKMessageViewModel(Action<OKMessageViewModel> okCommand, string message, string okButtonText = null)
+    public OKMessageViewModel(Action<OKMessageViewModel> okCommand, string message, string okButtonText = null, ChildWindowIcon icon = ChildWindowIcon.Info)
     {
         OKCommand = new RelayCommand(_ => okCommand(this));
 
         Message = message;
 
         OKButtonText = okButtonText ?? Localization.Resources.Strings.OK;
+        Icon = icon;
     }
 
     public ICommand OKCommand { get; }
@@ -43,6 +44,21 @@ public class OKMessageViewModel : ViewModelBase
                 return;
 
             _okButtonText = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private ChildWindowIcon _icon;
+
+    public ChildWindowIcon Icon
+    {
+        get => _icon;
+        private init
+        {
+            if (value == _icon)
+                return;
+
+            _icon = value;
             OnPropertyChanged();
         }
     }

--- a/Source/NETworkManager/Views/OKMessageChildWindow.xaml
+++ b/Source/NETworkManager/Views/OKMessageChildWindow.xaml
@@ -7,6 +7,7 @@
              xmlns:localization="clr-namespace:NETworkManager.Localization.Resources;assembly=NETworkManager.Localization"
              xmlns:simpleChildWindow="clr-namespace:MahApps.Metro.SimpleChildWindow;assembly=MahApps.Metro.SimpleChildWindow"
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:converters="clr-namespace:NETworkManager.Converters;assembly=NETworkManager.Converters"
              ChildWindowWidth="450"
              ChildWindowMaxHeight="500"
              ShowTitleBar="True"
@@ -17,7 +18,11 @@
              CloseByEscape="False"                               
              OverlayBrush="{DynamicResource ResourceKey=MahApps.Brushes.Gray.SemiTransparent}"                               
              mc:Ignorable="d" d:DataContext="{d:DesignInstance viewModels:OKMessageViewModel}">
+    <simpleChildWindow:ChildWindow.Resources>
+        <converters:ChildWindowIconToRectangleStyleConverter x:Key="ChildWindowIconToRectangleStyleConverter" />
+    </simpleChildWindow:ChildWindow.Resources>
     <Grid Margin="10">
+        
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="20" />
@@ -34,7 +39,7 @@
                 </Grid.ColumnDefinitions>
                 <Rectangle Grid.Column="0" Grid.Row="0"
                            Width="32" Height="32"
-                           Style="{StaticResource InfoImageRectangle}" />
+                           Style="{Binding Icon, Converter={StaticResource ChildWindowIconToRectangleStyleConverter}}" />
                 <TextBlock Grid.Column="2" Grid.Row="0"
                            VerticalAlignment="Center"
                            Text="{Binding Message}"


### PR DESCRIPTION
## Changes proposed in this pull request

- Add icons for dialog
-

## Related issue(s)

- Fixes #3099

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request introduces a new feature to enhance the customization of child window icons in the `NETworkManager` application. It adds support for dynamically setting the icon style based on the context (e.g., Info, Warn, Error) and updates the UI components accordingly. Additionally, there are minor visual adjustments to the tooltip design.

### New Feature: Dynamic Child Window Icons
* **New Enum for Icon Types**: Added `ChildWindowIcon` enum to define icon types (`Info`, `Warn`, `Error`) for child dialogs (`Source/NETworkManager.Utilities/ChildWindowIcon.cs`).
* **Converter for Icon Styles**: Implemented `ChildWindowIconToRectangleStyleConverter` to map `ChildWindowIcon` values to corresponding rectangle styles (`Source/NETworkManager.Converters/ChildWindowIconToRectangleStyleConverter.cs`).
* **ViewModel Update**: Extended `OKMessageViewModel` to include an `Icon` property, allowing the icon type to be passed during initialization (`Source/NETworkManager/ViewModels/OKMessageViewModel.cs`). [[1]](diffhunk://#diff-0bb2a9152ac0d421a764669abe132226fa989bb9263f0abfd65421231b472cebL9-R16) [[2]](diffhunk://#diff-0bb2a9152ac0d421a764669abe132226fa989bb9263f0abfd65421231b472cebR50-R64)
* **UI Integration**: Updated `OKMessageChildWindow.xaml` to use the new converter for dynamically applying icon styles (`Source/NETworkManager/Views/OKMessageChildWindow.xaml`). [[1]](diffhunk://#diff-f37540dec094a464c3fe69a4e4f47585ce16289976c701805d51e8c70779f523R10) [[2]](diffhunk://#diff-f37540dec094a464c3fe69a4e4f47585ce16289976c701805d51e8c70779f523R21-R25) [[3]](diffhunk://#diff-f37540dec094a464c3fe69a4e4f47585ce16289976c701805d51e8c70779f523L37-R42)

### Minor Visual Update
* **Tooltip Color Adjustment**: Changed the tooltip corner fill color to a custom hex value (`#b95353`) for improved visual consistency (`Source/NETworkManager/Resources/Templates/ValidationErrorTemplates.xaml`).

</details>

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
