### PR TITLE
Feature: Hide IPv4/6, DNS and DHCP info if adapter is down

### DIFF
--- a/Source/NETworkManager.Converters/BooleansAndToVisibilityCollapsedConverter.cs
+++ b/Source/NETworkManager.Converters/BooleansAndToVisibilityCollapsedConverter.cs
@@ -6,11 +6,11 @@ using System.Windows.Data;
 
 namespace NETworkManager.Converters;
 
-public sealed class BooleanToVisibilityCollapsedMultiConverter : IMultiValueConverter
+public sealed class BooleansAndToVisibilityCollapsedConverter : IMultiValueConverter
 {
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
     {
-        return values.OfType<bool>().Any(b => b) ? Visibility.Visible : Visibility.Collapsed;
+        return values.OfType<bool>().All(b => b) ? Visibility.Visible : Visibility.Collapsed;
     }
 
     public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)

--- a/Source/NETworkManager.Converters/BooleansOrToVisibilityCollapsedConverter.cs
+++ b/Source/NETworkManager.Converters/BooleansOrToVisibilityCollapsedConverter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Windows;
+using System.Windows.Data;
+
+namespace NETworkManager.Converters;
+
+public sealed class BooleansOrToVisibilityCollapsedConverter : IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        return values.OfType<bool>().Any(b => b) ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Source/NETworkManager.Models/Network/NetworkInterface.cs
+++ b/Source/NETworkManager.Models/Network/NetworkInterface.cs
@@ -54,6 +54,7 @@ public sealed class NetworkInterface
             var ipProperties = networkInterface.GetIPProperties();
 
             foreach (var unicastIPAddrInfo in ipProperties.UnicastAddresses)
+            {
                 switch (unicastIPAddrInfo.Address.AddressFamily)
                 {
                     case AddressFamily.InterNetwork:
@@ -74,11 +75,13 @@ public sealed class NetworkInterface
                         listIPv6Address.Add(unicastIPAddrInfo.Address);
                         break;
                 }
+            }
 
             var listIPv4Gateway = new List<IPAddress>();
             var listIPv6Gateway = new List<IPAddress>();
 
             foreach (var gatewayIPAddrInfo in ipProperties.GatewayAddresses)
+            {
                 switch (gatewayIPAddrInfo.Address.AddressFamily)
                 {
                     case AddressFamily.InterNetwork:
@@ -88,6 +91,7 @@ public sealed class NetworkInterface
                         listIPv6Gateway.Add(gatewayIPAddrInfo.Address);
                         break;
                 }
+            }
 
             // Check if autoconfiguration for DNS is enabled (only via registry key)
             var nameServerKey =

--- a/Source/NETworkManager/Views/IPScannerView.xaml
+++ b/Source/NETworkManager/Views/IPScannerView.xaml
@@ -24,7 +24,7 @@
         <converters:BooleanReverseToVisibilityCollapsedConverter x:Key="BooleanReverseToVisibilityCollapsedConverter" />
         <converters:BooleanToStringConverter x:Key="BooleanToStringConverter" />
         <converters:BooleanToVisibilityCollapsedConverter x:Key="BooleanToVisibilityCollapsedConverter" />
-        <converters:BooleanToVisibilityCollapsedMultiConverter x:Key="BooleanToVisibilityCollapsedMultiConverter" />
+        <converters:BooleansOrToVisibilityCollapsedConverter x:Key="BooleansOrToVisibilityCollapsedConverter" />
         <converters:HostUpStyleConverter x:Key="HostUpStyleConverter" />
         <converters:IPStatusToStringConverter x:Key="IPStatusToStringConverter" />
         <converters:IntNotZeroToVisibilityCollapsedConverter x:Key="IntNotZeroToVisibilityCollapsedConverter" />
@@ -518,7 +518,7 @@
                                     SortMemberPath="Hostname"
                                     MinWidth="150">
                     <DataGridTextColumn.Visibility>
-                        <MultiBinding Converter="{StaticResource BooleanToVisibilityCollapsedMultiConverter}">
+                        <MultiBinding Converter="{StaticResource BooleansOrToVisibilityCollapsedConverter}">
                             <Binding Source="{x:Static Member=settings:SettingsManager.Current}"
                                      Path="IPScanner_ResolveHostname" />
                             <Binding Source="{x:Static Member=settings:SettingsManager.Current}"
