### PR TITLE
Feature: #3109 -  Add F2/Delete hotkeys in HostsFileEditor & Refactor

### DIFF
--- a/Source/NETworkManager/ViewModels/HostsFileEditorViewModel.cs
+++ b/Source/NETworkManager/ViewModels/HostsFileEditorViewModel.cs
@@ -473,8 +473,21 @@ public class HostsFileEditorViewModel : ViewModelBase
         }
         catch (Exception ex)
         {
-            await _dialogCoordinator.ShowMessageAsync(this, Strings.Error, ex.Message,
-                MessageDialogStyle.Affirmative, AppearanceManager.MetroDialog);
+            var childWindow = new OKMessageChildWindow();
+
+            var childWindowViewModel = new OKMessageViewModel(_ =>
+            {
+                childWindow.IsOpen = false;
+                ConfigurationManager.Current.IsChildWindowOpen = false;
+            }, ex.Message, Strings.OK, ChildWindowIcon.Error);
+
+            childWindow.Title = Strings.Error;
+
+            childWindow.DataContext = childWindowViewModel;
+
+            ConfigurationManager.Current.IsChildWindowOpen = true;
+
+            await (Application.Current.MainWindow as MainWindow).ShowChildWindowAsync(childWindow);
         }
     }
 

--- a/Source/NETworkManager/Views/AWSSessionManagerSettingsView.xaml.cs
+++ b/Source/NETworkManager/Views/AWSSessionManagerSettingsView.xaml.cs
@@ -41,6 +41,7 @@ public partial class AWSSessionManagerSettingsView
 
     private void DataGridRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
     {
-        _viewModel.EditAWSProfile().ConfigureAwait(false);
+        if (_viewModel.EditAWSProfileCommand.CanExecute(null))
+            _viewModel.EditAWSProfileCommand.Execute(null);
     }
 }

