### PR TITLE
Docs: WiFi location access for 24H2 #3147

### DIFF
--- a/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
+++ b/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
@@ -11241,11 +11241,9 @@ namespace NETworkManager.Localization.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Access to the Wi-Fi adapter is not permitted by Windows.
+        ///   Looks up a localized string similar to Starting with Windows 11 24H2, you’ll need to allow access to the Wi-Fi adapter.
         ///
-        ///Open the Windows settings and allow Wi-Fi access for this application.
-        ///
-        ///Restart the application afterwards to use this feature..
+        ///Open Windows Settings &gt; Privacy &amp; security &gt; Location, enable access for Desktop Apps / NETworkManager, then restart the application..
         /// </summary>
         public static string WiFiAccessNotAvailableMessage {
             get {

--- a/Source/NETworkManager.Localization/Resources/Strings.resx
+++ b/Source/NETworkManager.Localization/Resources/Strings.resx
@@ -3815,11 +3815,9 @@ Try again in a few seconds.</value>
     <value>Expand and open search...</value>
   </data>
   <data name="WiFiAccessNotAvailableMessage" xml:space="preserve">
-    <value>Access to the Wi-Fi adapter is not permitted by Windows.
+    <value>Starting with Windows 11 24H2, you’ll need to allow access to the Wi-Fi adapter.
 
-Open the Windows settings and allow Wi-Fi access for this application.
-
-Restart the application afterwards to use this feature.</value>
+Open Windows Settings &gt; Privacy &amp; security &gt; Location, enable access for Desktop Apps / NETworkManager, then restart the application.</value>
   </data>
   <data name="DragDropApplicationsToReorderRightClickForMoreOptions" xml:space="preserve">
     <value>Drag and drop the applications to reorder them.

--- a/Website/docs/application/wifi.md
+++ b/Website/docs/application/wifi.md
@@ -10,7 +10,9 @@ Hidden wireless networks are displayed as `Hidden Network`.
 
 ## WiFi
 
-On the **WiFi** tab, you can select which wireless network adapter is used to scan for wireless networks. Wireless networks can be filtered by 2.4 Ghz, 5 Ghz and the SSID.
+On the **WiFi** tab, you can select which wireless network adapter is used to scan for wireless networks. Wireless networks can be filtered by 2.4 Ghz, 5 Ghz and 6 GHz.
+
+In the search field, you can filter the wireless networks by `SSID`, `Security`, `Frequency`, `Channel`, `BSSID (MAC Address)`, `Vendor` and `Phy kind`. The search is case insensitive.
 
 Right-click on a wireless network opens a context menu with the following options:
 
@@ -18,9 +20,13 @@ Right-click on a wireless network opens a context menu with the following option
 - **Disconnect**: Disconnect from the selected wireless network.
 - **Export...**: Opens a dialog to export the selected or all wireless network(s) to a file.
 
-In the search field, you can filter the wireless networks by `SSID`, `Security`, `Frequency`, `Channel`, `BSSID (MAC Address)`, `Vendor` and `Phy kind`. The search is case insensitive.
-
 :::note
+
+Starting with Windows 11 24H2, you’ll need to allow access to the Wi-Fi adapter.
+
+Open `Windows Settings > Privacy & security > Location`, enable access for Desktop Apps / NETworkManager, then restart the application.
+
+---
 
 Due to limitations of the `Windows.Devices.WiFi` API the channel bandwidth cannot be detected.
 

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -23,6 +23,10 @@ Release date: **xx.xx.2025**
 
 - Redesign settings reset dialog. [#3138](https://github.com/BornToBeRoot/NETworkManager/pull/3138)
 
+**WiFi**
+
+- Documentation for Windows 11 24H2 location permission added.  [#3138](https://github.com/BornToBeRoot/NETworkManager/pull/3138)
+
 ## Bugfixes
 
 ## Dependencies, Refactoring & Documentation

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -25,7 +25,7 @@ Release date: **xx.xx.2025**
 
 **WiFi**
 
-- Documentation for Windows 11 24H2 location permission added.  [#3138](https://github.com/BornToBeRoot/NETworkManager/pull/3138)
+- Documentation for Windows 11 24H2 location permission added. [#3148](https://github.com/BornToBeRoot/NETworkManager/pull/3148)
 
 ## Bugfixes
 


### PR DESCRIPTION
## Changes proposed in this pull request

- WiFi location access docs
-

## Related issue(s)

- Fixes #3147

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request updates the application to reflect new Windows 11 24H2 requirements for Wi-Fi adapter access and improves related documentation and user messaging. The main changes include updating user-facing strings to clarify the new permission steps, enhancing Wi-Fi documentation, and noting these updates in the changelog.

**Wi-Fi permission updates:**

* Updated the `WiFiAccessNotAvailableMessage` string in both `Strings.Designer.cs` and `Strings.resx` to inform users about the new Windows 11 24H2 requirement to enable location access for Desktop Apps / NETworkManager via Windows Settings. [[1]](diffhunk://#diff-fd26c2c2130e727ae40f1060c182242ce89c894d95f0168fa6443e230da8e4e0L11244-R11246) [[2]](diffhunk://#diff-aa5828c7aa59a68d20ce70a1088e4bd1038a53bac7f9eac6398a7b6e466f9df8L3818-R3820)

**Documentation improvements:**

* Revised `Website/docs/application/wifi.md` to include instructions for enabling location access for Wi-Fi adapter usage on Windows 11 24H2, clarified filtering options, and improved overall guidance.

**Changelog update:**

* Added a Wi-Fi section in `Website/docs/changelog/next-release.md` to document the new location permission requirement for Windows 11 24H2.

</details>

## To-Do

- [x] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs) to reflect this changes
- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