@@ -544,7 +544,7 @@
                                     SortMemberPath="MACAddress"
                                     MinWidth="150">
                     <DataGridTextColumn.Visibility>
-                        <MultiBinding Converter="{StaticResource BooleanToVisibilityCollapsedMultiConverter}">
+                        <MultiBinding Converter="{StaticResource BooleansOrToVisibilityCollapsedConverter}">
                             <Binding Source="{x:Static Member=settings:SettingsManager.Current}"
                                      Path="IPScanner_ResolveMACAddress" />
                             <Binding Source="{x:Static Member=settings:SettingsManager.Current}"
@@ -557,7 +557,7 @@
                                     SortMemberPath="Vendor"
                                     MinWidth="200">
                     <DataGridTextColumn.Visibility>
-                        <MultiBinding Converter="{StaticResource BooleanToVisibilityCollapsedMultiConverter}">
+                        <MultiBinding Converter="{StaticResource BooleansOrToVisibilityCollapsedConverter}">
                             <Binding Source="{x:Static Member=settings:SettingsManager.Current}"
                                      Path="IPScanner_ResolveMACAddress" />
                             <Binding Source="{x:Static Member=settings:SettingsManager.Current}"

--- a/Source/NETworkManager/Views/NetworkInterfaceView.xaml
+++ b/Source/NETworkManager/Views/NetworkInterfaceView.xaml
@@ -26,6 +26,7 @@
         <converters:BooleanReverseConverter x:Key="BooleanReverseConverter" />
         <converters:BooleanReverseToVisibilityCollapsedConverter x:Key="BooleanReverseToVisibilityCollapsedConverter" />
         <converters:BooleanToVisibilityCollapsedConverter x:Key="BooleanToVisibilityCollapsedConverter" />
+        <converters:BooleansAndToVisibilityCollapsedConverter x:Key="BooleansAndToVisibilityCollapsedConverter" />
         <converters:BooleanToStringConverter x:Key="BooleanToStringConverter" />
         <converters:Bytes1000ToSpeedConverter x:Key="Bytes1000ToSpeedConverter" />
         <converters:Bytes1000ToSizeConverter x:Key="Bytes1000ToSizeConverter" />
@@ -222,98 +223,302 @@
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
                                 </Grid.RowDefinitions>
-                                <GridSplitter Grid.Column="1" Grid.RowSpan="20" Background="Transparent"
+                                <GridSplitter Grid.Column="1" Grid.RowSpan="20"
+                                              Background="Transparent"
                                               HorizontalAlignment="Stretch" />
-                                <TextBlock Grid.Column="0" Grid.Row="0" Text="{x:Static localization:Strings.Name}" />
-                                <TextBox Grid.Column="2" Grid.Row="0" Text="{Binding SelectedNetworkInterface.Name}" />
+
+                                <TextBlock Grid.Column="0" Grid.Row="0"
+                                           Text="{x:Static localization:Strings.Name}" />
+                                <TextBox Grid.Column="2" Grid.Row="0"
+                                         Text="{Binding SelectedNetworkInterface.Name}" />
                                 <TextBlock Grid.Column="0" Grid.Row="1"
                                            Text="{x:Static localization:Strings.Description}" />
                                 <TextBox Grid.Column="2" Grid.Row="1"
                                          Text="{Binding SelectedNetworkInterface.Description}" />
-                                <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static localization:Strings.Type}" />
-                                <TextBox Grid.Column="2" Grid.Row="2" Text="{Binding SelectedNetworkInterface.Type}" />
+                                <TextBlock Grid.Column="0" Grid.Row="2"
+                                           Text="{x:Static localization:Strings.Type}" />
+                                <TextBox Grid.Column="2" Grid.Row="2"
+                                         Text="{Binding SelectedNetworkInterface.Type}" />
                                 <TextBlock Grid.Column="0" Grid.Row="3"
                                            Text="{x:Static localization:Strings.PhysicalAddress}" />
                                 <TextBox Grid.Column="2" Grid.Row="3"
                                          Text="{Binding SelectedNetworkInterface.PhysicalAddress, Converter={StaticResource PhysicalAddressToStringConverter}}" />
