### PR TITLE
Fix: DNS Lookup - Add MX priority

### DIFF
--- a/Source/NETworkManager.Models/Network/DNSLookup.cs
+++ b/Source/NETworkManager.Models/Network/DNSLookup.cs
@@ -2,7 +2,6 @@
 using DnsClient.Protocol;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
@@ -34,6 +33,7 @@ public sealed class DNSLookup
     #endregion
 
     #region Variables
+
     /// <summary>
     ///     Query types that can be used.
     /// </summary>
@@ -137,7 +137,7 @@ public sealed class DNSLookup
     {
         Task.Run(() =>
         {
-            // Append dns suffix to hostname, if option is set, otherwise just copy the list
+            // Append dns suffix to hostname, if the option is set, otherwise copy the list
             var queries = _addSuffix && _settings.QueryType != QueryType.PTR ? GetHostWithSuffix(hosts) : hosts;
 
             // For each dns server
@@ -249,8 +249,10 @@ public sealed class DNSLookup
         // CAA
         foreach (var record in dnsResourceRecords.OfType<CaaRecord>())
             OnRecordReceived(new DNSLookupRecordReceivedArgs(
-                new DNSLookupRecordInfo(record.DomainName, record.TimeToLive, $"{record.RecordClass}", $"{record.RecordType}",
-                    $"{record.Flags} {record.Tag} {record.Value}", $"{nameServer.Address}", nameServerHostname, nameServer.Port)));
+                new DNSLookupRecordInfo(
+                    record.DomainName, record.TimeToLive, $"{record.RecordClass}", $"{record.RecordType}",
+                    $"{record.Flags} {record.Tag} {record.Value}", $"{nameServer.Address}", nameServerHostname,
+                    nameServer.Port)));
 
         // CNAME
         foreach (var record in dnsResourceRecords.OfType<CNameRecord>())
@@ -264,14 +266,16 @@ public sealed class DNSLookup
             OnRecordReceived(new DNSLookupRecordReceivedArgs(
                 new DNSLookupRecordInfo(
                     record.DomainName, record.TimeToLive, $"{record.RecordClass}", $"{record.RecordType}",
-                    $"{record.Flags} {record.Protocol} {record.Algorithm} {Convert.ToBase64String(record.PublicKey.ToArray())}", $"{nameServer.Address}", nameServerHostname, nameServer.Port)));
+                    $"{record.Flags} {record.Protocol} {record.Algorithm} {Convert.ToBase64String(record.PublicKey.ToArray())}",
+                    $"{nameServer.Address}", nameServerHostname, nameServer.Port)));
 
         // MX
         foreach (var record in dnsResourceRecords.OfType<MxRecord>())
             OnRecordReceived(new DNSLookupRecordReceivedArgs(
                 new DNSLookupRecordInfo(
                     record.DomainName, record.TimeToLive, $"{record.RecordClass}", $"{record.RecordType}",
-                    record.Exchange, $"{nameServer.Address}", nameServerHostname, nameServer.Port)));
+                    $"{record.Preference} {record.Exchange}", $"{nameServer.Address}", nameServerHostname,
+                    nameServer.Port)));
 
         // NS
         foreach (var record in dnsResourceRecords.OfType<NsRecord>())
@@ -299,7 +303,8 @@ public sealed class DNSLookup
             OnRecordReceived(new DNSLookupRecordReceivedArgs(
                 new DNSLookupRecordInfo(
                     record.DomainName, record.TimeToLive, $"{record.RecordClass}", $"{record.RecordType}",
-                    $"{record.Priority} {record.Weight} {record.Port} {record.Target}", $"{nameServer.Address}", nameServerHostname, nameServer.Port)));
+                    $"{record.Priority} {record.Weight} {record.Port} {record.Target}", $"{nameServer.Address}",
+                    nameServerHostname, nameServer.Port)));
 
         // TXT
         foreach (var record in dnsResourceRecords.OfType<TxtRecord>())
@@ -307,8 +312,6 @@ public sealed class DNSLookup
                 new DNSLookupRecordInfo(
                     record.DomainName, record.TimeToLive, $"{record.RecordClass}", $"{record.RecordType}",
                     string.Join(", ", record.Text), $"{nameServer.Address}", nameServerHostname, nameServer.Port)));
-
-
 
         // ToDo: implement more
     }

--- a/Source/NETworkManager.sln.DotSettings
+++ b/Source/NETworkManager.sln.DotSettings
@@ -51,6 +51,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Controlz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dccp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=dhcpstaticipcoexistence/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=dnskey/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dockablz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dragablz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=EDNS/@EntryIndexedValue">True</s:Boolean>

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -57,6 +57,7 @@ Release date: **xx.xx.2025**
 **DNS Lookup**
 
 - Record types that are not implemented are now hidden in the user interface. [#3012](https://github.com/BornToBeRoot/NETworkManager/pull/3012)
+- Added priority to MX records. The result is now shown as `10 mail.example.com.` instead of `mail.example.com.`. [#3118](https://github.com/BornToBeRoot/NETworkManager/pull/3118)
 
 **PowerShell**
 


### PR DESCRIPTION
## Changes proposed in this pull request

- DNS Lookup - Add MX priority
-

## Related issue(s)

- Fixes #3118 
## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request mainly includes code cleanup and improvements to the formatting and consistency of DNS record processing in the `DNSLookup` class. It also updates the user dictionary for spell checking. The most important changes are grouped below:

**Code cleanup and formatting:**

* Removed an unused `using System.Diagnostics;` directive from `DNSLookup.cs` to clean up the imports.
* Improved line breaks and formatting in the `ProcessDnsAnswers` method to enhance readability when constructing `DNSLookupRecordInfo` for various DNS record types. [[1]](diffhunk://#diff-34b462a351dab4d3aa285420ceb7d3bc66d7ea67fa498806b1cca2a3c49454e2L252-R255) [[2]](diffhunk://#diff-34b462a351dab4d3aa285420ceb7d3bc66d7ea67fa498806b1cca2a3c49454e2L267-R278) [[3]](diffhunk://#diff-34b462a351dab4d3aa285420ceb7d3bc66d7ea67fa498806b1cca2a3c49454e2L302-R307)
* Removed unnecessary blank lines and made minor comment clarifications in `DNSLookup.cs`. [[1]](diffhunk://#diff-34b462a351dab4d3aa285420ceb7d3bc66d7ea67fa498806b1cca2a3c49454e2L140-R140) [[2]](diffhunk://#diff-34b462a351dab4d3aa285420ceb7d3bc66d7ea67fa498806b1cca2a3c49454e2R36) [[3]](diffhunk://#diff-34b462a351dab4d3aa285420ceb7d3bc66d7ea67fa498806b1cca2a3c49454e2L311-L312)

**Spell check dictionary update:**

* Added `dnskey` to the user dictionary in `NETworkManager.sln.DotSettings` to prevent spell check warnings for this term.

</details>

## To-Do

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
