### PR TITLE
Feature: Redesign settings reset dialog

### DIFF
--- a/Source/GlobalAssemblyInfo.cs
+++ b/Source/GlobalAssemblyInfo.cs
@@ -6,5 +6,5 @@ using System.Reflection;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("2025.6.13.0")]
-[assembly: AssemblyFileVersion("2025.6.13.0")]
+[assembly: AssemblyVersion("2025.8.11.0")]
+[assembly: AssemblyFileVersion("2025.8.11.0")]

--- a/Source/NETworkManager.Converters/ChildWindowIconToRectangleStyleConverter.cs
+++ b/Source/NETworkManager.Converters/ChildWindowIconToRectangleStyleConverter.cs
@@ -17,6 +17,8 @@ public sealed class ChildWindowIconToRectangleStyleConverter : IValueConverter
         {
             case ChildWindowIcon.Info:
                 return Application.Current.FindResource("InfoImageRectangle");
+            case ChildWindowIcon.Question:
+                return Application.Current.FindResource("QuestionImageRectangle");
             case ChildWindowIcon.Warn:
                 return Application.Current.FindResource("WarnImageRectangle");
             case ChildWindowIcon.Error:

--- a/Source/NETworkManager.Settings/SettingsManager.cs
+++ b/Source/NETworkManager.Settings/SettingsManager.cs
@@ -190,6 +190,10 @@ public static class SettingsManager
         if (fromVersion < new Version(2024, 11, 11, 0))
             UpgradeTo_2024_11_11_0();
 
+        // 2025.8.11.0
+        if (fromVersion < new Version(2025, 8, 11, 0))
+            UpgradeTo_2025_8_11_0();
+
         // Latest
         if (fromVersion < toVersion)
             UpgradeToLatest(toVersion);
@@ -311,12 +315,11 @@ public static class SettingsManager
     }
 
     /// <summary>
-    ///     Method to apply changes for the latest version.
+    ///     Method to apply changes for version 2025.8.11.0.
     /// </summary>
-    /// <param name="version">Latest version.</param>
-    private static void UpgradeToLatest(Version version)
+    private static void UpgradeTo_2025_8_11_0()
     {
-        Log.Info($"Apply upgrade to {version}...");
+        Log.Info("Apply upgrade to 2025.8.11.0...");
 
         // Add Hosts editor application
         Log.Info("Add new app \"Hosts File Editor\"...");
@@ -324,6 +327,15 @@ public static class SettingsManager
         Current.General_ApplicationList.Insert(
             ApplicationManager.GetDefaultList().ToList().FindIndex(x => x.Name == ApplicationName.HostsFileEditor),
             ApplicationManager.GetDefaultList().First(x => x.Name == ApplicationName.HostsFileEditor));
+    }
+
+    /// <summary>
+    ///     Method to apply changes for the latest version.
+    /// </summary>
+    /// <param name="version">Latest version.</param>
+    private static void UpgradeToLatest(Version version)
+    {
+        Log.Info($"Apply upgrade to {version}...");
     }
 
     #endregion

--- a/Source/NETworkManager.Utilities/ChildWindowIcon.cs
+++ b/Source/NETworkManager.Utilities/ChildWindowIcon.cs
@@ -11,6 +11,11 @@ public enum ChildWindowIcon
     Info,
 
     /// <summary>
+    /// Question icon.
+    /// </summary>
+    Question,
+
+    /// <summary>
     /// Warning icon.
     /// </summary>
     Warn,

--- a/Source/NETworkManager/Resources/Styles/RectangleStyles.xaml
+++ b/Source/NETworkManager/Resources/Styles/RectangleStyles.xaml
@@ -36,6 +36,20 @@
         <Setter Property="ToolTipService.ShowDuration" Value="600000" />
     </Style>
 
+    <Style x:Key="QuestionImageRectangle" TargetType="{x:Type Rectangle}">
+        <Style.Resources>
+            <Style TargetType="{x:Type ToolTip}" BasedOn="{StaticResource DefaultToolTip}" />
+        </Style.Resources>
+        <Setter Property="Fill" Value="{DynamicResource MahApps.Brushes.Gray3}" />
+        <Setter Property="OpacityMask">
+            <Setter.Value>
+                <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=HelpCircleOutline}" />
+            </Setter.Value>
+        </Setter>
+        <Setter Property="ToolTipService.InitialShowDelay" Value="0" />
+        <Setter Property="ToolTipService.ShowDuration" Value="600000" />
+    </Style>
+
     <Style x:Key="WarnImageRectangle" TargetType="{x:Type Rectangle}">
         <Style.Resources>
             <Style TargetType="{x:Type ToolTip}" BasedOn="{StaticResource DefaultToolTip}" />