-                                <TextBlock Grid.Column="0" Grid.Row="4" Text="{x:Static localization:Strings.Status}" />
+                                <TextBlock Grid.Column="0" Grid.Row="4"
+                                           Text="{x:Static localization:Strings.Status}" />
                                 <TextBox Grid.Column="2" Grid.Row="4"
                                          Text="{Binding SelectedNetworkInterface.Status, Converter={StaticResource OperationalStatusToStringConverter}}" />
-                                <TextBlock Grid.Column="0" Grid.Row="5" Text="{x:Static localization:Strings.Speed}" />
+                                <TextBlock Grid.Column="0" Grid.Row="5"
+                                           Text="{x:Static localization:Strings.Speed}" />
                                 <TextBox Grid.Column="2" Grid.Row="5"
                                          Text="{Binding SelectedNetworkInterface.Speed, Converter={StaticResource Bytes1000ToSpeedConverter}}" />
                                 <TextBlock Grid.Column="0" Grid.Row="6"
-                                           Text="{x:Static localization:Strings.IPv4ProtocolAvailable}" />
+                                           Text="{x:Static localization:Strings.IPv4ProtocolAvailable}">
+                                    <TextBlock.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                        </MultiBinding>
+                                    </TextBlock.Visibility>
+                                </TextBlock>
                                 <TextBox Grid.Column="2" Grid.Row="6"
-                                         Text="{Binding SelectedNetworkInterface.IPv4ProtocolAvailable, Converter={StaticResource BooleanToStringConverter}}" />
+                                         Text="{Binding SelectedNetworkInterface.IPv4ProtocolAvailable, Converter={StaticResource BooleanToStringConverter}}">
+                                    <TextBox.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                        </MultiBinding>
+                                    </TextBox.Visibility>
+                                </TextBox>
                                 <TextBlock Grid.Column="0" Grid.Row="7"
-                                           Text="{x:Static localization:Strings.IPv4Address}"
-                                           Visibility="{Binding SelectedNetworkInterface.IPv4ProtocolAvailable, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                           Text="{x:Static localization:Strings.IPv4Address}">
+                                    <TextBlock.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                            <Binding Path="SelectedNetworkInterface.IPv4ProtocolAvailable" />
+                                        </MultiBinding>
+                                    </TextBlock.Visibility>
+                                </TextBlock>
                                 <TextBox Grid.Column="2" Grid.Row="7"
-                                         Text="{Binding SelectedNetworkInterface.IPv4Address, Converter={StaticResource IPAddressSubnetmaskTupleArrayToStringConverter}}"
-                                         Visibility="{Binding SelectedNetworkInterface.IPv4ProtocolAvailable, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                         Text="{Binding SelectedNetworkInterface.IPv4Address, Converter={StaticResource IPAddressSubnetmaskTupleArrayToStringConverter}}">
+                                    <TextBox.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                            <Binding Path="SelectedNetworkInterface.IPv4ProtocolAvailable" />
+                                        </MultiBinding>
+                                    </TextBox.Visibility>
+                                </TextBox>
                                 <TextBlock Grid.Column="0" Grid.Row="8"
-                                           Text="{x:Static localization:Strings.IPv4DefaultGateway}"
-                                           Visibility="{Binding SelectedNetworkInterface.IPv4ProtocolAvailable, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                           Text="{x:Static localization:Strings.IPv4DefaultGateway}">
+                                    <TextBlock.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                            <Binding Path="SelectedNetworkInterface.IPv4ProtocolAvailable" />
+                                        </MultiBinding>
+                                    </TextBlock.Visibility>
+                                </TextBlock>
                                 <TextBox Grid.Column="2" Grid.Row="8"
-                                         Text="{Binding SelectedNetworkInterface.IPv4Gateway, Converter={StaticResource IPAddressArrayToStringConverter}}"
-                                         Visibility="{Binding SelectedNetworkInterface.IPv4ProtocolAvailable, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                         Text="{Binding SelectedNetworkInterface.IPv4Gateway, Converter={StaticResource IPAddressArrayToStringConverter}}">
+                                    <TextBox.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                            <Binding Path="SelectedNetworkInterface.IPv4ProtocolAvailable" />
+                                        </MultiBinding>
+                                    </TextBox.Visibility>
+                                </TextBox>
                                 <TextBlock Grid.Column="0" Grid.Row="9"
