### PR TITLE
Fix: Status window with display scaling

### DIFF
--- a/Source/NETworkManager/StatusWindow.xaml.cs
+++ b/Source/NETworkManager/StatusWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Windows.Forms;
 using System.Windows.Input;
@@ -43,7 +44,7 @@ public partial class StatusWindow : INotifyPropertyChanged
     #endregion
 
     #region Variables
-    
+
     // Set priority to make the ui smoother
     private readonly DispatcherTimer _dispatcherTimerClose = new(DispatcherPriority.Normal);
 
@@ -142,16 +143,18 @@ public partial class StatusWindow : INotifyPropertyChanged
         // ToDo: User setting...
         if (Screen.PrimaryScreen != null)
         {
-            Left = Screen.PrimaryScreen.WorkingArea.Right - Width - 10;
-            Top = Screen.PrimaryScreen.WorkingArea.Bottom - Height - 10;
+            var scaleFactor = System.Windows.Media.VisualTreeHelper.GetDpi(this).DpiScaleX;
+
+            Left = Screen.PrimaryScreen.WorkingArea.Right / scaleFactor - Width - 10;
+            Top = Screen.PrimaryScreen.WorkingArea.Bottom / scaleFactor - Height - 10;
         }
 
         // Show the window
         Show();
-        
+
         // Check the network connection
         Check();
-        
+
         // Close the window after a certain time
         if (enableCloseTimer)
         {

--- a/Source/NETworkManager/StatusWindow.xaml.cs
+++ b/Source/NETworkManager/StatusWindow.xaml.cs
@@ -1,14 +1,12 @@
-﻿using System;
+﻿using NETworkManager.Settings;
+using NETworkManager.Utilities;
+using NETworkManager.Views;
+using System;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Threading;
-using log4net;
-using NETworkManager.Settings;
-using NETworkManager.Utilities;
-using NETworkManager.Views;
 
 namespace NETworkManager;
 

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -34,6 +34,8 @@ Release date: **xx.xx.2025**
 
 ## Bug Fixes
 
+- Fixed an issue where the status window was out of screen when a display scale other than 100% was set. [#3185](https://github.com/BornToBeRoot/NETworkManager/pull/3185)
+
 **Web Console**
 
 - Fixed a crash that occurred when clearing the browser cache. [#3169](https://github.com/BornToBeRoot/NETworkManager/pull/3169)


### PR DESCRIPTION
## Changes proposed in this pull request

- Fix: Status window with display scaling
-

## Related issue(s)

- Fixes #3183

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>



</details>

## To-Do

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
