### PR TITLE
Feature: Replace IPv6 Regex with IPAddress Parse

### DIFF
--- a/Source/NETworkManager.Models/Network/SNTPLookup.cs
+++ b/Source/NETworkManager.Models/Network/SNTPLookup.cs
@@ -101,7 +101,7 @@ public sealed class SNTPLookup
                 // NTP requires an IP address to connect to
                 IPAddress serverIP = null;
 
-                if (IPAddress.TryParse(server.Server, out var address) && (address.AddressFamily == AddressFamily.InterNetwork || address.AddressFamily == AddressFamily.InterNetworkV6))
+                if (IPAddress.TryParse(server.Server, out var address) && address.AddressFamily is AddressFamily.InterNetwork or AddressFamily.InterNetworkV6)
                 {
                     serverIP = address;
                 }

--- a/Source/NETworkManager.Models/Network/SNTPLookup.cs
+++ b/Source/NETworkManager.Models/Network/SNTPLookup.cs
@@ -1,10 +1,9 @@
-﻿using System;
+﻿using NETworkManager.Utilities;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using NETworkManager.Utilities;
 
 namespace NETworkManager.Models.Network;
 
@@ -102,10 +101,9 @@ public sealed class SNTPLookup
                 // NTP requires an IP address to connect to
                 IPAddress serverIP = null;
 
-                if (Regex.IsMatch(server.Server, RegexHelper.IPv4AddressRegex) ||
-                    Regex.IsMatch(server.Server, RegexHelper.IPv6AddressRegex))
+                if (IPAddress.TryParse(server.Server, out var address) && (address.AddressFamily == AddressFamily.InterNetwork || address.AddressFamily == AddressFamily.InterNetworkV6))
                 {
-                    serverIP = IPAddress.Parse(server.Server);
+                    serverIP = address;
                 }
                 else
                 {

--- a/Source/NETworkManager.Validators/IPAddressOrHostnameAsRangeValidator.cs
+++ b/Source/NETworkManager.Validators/IPAddressOrHostnameAsRangeValidator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Net;
 using System.Text.RegularExpressions;
 using System.Windows.Controls;
 using NETworkManager.Localization.Resources;
@@ -19,11 +20,10 @@ public class IPAddressOrHostnameAsRangeValidator : ValidationRule
         {
             var localItem = item.Trim();
 
-            // Check if it is a valid IPv4 address like 192.168.0.1, a valid IPv6 address like ::1 or a valid hostname like server-01 or server-01.example.com
-            var isValid = Regex.IsMatch(localItem, RegexHelper.IPv4AddressRegex) ||
-                          Regex.IsMatch(localItem, RegexHelper.IPv6AddressRegex) ||
+            // Check if it is a valid IPv4 address like 192.168.0.1, a valid IPv6 address like "::1" or a valid hostname like "server-01" or "server-01.example.com"
+            var isValid = (IPAddress.TryParse(localItem, out var ipAddress) && ipAddress.AddressFamily is System.Net.Sockets.AddressFamily.InterNetwork or System.Net.Sockets.AddressFamily.InterNetworkV6) ||
                           Regex.IsMatch(localItem, RegexHelper.HostnameOrDomainRegex);
-
+            
             if (!isValid)
                 return new ValidationResult(false, Strings.EnterValidHostnameOrIPAddress);
         }

--- a/Source/NETworkManager.Validators/IPv6AddressValidator.cs
+++ b/Source/NETworkManager.Validators/IPv6AddressValidator.cs
@@ -1,5 +1,6 @@
 ﻿using NETworkManager.Localization.Resources;
 using System.Globalization;
+using System.Net;
 using System.Net.Sockets;
 using System.Windows.Controls;
 
@@ -11,7 +12,7 @@ public class IPv6AddressValidator : ValidationRule
     {
         var input = (value as string);
 
-        if (System.Net.IPAddress.TryParse(input, out var address) && address.AddressFamily == AddressFamily.InterNetworkV6)
+        if (IPAddress.TryParse(input, out var address) && address.AddressFamily == AddressFamily.InterNetworkV6)
             return ValidationResult.ValidResult;
 
         return new ValidationResult(false, Strings.EnterValidIPv6Address);

--- a/Source/NETworkManager.Validators/MultipleIPAddressesValidator.cs
+++ b/Source/NETworkManager.Validators/MultipleIPAddressesValidator.cs
@@ -1,8 +1,7 @@
 ﻿using System.Globalization;
-using System.Text.RegularExpressions;
+using System.Net;
 using System.Windows.Controls;
 using NETworkManager.Localization.Resources;
-using NETworkManager.Utilities;
 
 namespace NETworkManager.Validators;
 
@@ -10,15 +9,14 @@ public class MultipleIPAddressesValidator : ValidationRule
 {
     public override ValidationResult Validate(object value, CultureInfo cultureInfo)
     {
-        if (value == null)
-            return ValidationResult.ValidResult;
-
-        for (var index = 0; index < ((string)value).Split(';').Length; index++)
+        var ipAddresses = (value as string)?.Split(';');
+        
+        if (ipAddresses == null || ipAddresses.Length == 0)
+            return new ValidationResult(false, Strings.EnterOneOrMoreValidIPAddresses);
+        
+        foreach (var ipAddress in ipAddresses)
         {
-            var ipAddress = ((string)value).Split(';')[index];
-
-            if (!Regex.IsMatch(ipAddress.Trim(), RegexHelper.IPv4AddressRegex) &&
-                !Regex.IsMatch(ipAddress.Trim(), RegexHelper.IPv6AddressRegex))
+            if(!(IPAddress.TryParse(ipAddress, out var ip) && ip.AddressFamily is System.Net.Sockets.AddressFamily.InterNetwork or System.Net.Sockets.AddressFamily.InterNetworkV6))
                 return new ValidationResult(false, Strings.EnterOneOrMoreValidIPAddresses);
         }
 

--- a/Source/NETworkManager/Views/SettingsNetworkView.xaml
+++ b/Source/NETworkManager/Views/SettingsNetworkView.xaml
@@ -20,6 +20,7 @@
             <TextBox.Text>
                 <Binding Path="CustomDNSServer" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
                     <Binding.ValidationRules>
+                        <validators:EmptyValidator ValidatesOnTargetUpdated="True" />
                         <validators:MultipleIPAddressesValidator ValidatesOnTargetUpdated="True" />
                     </Binding.ValidationRules>
                 </Binding>

--- a/Source/global.json
+++ b/Source/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.412",
+    "version": "8.0.411",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }


### PR DESCRIPTION
## Changes proposed in this pull request

-  Replace IPv6 Regex with IPAddress Parse
-

ToDo:
- [ ] IPAddressOrHostnameAsRangeValidator -  Check if we need to use this more often to validate input

## Related issue(s)

- Fixes Status: Open.
#3097

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

{generated summary}

</details>

## To-Do

- [ ] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