-                                           Text="{x:Static localization:Strings.DHCPEnabled}" />
+                                           Text="{x:Static localization:Strings.DHCPEnabled}">
+                                    <TextBlock.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                        </MultiBinding>
+                                    </TextBlock.Visibility>
+                                </TextBlock>
                                 <TextBox Grid.Column="2" Grid.Row="9"
-                                         Text="{Binding SelectedNetworkInterface.DhcpEnabled, Converter={StaticResource BooleanToStringConverter}}" />
+                                         Text="{Binding SelectedNetworkInterface.DhcpEnabled, Converter={StaticResource BooleanToStringConverter}}">
+                                    <TextBox.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                        </MultiBinding>
+                                    </TextBox.Visibility>
+                                </TextBox>
                                 <TextBlock Grid.Column="0" Grid.Row="10"
-                                           Text="{x:Static localization:Strings.DHCPServer}"
-                                           Visibility="{Binding SelectedNetworkInterface.DhcpEnabled, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                           Text="{x:Static localization:Strings.DHCPServer}">
+                                    <TextBlock.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                            <Binding Path="SelectedNetworkInterface.DhcpEnabled" />
+                                        </MultiBinding>
+                                    </TextBlock.Visibility>
+                                </TextBlock>
                                 <TextBox Grid.Column="2" Grid.Row="10"
-                                         Text="{Binding SelectedNetworkInterface.DhcpServer, Converter={StaticResource IPAddressArrayToStringConverter}}"
-                                         Visibility="{Binding SelectedNetworkInterface.DhcpEnabled, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                         Text="{Binding SelectedNetworkInterface.DhcpServer, Converter={StaticResource IPAddressArrayToStringConverter}}">
+                                    <TextBox.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                            <Binding Path="SelectedNetworkInterface.DhcpEnabled" />
+                                        </MultiBinding>
+                                    </TextBox.Visibility>
+                                </TextBox>
                                 <TextBlock Grid.Column="0" Grid.Row="11"
-                                           Text="{x:Static localization:Strings.DHCPLeaseObtained}"
-                                           Visibility="{Binding SelectedNetworkInterface.DhcpEnabled, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                           Text="{x:Static localization:Strings.DHCPLeaseObtained}">
+                                    <TextBlock.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                            <Binding Path="SelectedNetworkInterface.DhcpEnabled" />
+                                        </MultiBinding>
+                                    </TextBlock.Visibility>
+                                </TextBlock>
                                 <TextBox Grid.Column="2" Grid.Row="11"
-                                         Text="{Binding SelectedNetworkInterface.DhcpLeaseObtained}"
-                                         Visibility="{Binding SelectedNetworkInterface.DhcpEnabled, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                         Text="{Binding SelectedNetworkInterface.DhcpLeaseObtained}">
+                                    <TextBox.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                            <Binding Path="SelectedNetworkInterface.DhcpEnabled" />
+                                        </MultiBinding>
+                                    </TextBox.Visibility>
+                                </TextBox>
                                 <TextBlock Grid.Column="0" Grid.Row="12"
-                                           Text="{x:Static localization:Strings.DHCPLeaseExpires}"
-                                           Visibility="{Binding SelectedNetworkInterface.DhcpEnabled, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                           Text="{x:Static localization:Strings.DHCPLeaseExpires}">
+                                    <TextBlock.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                            <Binding Path="SelectedNetworkInterface.DhcpEnabled" />
+                                        </MultiBinding>
+                                    </TextBlock.Visibility>
+                                </TextBlock>
                                 <TextBox Grid.Column="2" Grid.Row="12"
-                                         Text="{Binding SelectedNetworkInterface.DhcpLeaseExpires}"
-                                         Visibility="{Binding SelectedNetworkInterface.DhcpEnabled, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                         Text="{Binding SelectedNetworkInterface.DhcpLeaseExpires}">
+                                    <TextBox.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                            <Binding Path="SelectedNetworkInterface.DhcpEnabled" />
+                                        </MultiBinding>
+                                    </TextBox.Visibility>
+                                </TextBox>
                                 <TextBlock Grid.Column="0" Grid.Row="13"