--- a/Source/NETworkManager/Views/CredentialsPasswordProfileFileChildWindow.xaml.cs
+++ b/Source/NETworkManager/Views/CredentialsPasswordProfileFileChildWindow.xaml.cs
@@ -13,7 +13,6 @@ public partial class CredentialsPasswordProfileFileChildWindow
 
     private void ChildWindow_OnLoaded(object sender, RoutedEventArgs e)
     {
-        // Focus the PasswordBox when the child window is loaded 
         Dispatcher.BeginInvoke(DispatcherPriority.ContextIdle, new Action(delegate
         {
             PasswordBoxPassword.Focus();

--- a/Source/NETworkManager/Views/DNSLookupSettingsView.xaml.cs
+++ b/Source/NETworkManager/Views/DNSLookupSettingsView.xaml.cs
@@ -1,8 +1,8 @@
-﻿using System.Windows;
+﻿using MahApps.Metro.Controls.Dialogs;
+using NETworkManager.ViewModels;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using MahApps.Metro.Controls.Dialogs;
-using NETworkManager.ViewModels;
 
 namespace NETworkManager.Views;
 
@@ -24,6 +24,7 @@ public partial class DNSLookupSettingsView
 
     private void DataGridRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
     {
-        _viewModel.EditDNSServer().ConfigureAwait(false);
+        if (_viewModel.EditDNSServerCommand.CanExecute(null))
+            _viewModel.EditDNSServerCommand.Execute(null);
     }
 }

--- a/Source/NETworkManager/Views/GroupChildWindow.xaml.cs
+++ b/Source/NETworkManager/Views/GroupChildWindow.xaml.cs
@@ -27,7 +27,6 @@ public partial class GroupChildWindow
 
     private void ChildWindow_OnLoaded(object sender, RoutedEventArgs e)
     {
-        // Focus the PasswordBox when the child window is loaded 
         Dispatcher.BeginInvoke(DispatcherPriority.ContextIdle, new Action(delegate
         {
             TextBoxName.Focus();

--- a/Source/NETworkManager/Views/HostsFileEditorEntryChildWindow.xaml.cs
+++ b/Source/NETworkManager/Views/HostsFileEditorEntryChildWindow.xaml.cs
@@ -13,7 +13,6 @@ public partial class HostsFileEditorEntryChildWindow
 
     private void ChildWindow_OnLoaded(object sender, RoutedEventArgs e)
     {
-        // Focus the PasswordBox when the child window is loaded 
         Dispatcher.BeginInvoke(DispatcherPriority.ContextIdle, new Action(delegate
         {
             TextBoxIPAddress.Focus();

--- a/Source/NETworkManager/Views/HostsFileEditorView.xaml
+++ b/Source/NETworkManager/Views/HostsFileEditorView.xaml
@@ -169,6 +169,7 @@
                     </controls:MultiSelectDataGrid.Resources>
                     <controls:MultiSelectDataGrid.RowStyle>
                         <Style TargetType="{x:Type DataGridRow}" BasedOn="{StaticResource MahApps.Styles.DataGridRow}">
+                            <EventSetter Event="MouseDoubleClick" Handler="DataGridRow_MouseDoubleClick" />
                             <Setter Property="ContextMenu" Value="{StaticResource MultiRowContextMenu}" />
                             <Style.Triggers>
                                 <DataTrigger
@@ -197,6 +198,10 @@
                                             SortMemberPath="Hostname"
                                             MinWidth="200" />
                     </controls:MultiSelectDataGrid.Columns>
+                    <controls:MultiSelectDataGrid.InputBindings>
+                        <KeyBinding Command="{Binding EditEntryCommand}" Key="F2" />
+                        <KeyBinding Command="{Binding DeleteEntryCommand}" Key="Delete" />
+                    </controls:MultiSelectDataGrid.InputBindings>
                 </controls:MultiSelectDataGrid>
                 <Grid Grid.Column="0" Grid.Row="4">
                     <Grid.ColumnDefinitions>

--- a/Source/NETworkManager/Views/HostsFileEditorView.xaml.cs
+++ b/Source/NETworkManager/Views/HostsFileEditorView.xaml.cs
@@ -1,7 +1,7 @@
-﻿using System.Windows;
-using System.Windows.Controls;
-using MahApps.Metro.Controls.Dialogs;
+﻿using MahApps.Metro.Controls.Dialogs;
 using NETworkManager.ViewModels;
+using System.Windows;
+using System.Windows.Controls;
 
 namespace NETworkManager.Views;
 
@@ -29,5 +29,11 @@ public partial class HostsFileEditorView
     {
         if (sender is ContextMenu menu)
             menu.DataContext = _viewModel;
+    }
+
+    private void DataGridRow_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+    {
+        if (_viewModel.EditEntryCommand.CanExecute(null))
+            _viewModel.EditEntryCommand.Execute(null);
     }
 }

--- a/Source/NETworkManager/Views/OKCancelInfoMessageChildWindow.xaml
+++ b/Source/NETworkManager/Views/OKCancelInfoMessageChildWindow.xaml
@@ -17,7 +17,8 @@
              AllowMove="True"
              TitleForeground="{DynamicResource MahApps.Brushes.Gray3}"
              CloseByEscape="False"                               
-             OverlayBrush="{DynamicResource ResourceKey=MahApps.Brushes.Gray.SemiTransparent}"                               
+             OverlayBrush="{DynamicResource ResourceKey=MahApps.Brushes.Gray.SemiTransparent}"         
+             Loaded="ChildWindow_Loaded"
              mc:Ignorable="d" d:DataContext="{d:DesignInstance viewModels:OKCancelInfoMessageViewModel}">
     <Grid Margin="10">
         <Grid.RowDefinitions>
@@ -40,13 +41,15 @@
                 <TextBlock Grid.Column="2" Grid.Row="0"
                            VerticalAlignment="Center"
                            Text="{Binding Message}"
-                           Style="{StaticResource ResourceKey=WrapTextBlock}"/>                
+                           Style="{StaticResource ResourceKey=WrapTextBlock}"/>
             </Grid>
         </ScrollViewer>
         <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Content="{Binding OKButtonText}" Command="{Binding Path=OKCommand}" IsDefault="True"
+            <Button x:Name="ButtonOK"
+                    Content="{Binding OKButtonText}" Command="{Binding Path=OKCommand}" IsDefault="True"
                     Style="{StaticResource ResourceKey=HighlightedButton}" Margin="0,0,10,0" />
-            <Button Content="{Binding CancelButtonText}" Command="{Binding Path=CancelCommand}" IsCancel="True"
+            <Button x:Name="ButtonCancel"
+                    Content="{Binding CancelButtonText}" Command="{Binding Path=CancelCommand}" IsCancel="True"
                     Style="{StaticResource ResourceKey=DefaultButton}" />
         </StackPanel>
     </Grid>

--- a/Source/NETworkManager/Views/OKCancelInfoMessageChildWindow.xaml.cs
+++ b/Source/NETworkManager/Views/OKCancelInfoMessageChildWindow.xaml.cs
@@ -1,9 +1,20 @@
-﻿namespace NETworkManager.Views;
+﻿using System;
+using System.Windows.Threading;
+
+namespace NETworkManager.Views;
 
 public partial class OKCancelInfoMessageChildWindow
 {
     public OKCancelInfoMessageChildWindow()
     {
         InitializeComponent();
+    }
+
+    private void ChildWindow_Loaded(object sender, System.Windows.RoutedEventArgs e)
+    {
+        Dispatcher.BeginInvoke(DispatcherPriority.ContextIdle, new Action(delegate
+        {
+            ButtonOK.Focus();
+        }));
     }
 }

--- a/Source/NETworkManager/Views/OKMessageChildWindow.xaml
+++ b/Source/NETworkManager/Views/OKMessageChildWindow.xaml
@@ -16,7 +16,8 @@
              AllowMove="True"
              TitleForeground="{DynamicResource MahApps.Brushes.Gray3}"
              CloseByEscape="False"                               
-             OverlayBrush="{DynamicResource ResourceKey=MahApps.Brushes.Gray.SemiTransparent}"                               
+             OverlayBrush="{DynamicResource ResourceKey=MahApps.Brushes.Gray.SemiTransparent}"      
+             Loaded="ChildWindow_Loaded"
              mc:Ignorable="d" d:DataContext="{d:DesignInstance viewModels:OKMessageViewModel}">
     <simpleChildWindow:ChildWindow.Resources>
         <converters:ChildWindowIconToRectangleStyleConverter x:Key="ChildWindowIconToRectangleStyleConverter" />
@@ -47,7 +48,8 @@
             </Grid>
         </ScrollViewer>
         <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Content="{Binding OKButtonText}" Command="{Binding Path=OKCommand}" IsDefault="True"
+            <Button x:Name="ButtonOK"
+                    Content="{Binding OKButtonText}" Command="{Binding Path=OKCommand}" IsDefault="True"
                     Style="{StaticResource ResourceKey=HighlightedButton}" />            
         </StackPanel>
     </Grid>

--- a/Source/NETworkManager/Views/OKMessageChildWindow.xaml.cs
+++ b/Source/NETworkManager/Views/OKMessageChildWindow.xaml.cs
@@ -1,9 +1,20 @@
-﻿namespace NETworkManager.Views;
+﻿using System;
+using System.Windows.Threading;
+
+namespace NETworkManager.Views;
 
 public partial class OKMessageChildWindow
 {
     public OKMessageChildWindow()
     {
         InitializeComponent();
+    }
+
+    private void ChildWindow_Loaded(object sender, System.Windows.RoutedEventArgs e)
+    {
+        Dispatcher.BeginInvoke(DispatcherPriority.ContextIdle, new Action(delegate
+        {
+            ButtonOK.Focus();
+        }));
     }
 }

--- a/Source/NETworkManager/Views/PortScannerSettingsView.xaml.cs
+++ b/Source/NETworkManager/Views/PortScannerSettingsView.xaml.cs
@@ -24,6 +24,7 @@ public partial class PortScannerSettingsView
 
     private void DataGridRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
     {
-        _viewModel.EditPortProfile().ConfigureAwait(false);
+        if (_viewModel.EditPortProfileCommand.CanExecute(null))
+            _viewModel.EditPortProfileCommand.Execute(null);
     }
 }

--- a/Source/NETworkManager/Views/ProfileChildWindow.xaml.cs
+++ b/Source/NETworkManager/Views/ProfileChildWindow.xaml.cs
@@ -31,7 +31,6 @@ public partial class ProfileChildWindow
 
     private void ChildWindow_OnLoaded(object sender, RoutedEventArgs e)
     {
-        // Focus the PasswordBox when the child window is loaded 
         Dispatcher.BeginInvoke(DispatcherPriority.ContextIdle, new Action(delegate
         {
             TextBoxName.Focus();

--- a/Source/NETworkManager/Views/SNMPSettingsView.xaml.cs
+++ b/Source/NETworkManager/Views/SNMPSettingsView.xaml.cs
@@ -24,6 +24,7 @@ public partial class SNMPSettingsView
 
     private void DataGridRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
     {
-        _viewModel.EditOIDProfile().ConfigureAwait(false);
+        if(_viewModel.EditOIDProfileCommand.CanExecute(null))
+            _viewModel.EditOIDProfileCommand.Execute(null);
     }
 }

--- a/Source/NETworkManager/Views/SNTPLookupSettingsView.xaml.cs
+++ b/Source/NETworkManager/Views/SNTPLookupSettingsView.xaml.cs
@@ -24,6 +24,7 @@ public partial class SNTPLookupSettingsView
 
     private void DataGridRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
     {
-        _viewModel.EditServer().ConfigureAwait(false);
+        if(_viewModel.EditServerCommand.CanExecute(null))
+            _viewModel.EditServerCommand.Execute(null);
     }
 }

--- a/Source/NETworkManager/Views/SettingsProfilesView.xaml.cs
+++ b/Source/NETworkManager/Views/SettingsProfilesView.xaml.cs
@@ -35,6 +35,7 @@ public partial class SettingsProfilesView
 
     private void DataGridRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
     {
-        _viewModel.EditProfileFileCommand.Execute(null);
+        if (_viewModel.EditProfileFileCommand.CanExecute(null))
+            _viewModel.EditProfileFileCommand.Execute(null);
     }
 }

--- a/Source/NETworkManager/Views/UpgradeChildWindow.xaml
+++ b/Source/NETworkManager/Views/UpgradeChildWindow.xaml
@@ -14,6 +14,7 @@
                                CloseByEscape="False"               
                                Padding="20"
                                OverlayBrush="{DynamicResource ResourceKey=MahApps.Brushes.Gray8}"
+             Loaded="ChildWindow_Loaded"
              mc:Ignorable="d" d:DataContext="{d:DesignInstance viewModels:UpgradeViewModel}">
     <Grid Margin="10">
         <Grid.RowDefinitions>
@@ -76,7 +77,8 @@
                 </Button>
             </StackPanel>
         </ScrollViewer>
-        <Button Grid.Column="0" Grid.Row="2" HorizontalAlignment="Right" Content="{x:Static Member=localization:Strings.Continue}"
+        <Button x:Name="ButtonContinue"
+                Grid.Column="0" Grid.Row="2" HorizontalAlignment="Right" Content="{x:Static Member=localization:Strings.Continue}"
                 Command="{Binding Path=ContinueCommand}" IsDefault="True"
                 Style="{StaticResource ResourceKey=HighlightedButton}" />   
           </Grid>

--- a/Source/NETworkManager/Views/UpgradeChildWindow.xaml.cs
+++ b/Source/NETworkManager/Views/UpgradeChildWindow.xaml.cs
@@ -1,9 +1,20 @@
-﻿namespace NETworkManager.Views;
+﻿using System;
+using System.Windows.Threading;
+
+namespace NETworkManager.Views;
 
 public partial class UpgradeChildWindow
 {
     public UpgradeChildWindow()
     {
         InitializeComponent();
+    }
+
+    private void ChildWindow_Loaded(object sender, System.Windows.RoutedEventArgs e)
+    {
+        Dispatcher.BeginInvoke(DispatcherPriority.ContextIdle, new Action(delegate
+        {
+            ButtonContinue.Focus();
+        }));
     }
 }

--- a/Source/NETworkManager/Views/WelcomeChildWindow.xaml
+++ b/Source/NETworkManager/Views/WelcomeChildWindow.xaml
@@ -15,6 +15,7 @@
                                CloseByEscape="False"               
                                Padding="20"
                                OverlayBrush="{DynamicResource MahApps.Brushes.Gray8}"
+                               Loaded="ChildWindow_Loaded"
              mc:Ignorable="d" d:DataContext="{d:DesignInstance viewModels:WelcomeViewModel}">
     <Grid Margin="10">
         <Grid.RowDefinitions>
@@ -125,7 +126,8 @@
                 </StackPanel>
             </StackPanel>
         </ScrollViewer>
-        <Button Grid.Column="0" Grid.Row="2" HorizontalAlignment="Right" Content="{x:Static Member=localization:Strings.Continue}"
+        <Button x:Name="ButtonContinue"
+                Grid.Column="0" Grid.Row="2" HorizontalAlignment="Right" Content="{x:Static Member=localization:Strings.Continue}"
                 Command="{Binding ContinueCommand}" IsDefault="True"
                 Style="{StaticResource ResourceKey=HighlightedButton}" />   
           </Grid>

--- a/Source/NETworkManager/Views/WelcomeChildWindow.xaml.cs
+++ b/Source/NETworkManager/Views/WelcomeChildWindow.xaml.cs
@@ -1,9 +1,20 @@
-﻿namespace NETworkManager.Views;
+﻿using System;
+using System.Windows.Threading;
+
+namespace NETworkManager.Views;
 
 public partial class WelcomeChildWindow
 {
     public WelcomeChildWindow()
     {
         InitializeComponent();
+    }
+
+    private void ChildWindow_Loaded(object sender, System.Windows.RoutedEventArgs e)
+    {
+        Dispatcher.BeginInvoke(DispatcherPriority.ContextIdle, new Action(delegate
+        {
+            ButtonContinue.Focus();
+        }));
     }
 }

--- a/Website/docs/application/hosts-file-editor.md
+++ b/Website/docs/application/hosts-file-editor.md
@@ -36,6 +36,8 @@ In addition, further actions can be performed using the buttons below:
 
 With `F5` you can refresh the hosts file.
 
-Right-click on the result to enable, disable, edit or delete an entry, or to copy or export the information.
+Right-click on the result to `enable`, `disable`, `edit` or `delete` an entry, or to `copy` or `export` the information.
+
+You can also use the Hotkeys `F2` (`edit`) or `Del` (`delete`) on a selected entry.
 
 :::


### PR DESCRIPTION
## Changes proposed in this pull request

- Add F2/Delete hotkeys in HostsFileEditor
- Refactor some code

## Related issue(s)

- Fixes #3109 

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request introduces several improvements to the `NETworkManager` project, focusing on enhancing user interface interactions, improving command execution patterns, and ensuring better accessibility by setting focus on specific UI elements when child windows are loaded. Below is a summary of the most important changes grouped by theme:

### Enhanced User Interface Interactions:
* [`Source/NETworkManager/ViewModels/HostsFileEditorViewModel.cs`](diffhunk://#diff-b3600f52de0ebf5aa38b90debf2d6db9eafe36f151ba0facb7281d25b4c08795L476-R490): Replaced the dialog coordinator with a child window (`OKMessageChildWindow`) for error messages, improving consistency in UI design.
* [`Source/NETworkManager/Views/HostsFileEditorView.xaml`](diffhunk://#diff-9f1858354e7d73553c57eb8c2b1ae9e997d7a60f42df5b5d26b4e0831902b98dR172): Added mouse double-click event and keyboard shortcuts (`F2` for edit, `Delete` for delete) to the `MultiSelectDataGrid` for better user interaction. [[1]](diffhunk://#diff-9f1858354e7d73553c57eb8c2b1ae9e997d7a60f42df5b5d26b4e0831902b98dR172) [[2]](diffhunk://#diff-9f1858354e7d73553c57eb8c2b1ae9e997d7a60f42df5b5d26b4e0831902b98dR201-R204)

### Improved Command Execution Patterns:
* Replaced direct method calls with `CanExecute` checks and `Execute` invocations for commands across multiple files to ensure proper command validation before execution:
  - [`Source/NETworkManager/Views/AWSSessionManagerSettingsView.xaml.cs`](diffhunk://#diff-2efb8beca85016f9f5b57026ba840b555eb3c6472813af7859d8ced34918fbbbL44-R45): Updated AWS profile editing logic.
  - [`Source/NETworkManager/Views/DNSLookupSettingsView.xaml.cs`](diffhunk://#diff-2bbc2aeb5247ba92080c49a604c8188af90b5d9f1731f3c0fcb24bf009da82b0L27-R28): Updated DNS server editing logic.
  - [`Source/NETworkManager/Views/HostsFileEditorView.xaml.cs`](diffhunk://#diff-6c87b74ff1ae8b5d8b5323ec74a9bf13c9f2c1f69d3f3fffe16559a2d3e1c39aR33-R38): Added command execution for editing entries.
  - Similar updates in `PortScannerSettingsView.xaml.cs`, `SNMPSettingsView.xaml.cs`, `SNTPLookupSettingsView.xaml.cs`, and `SettingsProfilesView.xaml.cs`. [[1]](diffhunk://#diff-02e38a780b90d053c6e3b6119dd4ee0cfa86190bc0a3a26ffda55ddf4c88b615L27-R28) [[2]](diffhunk://#diff-c9becee71a4cd7e68b6e107c2e42a7ed546bff68985cf9f6f8dc3d4d6192b36bL27-R28) [[3]](diffhunk://#diff-c5794b8e97f593536bcbd8307a953fb8f7dcfd8ada1f4e9714eac9e34238aa4dL27-R28) [[4]](diffhunk://#diff-100783c1992e4201949c08135594ce1015364e4839084ab43eabe2c9448ef62fR38)

### Accessibility Improvements in Child Windows:
* Added focus logic to specific UI elements when child windows are loaded to improve accessibility and user experience:
  - `Source/NETworkManager/Views/OKMessageChildWindow.xaml` and `OKMessageChildWindow.xaml.cs`: Focuses the `OK` button when loaded. [[1]](diffhunk://#diff-f37540dec094a464c3fe69a4e4f47585ce16289976c701805d51e8c70779f523R20) [[2]](diffhunk://#diff-1256eca2c51f77216a18cb8114b15e30604be9d7874c0380566847d8c8fce5dcL1-R19)
  - Similar focus improvements in `UpgradeChildWindow`, `WelcomeChildWindow`, and `OKCancelInfoMessageChildWindow`. [[1]](diffhunk://#diff-1de9d36d571673820542f59f4a5eb691f18717cd39f5f93c258bc526126a683fR17) [[2]](diffhunk://#diff-ac1eac6bbc83b795dd8d73343c6827c16f931eba71c46b93954da25a4e1e2cb9L1-R19) [[3]](diffhunk://#diff-2b2d1140059e44624e6e9bb73ee14f34d1d6aaf9391e0261e2658783851d086aR18) [[4]](diffhunk://#diff-1ddae73c246921902cc71fc45944172f33516382dd797d6ba567e278a3488682R21) [[5]](diffhunk://#diff-f4afc229566a8107850b2ce8148a60e746653b9d32c5e61517cc83b165fa5683L1-R19)

### Code Cleanup:
* Removed unnecessary comments and redundant `using` directives across several files to improve code readability and maintainability:
  - `Source/NETworkManager/Views/DNSLookupSettingsView.xaml.cs` and `HostsFileEditorView.xaml.cs`. [[1]](diffhunk://#diff-2bbc2aeb5247ba92080c49a604c8188af90b5d9f1731f3c0fcb24bf009da82b0L1-L5) [[2]](diffhunk://#diff-6c87b74ff1ae8b5d8b5323ec74a9bf13c9f2c1f69d3f3fffe16559a2d3e1c39aL1-R4)

These changes collectively enhance the user experience, improve code quality, and ensure better adherence to UI and accessibility standards.

</details>

## To-Do

- [x] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