--- a/Source/NETworkManager/ViewModels/OKCancelInfoMessageViewModel.cs
+++ b/Source/NETworkManager/ViewModels/OKCancelInfoMessageViewModel.cs
@@ -7,7 +7,7 @@ namespace NETworkManager.ViewModels;
 public class OKCancelInfoMessageViewModel : ViewModelBase
 {
     public OKCancelInfoMessageViewModel(Action<OKCancelInfoMessageViewModel> okCommand,
-        Action<OKCancelInfoMessageViewModel> cancelHandler, string message, string okButtonText = null, string cancelButtonText = null)
+        Action<OKCancelInfoMessageViewModel> cancelHandler, string message, string okButtonText = null, string cancelButtonText = null, ChildWindowIcon icon = ChildWindowIcon.Info)
     {
         OKCommand = new RelayCommand(_ => okCommand(this));
         CancelCommand = new RelayCommand(_ => cancelHandler(this));
@@ -23,7 +23,6 @@ public class OKCancelInfoMessageViewModel : ViewModelBase
     public ICommand CancelCommand { get; }
 
     private readonly string _message;
-
     public string Message
     {
         get => _message;
@@ -38,7 +37,6 @@ public class OKCancelInfoMessageViewModel : ViewModelBase
     }
 
     private readonly string _okButtonText;
-
     public string OKButtonText
     {
         get => _okButtonText;
@@ -53,7 +51,6 @@ public class OKCancelInfoMessageViewModel : ViewModelBase
     }
 
     private readonly string _cancelButtonText;
-
     public string CancelButtonText
     {
         get => _cancelButtonText;
@@ -63,6 +60,20 @@ public class OKCancelInfoMessageViewModel : ViewModelBase
                 return;
 
             _cancelButtonText = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private ChildWindowIcon _icon;
+    public ChildWindowIcon Icon
+    {
+        get => _icon;
+        private init
+        {
+            if (value == _icon)
+                return;
+
+            _icon = value;
             OnPropertyChanged();
         }
     }

--- a/Source/NETworkManager/ViewModels/OKMessageViewModel.cs
+++ b/Source/NETworkManager/ViewModels/OKMessageViewModel.cs
@@ -19,7 +19,6 @@ public class OKMessageViewModel : ViewModelBase
     public ICommand OKCommand { get; }
 
     private readonly string _message;
-
     public string Message
     {
         get => _message;
@@ -34,7 +33,6 @@ public class OKMessageViewModel : ViewModelBase
     }
 
     private readonly string _okButtonText;
-
     public string OKButtonText
     {
         get => _okButtonText;
@@ -49,7 +47,6 @@ public class OKMessageViewModel : ViewModelBase
     }
 
     private ChildWindowIcon _icon;
-
     public ChildWindowIcon Icon
     {
         get => _icon;

--- a/Source/NETworkManager/ViewModels/SettingsSettingsViewModel.cs
+++ b/Source/NETworkManager/ViewModels/SettingsSettingsViewModel.cs
@@ -1,11 +1,14 @@
-﻿using System;
-using System.Diagnostics;
-using System.Windows;
-using System.Windows.Input;
-using MahApps.Metro.Controls.Dialogs;
+﻿using MahApps.Metro.Controls.Dialogs;
+using MahApps.Metro.SimpleChildWindow;
 using NETworkManager.Localization.Resources;
 using NETworkManager.Settings;
 using NETworkManager.Utilities;
+using NETworkManager.Views;
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
 
 namespace NETworkManager.ViewModels;
 
@@ -61,26 +64,47 @@ public class SettingsSettingsViewModel : ViewModelBase
 
     public ICommand ResetSettingsCommand => new RelayCommand(_ => ResetSettingsAction());
 
-    private async void ResetSettingsAction()
+    private void ResetSettingsAction()
     {
-        var settings = AppearanceManager.MetroDialog;
-
-        settings.AffirmativeButtonText = Strings.Reset;
-        settings.NegativeButtonText = Strings.Cancel;
-
-        settings.DefaultButtonFocus = MessageDialogResult.Affirmative;
-
-        if (await _dialogCoordinator.ShowMessageAsync(this, Strings.ResetSettingsQuestion,
-                Strings.SettingsAreResetAndApplicationWillBeRestartedMessage,
-                MessageDialogStyle.AffirmativeAndNegative, settings) != MessageDialogResult.Affirmative)
-            return;
-
-        // Init default settings
-        SettingsManager.Initialize();
-
-        // Restart the application
-        (Application.Current.MainWindow as MainWindow)?.RestartApplication();
+        ResetSettings().ConfigureAwait(false);
     }
 
+    #endregion
+
+    #region Methods
+
+    private Task ResetSettings()
+    {
+        var childWindow = new OKCancelInfoMessageChildWindow();
+
+        var childWindowViewModel = new OKCancelInfoMessageViewModel(_ =>
+        {
+            childWindow.IsOpen = false;
+            ConfigurationManager.Current.IsChildWindowOpen = false;
+
+            // Init default settings
+            SettingsManager.Initialize();
+
+            // Restart the application
+            (Application.Current.MainWindow as MainWindow)?.RestartApplication();
+        }, _ =>
+        {
+            childWindow.IsOpen = false;
+            ConfigurationManager.Current.IsChildWindowOpen = false;
+        },
+            Strings.SettingsAreResetAndApplicationWillBeRestartedMessage,
+            Strings.Reset,
+            Strings.Cancel,
+            ChildWindowIcon.Question
+        );
+
+        childWindow.Title = Strings.ResetSettingsQuestion;
+
+        childWindow.DataContext = childWindowViewModel;
+
+        ConfigurationManager.Current.IsChildWindowOpen = true;
+
+        return (Application.Current.MainWindow as MainWindow).ShowChildWindowAsync(childWindow);
+    }
     #endregion
 }

--- a/Source/NETworkManager/ViewModels/SettingsSettingsViewModel.cs
+++ b/Source/NETworkManager/ViewModels/SettingsSettingsViewModel.cs
@@ -1,5 +1,4 @@
-﻿using MahApps.Metro.Controls.Dialogs;
-using MahApps.Metro.SimpleChildWindow;
+﻿using MahApps.Metro.SimpleChildWindow;
 using NETworkManager.Localization.Resources;
 using NETworkManager.Settings;
 using NETworkManager.Utilities;
@@ -15,9 +14,6 @@ namespace NETworkManager.ViewModels;
 public class SettingsSettingsViewModel : ViewModelBase
 {
     #region Variables
-
-    private readonly IDialogCoordinator _dialogCoordinator;
-
     public Action CloseAction { get; set; }
 
     private string _location;
@@ -34,15 +30,12 @@ public class SettingsSettingsViewModel : ViewModelBase
             OnPropertyChanged();
         }
     }
-
     #endregion
 
     #region Constructor, LoadSettings
 
-    public SettingsSettingsViewModel(IDialogCoordinator instance)
+    public SettingsSettingsViewModel()
     {
-        _dialogCoordinator = instance;
-
         LoadSettings();
     }
 

--- a/Source/NETworkManager/ViewModels/WebConsoleSettingsViewModel.cs
+++ b/Source/NETworkManager/ViewModels/WebConsoleSettingsViewModel.cs
@@ -1,14 +1,13 @@
-﻿using System;
-using MahApps.Metro.SimpleChildWindow;
+﻿using MahApps.Metro.SimpleChildWindow;
+using Microsoft.Web.WebView2.Core;
 using NETworkManager.Localization.Resources;
 using NETworkManager.Settings;
 using NETworkManager.Utilities;
 using NETworkManager.Views;
+using System;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
-using Microsoft.Web.WebView2.Core;
-using Microsoft.Web.WebView2.Wpf;
 
 namespace NETworkManager.ViewModels;
 

--- a/Source/NETworkManager/Views/OKCancelInfoMessageChildWindow.xaml
+++ b/Source/NETworkManager/Views/OKCancelInfoMessageChildWindow.xaml
@@ -7,6 +7,7 @@
              xmlns:localization="clr-namespace:NETworkManager.Localization.Resources;assembly=NETworkManager.Localization"
              xmlns:simpleChildWindow="clr-namespace:MahApps.Metro.SimpleChildWindow;assembly=MahApps.Metro.SimpleChildWindow"
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:converters="clr-namespace:NETworkManager.Converters;assembly=NETworkManager.Converters"
              ChildWindowWidth="450"
              ChildWindowMaxHeight="500"
              ShowTitleBar="True"
@@ -20,6 +21,9 @@
              OverlayBrush="{DynamicResource ResourceKey=MahApps.Brushes.Gray.SemiTransparent}"         
              Loaded="ChildWindow_Loaded"
              mc:Ignorable="d" d:DataContext="{d:DesignInstance viewModels:OKCancelInfoMessageViewModel}">
+    <simpleChildWindow:ChildWindow.Resources>
+        <converters:ChildWindowIconToRectangleStyleConverter x:Key="ChildWindowIconToRectangleStyleConverter" />
+    </simpleChildWindow:ChildWindow.Resources>
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
@@ -36,8 +40,8 @@
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
                 <Rectangle Grid.Column="0" Grid.Row="0"
-                           Width="32" Height="32"
-                           Style="{StaticResource InfoImageRectangle}" />
+           Width="32" Height="32"
+           Style="{Binding Icon, Converter={StaticResource ChildWindowIconToRectangleStyleConverter}}" />
                 <TextBlock Grid.Column="2" Grid.Row="0"
                            VerticalAlignment="Center"
                            Text="{Binding Message}"

--- a/Source/NETworkManager/Views/SettingsSettingsView.xaml
+++ b/Source/NETworkManager/Views/SettingsSettingsView.xaml
@@ -4,10 +4,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
-             xmlns:dialogs="clr-namespace:MahApps.Metro.Controls.Dialogs;assembly=MahApps.Metro"
              xmlns:viewModels="clr-namespace:NETworkManager.ViewModels"
              xmlns:localization="clr-namespace:NETworkManager.Localization.Resources;assembly=NETworkManager.Localization"
-             dialogs:DialogParticipation.Register="{Binding}"
              mc:Ignorable="d" Loaded="UserControl_Loaded"
              d:DataContext="{d:DesignInstance viewModels:SettingsSettingsViewModel}">
     <StackPanel>

--- a/Source/NETworkManager/Views/SettingsSettingsView.xaml.cs
+++ b/Source/NETworkManager/Views/SettingsSettingsView.xaml.cs
@@ -1,12 +1,11 @@
-﻿using System.Windows;
-using MahApps.Metro.Controls.Dialogs;
-using NETworkManager.ViewModels;
+﻿using NETworkManager.ViewModels;
+using System.Windows;
 
 namespace NETworkManager.Views;
 
 public partial class SettingsSettingsView
 {
-    private readonly SettingsSettingsViewModel _viewModel = new(DialogCoordinator.Instance);
+    private readonly SettingsSettingsViewModel _viewModel = new();
 
     public SettingsSettingsView()
     {

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -21,6 +21,8 @@ Release date: **xx.xx.2025**
 
 ## Improvements
 
+- Redesign settings reset dialog. [#3138](https://github.com/BornToBeRoot/NETworkManager/pull/3138)
+
 ## Bugfixes
 
 ## Dependencies, Refactoring & Documentation


### PR DESCRIPTION
## Changes proposed in this pull request

- Redesign settings reset dialog
-

## Related issue(s)

- 

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request introduces support for a new "Question" icon in the application's child window dialogs, improves the flexibility of dialog view models, and refactors the settings reset dialog to use the new child window infrastructure. The main changes add the new icon type, update the related styles and converters, and refactor dialog presentation to use view models that support icon selection.

### Icon Support Improvements

* Added a new `Question` value to the `ChildWindowIcon` enum to support question-style dialogs.
* Updated the `ChildWindowIconToRectangleStyleConverter` to handle the new `Question` icon, returning the appropriate resource.
* Added a new rectangle style, `QuestionImageRectangle`, to `RectangleStyles.xaml` for displaying the question icon.

### Dialog and ViewModel Enhancements

* Updated the `OKCancelInfoMessageViewModel` to accept an `icon` parameter and expose an `Icon` property, allowing dialogs to display different icons based on context. [[1]](diffhunk://#diff-057a80d49f2604ccd6480131431227c25a9158fd676acf82fdf116c2e3f1453cL10-R10) [[2]](diffhunk://#diff-057a80d49f2604ccd6480131431227c25a9158fd676acf82fdf116c2e3f1453cR66-R79)
* Refactored the `OKCancelInfoMessageChildWindow.xaml` to use a converter for selecting the icon style based on the view model's `Icon` property, enabling dynamic icon display. [[1]](diffhunk://#diff-1ddae73c246921902cc71fc45944172f33516382dd797d6ba567e278a3488682R24-R26) [[2]](diffhunk://#diff-1ddae73c246921902cc71fc45944172f33516382dd797d6ba567e278a3488682L40-R44)

### Settings Dialog Refactor

* Refactored the settings reset logic to use the new `OKCancelInfoMessageChildWindow` with the `Question` icon, improving consistency and user experience for confirmation dialogs.

</details>

## To-Do

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