-                                           Text="{x:Static localization:Strings.IPv6ProtocolAvailable}" />
+                                           Text="{x:Static localization:Strings.IPv6ProtocolAvailable}">
+                                    <TextBlock.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                        </MultiBinding>
+                                    </TextBlock.Visibility>
+                                </TextBlock>
                                 <TextBox Grid.Column="2" Grid.Row="13"
-                                         Text="{Binding SelectedNetworkInterface.IPv6ProtocolAvailable, Converter={StaticResource BooleanToStringConverter}}" />
+                                         Text="{Binding SelectedNetworkInterface.IPv6ProtocolAvailable, Converter={StaticResource BooleanToStringConverter}}">
+                                    <TextBox.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                        </MultiBinding>
+                                    </TextBox.Visibility>
+                                </TextBox>
                                 <TextBlock Grid.Column="0" Grid.Row="14"
-                                           Text="{x:Static localization:Strings.IPv6AddressLinkLocal}"
-                                           Visibility="{Binding SelectedNetworkInterface.IPv6ProtocolAvailable, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                           Text="{x:Static localization:Strings.IPv6AddressLinkLocal}">
+                                    <TextBlock.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                            <Binding Path="SelectedNetworkInterface.IPv6ProtocolAvailable" />
+                                        </MultiBinding>
+                                    </TextBlock.Visibility>
+                                </TextBlock>
                                 <TextBox Grid.Column="2" Grid.Row="14"
-                                         Text="{Binding SelectedNetworkInterface.IPv6AddressLinkLocal, Converter={StaticResource IPAddressArrayToStringConverter}}"
-                                         Visibility="{Binding SelectedNetworkInterface.IPv6ProtocolAvailable, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                         Text="{Binding SelectedNetworkInterface.IPv6AddressLinkLocal, Converter={StaticResource IPAddressArrayToStringConverter}}">
+                                    <TextBox.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                            <Binding Path="SelectedNetworkInterface.IPv6ProtocolAvailable" />
+                                        </MultiBinding>
+                                    </TextBox.Visibility>
+                                </TextBox>
                                 <TextBlock Grid.Column="0" Grid.Row="15"
-                                           Text="{x:Static localization:Strings.IPv6Address}"
-                                           Visibility="{Binding SelectedNetworkInterface.IPv6ProtocolAvailable, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                           Text="{x:Static localization:Strings.IPv6Address}">
+                                    <TextBlock.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                            <Binding Path="SelectedNetworkInterface.IPv6ProtocolAvailable" />
+                                        </MultiBinding>
+                                    </TextBlock.Visibility>
+                                </TextBlock>
                                 <TextBox Grid.Column="2" Grid.Row="15"
-                                         Text="{Binding SelectedNetworkInterface.IPv6Address, Converter={StaticResource IPAddressArrayToStringConverter}}"
-                                         Visibility="{Binding SelectedNetworkInterface.IPv6ProtocolAvailable, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                         Text="{Binding SelectedNetworkInterface.IPv6Address, Converter={StaticResource IPAddressArrayToStringConverter}}">
+                                    <TextBox.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                            <Binding Path="SelectedNetworkInterface.IPv6ProtocolAvailable" />
+                                        </MultiBinding>
+                                    </TextBox.Visibility>
+                                </TextBox>
                                 <TextBlock Grid.Column="0" Grid.Row="16"
-                                           Text="{x:Static localization:Strings.IPv6DefaultGateway}"
-                                           Visibility="{Binding SelectedNetworkInterface.IPv6ProtocolAvailable, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                           Text="{x:Static localization:Strings.IPv6DefaultGateway}">
+                                    <TextBlock.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                            <Binding Path="SelectedNetworkInterface.IPv6ProtocolAvailable" />
+                                        </MultiBinding>
+                                    </TextBlock.Visibility>
+                                </TextBlock>
                                 <TextBox Grid.Column="2" Grid.Row="16"
