### PR TITLE
Fix: Set correct hwnd for temporary webview2 controller

### DIFF
--- a/Source/NETworkManager/ViewModels/WebConsoleSettingsViewModel.cs
+++ b/Source/NETworkManager/ViewModels/WebConsoleSettingsViewModel.cs
@@ -4,10 +4,10 @@ using NETworkManager.Localization.Resources;
 using NETworkManager.Settings;
 using NETworkManager.Utilities;
 using NETworkManager.Views;
-using System;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Interop;
 
 namespace NETworkManager.ViewModels;
 
@@ -118,7 +118,10 @@ public class WebConsoleSettingsViewModel : ViewModelBase
                 // Create a temporary WebView2 instance to clear browsing data
                 var webView2Environment =
                     await CoreWebView2Environment.CreateAsync(null, GlobalStaticConfiguration.WebConsole_Cache);
-                var webView2Controller = await webView2Environment.CreateCoreWebView2ControllerAsync(IntPtr.Zero);
+
+                var windowHwnd = new WindowInteropHelper(Application.Current.MainWindow).Handle;
+
+                var webView2Controller = await webView2Environment.CreateCoreWebView2ControllerAsync(windowHwnd);
 
                 await webView2Controller.CoreWebView2.Profile.ClearBrowsingDataAsync();
 

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -31,6 +31,9 @@ Release date: **xx.xx.2025**
 
 ## Bugfixes
 
+- **Web Console**
+  - Fixed an issue where clearing the Browser cache crashed the application. [#3169](https://github.com/BornToBeRoot/NETworkManager/pull/3169)
+
 - **Profiles**
   - Fixed an issue where only one profile was deleted in `Settings > Profiles` when multiple profiles were selected. [#3144](https://github.com/BornToBeRoot/NETworkManager/pull/3144) [#3145](https://github.com/BornToBeRoot/NETworkManager/issues/3145)
 


### PR DESCRIPTION
## Changes proposed in this pull request

- Set correct hwnd for temporary webview2 controller
-

## Related issue(s)

- Fixes #3168 

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request updates the way the application handles the deletion of browsing data in the web console settings. The main change is that the code now passes the main window handle when creating the WebView2 controller, which improves compatibility and stability when clearing browsing data.

Improvements to WebView2 controller initialization:

* Updated `DeleteBrowsingData()` in `WebConsoleSettingsViewModel.cs` to use the main window handle (`WindowInteropHelper(Application.Current.MainWindow).Handle`) when creating the WebView2 controller, instead of passing `IntPtr.Zero`. This change ensures the controller is properly associated with the application's main window.
* Removed the unnecessary `using System;` directive from `WebConsoleSettingsViewModel.cs`, as it is no longer needed after the change.

</details>

## To-Do

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