-                                         Text="{Binding SelectedNetworkInterface.IPv6Gateway , Converter={StaticResource IPAddressArrayToStringConverter}}"
-                                         Visibility="{Binding SelectedNetworkInterface.IPv6ProtocolAvailable, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                         Text="{Binding SelectedNetworkInterface.IPv6Gateway , Converter={StaticResource IPAddressArrayToStringConverter}}">
+                                    <TextBox.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                            <Binding Path="SelectedNetworkInterface.IPv6ProtocolAvailable" />
+                                        </MultiBinding>
+                                    </TextBox.Visibility>
+                                </TextBox>
                                 <TextBlock Grid.Column="0" Grid.Row="17"
-                                           Text="{x:Static localization:Strings.DNSAutoconfiguration}" />
+                                           Text="{x:Static localization:Strings.DNSAutoconfiguration}">
+                                    <TextBlock.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                        </MultiBinding>
+                                    </TextBlock.Visibility>
+                                </TextBlock>
                                 <TextBox Grid.Column="2" Grid.Row="17"
-                                         Text="{Binding SelectedNetworkInterface.DNSAutoconfigurationEnabled, Converter={StaticResource BooleanToStringConverter}}" />
+                                         Text="{Binding SelectedNetworkInterface.DNSAutoconfigurationEnabled, Converter={StaticResource BooleanToStringConverter}}">
+                                    <TextBox.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                        </MultiBinding>
+                                    </TextBox.Visibility>
+                                </TextBox>
                                 <TextBlock Grid.Column="0" Grid.Row="18"
-                                           Text="{x:Static localization:Strings.DNSSuffix}" />
+                                           Text="{x:Static localization:Strings.DNSSuffix}">
+                                    <TextBlock.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                        </MultiBinding>
+                                    </TextBlock.Visibility>
+                                </TextBlock>
                                 <TextBox Grid.Column="2" Grid.Row="18"
-                                         Text="{Binding SelectedNetworkInterface.DNSSuffix}" />
+                                         Text="{Binding SelectedNetworkInterface.DNSSuffix}">
+                                    <TextBox.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                        </MultiBinding>
+                                    </TextBox.Visibility>
+                                </TextBox>
                                 <TextBlock Grid.Column="0" Grid.Row="19"
-                                           Text="{x:Static localization:Strings.DNSServers}" />
+                                           Text="{x:Static localization:Strings.DNSServers}">
+                                    <TextBlock.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                        </MultiBinding>
+                                    </TextBlock.Visibility>
+                                </TextBlock>
                                 <TextBox Grid.Column="2" Grid.Row="19"
-                                         Text="{Binding SelectedNetworkInterface.DNSServer, Converter={StaticResource IPAddressArrayToStringConverter}}" />
+                                         Text="{Binding SelectedNetworkInterface.DNSServer, Converter={StaticResource IPAddressArrayToStringConverter}}">
+                                    <TextBox.Visibility>
+                                        <MultiBinding
+                                            Converter="{StaticResource BooleansAndToVisibilityCollapsedConverter}">
+                                            <Binding Path="SelectedNetworkInterface.IsOperational" />
+                                        </MultiBinding>
+                                    </TextBox.Visibility>
+                                </TextBox>
                             </Grid>
                         </ScrollViewer>
                         <mahAppsControls:MetroProgressBar Grid.Row="4"
@@ -1396,11 +1601,15 @@
                                         <Grid.ToolTip>
                                             <ToolTip MinWidth="250">
                                                 <StackPanel Margin="10">
-                                                    <TextBlock Text="{Binding Host}" Style="{StaticResource DefaultTextBlock}" />
-                                                    <Separator Background="{DynamicResource MahApps.Brushes.Gray8}" Margin="0,10" />
-                                                    <TextBlock Text="{Binding Description}" Style="{StaticResource InfoTextBlock}" TextWrapping="Wrap" />
+                                                    <TextBlock Text="{Binding Host}"
+                                                               Style="{StaticResource DefaultTextBlock}" />
+                                                    <Separator Background="{DynamicResource MahApps.Brushes.Gray8}"
+                                                               Margin="0,10" />
+                                                    <TextBlock Text="{Binding Description}"
+                                                               Style="{StaticResource InfoTextBlock}"
+                                                               TextWrapping="Wrap" />
                                                 </StackPanel>
-                                            </ToolTip>                                        
+                                            </ToolTip>
                                         </Grid.ToolTip>
                                         <TextBlock Text="{Binding Name}" Style="{StaticResource CenterTextBlock}" />
                                     </Grid>

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -46,6 +46,10 @@ Release date: **xx.xx.2025**
 - Redesign export dialog. [#3090](https://github.com/BornToBeRoot/NETworkManager/pull/3090)
 - Add upgrade dialog when updating from a previous version. [#3077](https://github.com/BornToBeRoot/NETworkManager/pull/3077)
 
+**Network Interface**
+
+- Hide (outdated) IPv4/IPv6, DHCP, and DNS informations if adapter is not connected (Status is `down`). [#3114](https://github.com/BornToBeRoot/NETworkManager/pull/3114)
+
 **WiFi**
 
 - Redesign refresh button/view. [#3012](https://github.com/BornToBeRoot/NETworkManager/pull/3012)


### PR DESCRIPTION
## Changes proposed in this pull request

- Hide IPv4/6, DNS and DHCP info if adapter is down
-

## Related issue(s)

- Fixes #3111

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request introduces new converters for handling visibility logic based on boolean values, refactors existing converters for clarity, and improves code readability in the `GetNetworkInterfaces` method. Additionally, it updates XAML files to utilize the new converters.

### Converter Enhancements:

* Added `BooleansAndToVisibilityCollapsedConverter` to handle visibility logic where all boolean values must be `true` for visibility. (`Source/NETworkManager.Converters/BooleansAndToVisibilityCollapsedConverter.cs`, [Source/NETworkManager.Converters/BooleansAndToVisibilityCollapsedConverter.csR1-R20](diffhunk://#diff-8b8bd0f29c3a7534f347227c97093c5d9ef02cb7163b250a0903be4bd064749cR1-R20))
* Renamed `BooleanToVisibilityCollapsedMultiConverter` to `BooleansOrToVisibilityCollapsedConverter` for clarity and updated its usage in XAML files. (`Source/NETworkManager.Converters/BooleansOrToVisibilityCollapsedConverter.cs`, [[1]](diffhunk://#diff-9c6bd966411b57b3ca0238c8fd47ed5e57c5536611b46b27f9bbfa1c5df5e142L9-R9); `Source/NETworkManager/Views/IPScannerView.xaml`, [[2]](diffhunk://#diff-2abe8b94765df22bf4c72b246cad6ddea39d5c7029bc2d141dcb77ddd18a80a5L27-R27) [[3]](diffhunk://#diff-2abe8b94765df22bf4c72b246cad6ddea39d5c7029bc2d141dcb77ddd18a80a5L521-R521) [[4]](diffhunk://#diff-2abe8b94765df22bf4c72b246cad6ddea39d5c7029bc2d141dcb77ddd18a80a5L547-R547) [[5]](diffhunk://#diff-2abe8b94765df22bf4c72b246cad6ddea39d5c7029bc2d141dcb77ddd18a80a5L560-R560)

### Code Readability Improvements:

* Added missing braces `{}` in the `GetNetworkInterfaces` method to improve readability and maintain consistency. (`Source/NETworkManager.Models/Network/NetworkInterface.cs`, [[1]](diffhunk://#diff-4c6706c381e0739b2a42f2fa27781247cab3deb8cdb25fa8b1f32b6f08827a54R57) [[2]](diffhunk://#diff-4c6706c381e0739b2a42f2fa27781247cab3deb8cdb25fa8b1f32b6f08827a54R78-R84) [[3]](diffhunk://#diff-4c6706c381e0739b2a42f2fa27781247cab3deb8cdb25fa8b1f32b6f08827a54R94)

### XAML Updates:

* Integrated `BooleansAndToVisibilityCollapsedConverter` into `NetworkInterfaceView.xaml` for enhanced visibility logic. (`Source/NETworkManager/Views/NetworkInterfaceView.xaml`, [Source/NETworkManager/Views/NetworkInterfaceView.xamlR29](diffhunk://#diff-794cb657f1635bc0546ae08f4e4e2a7ed084021e14c74d922b3f45a937ff475dR29))

</details>

## To-Do

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
