### PR TITLE
Fix: Profile filter dialog closing when putty/powershell console is open

### DIFF
--- a/Source/NETworkManager.Settings/ConfigurationInfo.cs
+++ b/Source/NETworkManager.Settings/ConfigurationInfo.cs
@@ -452,6 +452,27 @@ public class ConfigurationInfo : PropertyChangedBase
     }
 
     /// <summary>
+    /// Private variable for <see cref="IsProfileFilterPopupOpen" />.
+    /// </summary>
+    private bool _isProfileFilterPopupOpen;
+
+    /// <summary>
+    /// Indicates if a profile filter popup is open.
+    /// </summary>
+    public bool IsProfileFilterPopupOpen
+    {
+        get => _isProfileFilterPopupOpen;
+        set
+        {
+            if (value == _isProfileFilterPopupOpen)
+                return;
+
+            _isProfileFilterPopupOpen = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
     ///     Private variable for <see cref="FixAirspace" />.
     /// </summary>
     private bool _fixAirspace;

--- a/Source/NETworkManager/MainWindow.xaml.cs
+++ b/Source/NETworkManager/MainWindow.xaml.cs
@@ -1443,7 +1443,7 @@ public sealed partial class MainWindow : INotifyPropertyChanged
             }, info.Name, showWrongPassword);
 
             childWindow.Title = Strings.UnlockProfileFile;
-            
+
             childWindow.DataContext = viewModel;
 
             ConfigurationManager.OnDialogOpen();
@@ -2004,10 +2004,16 @@ public sealed partial class MainWindow : INotifyPropertyChanged
            - Settings are opened
            - Profile file DropDown is opened
            - Application search TextBox is opened
+           - Profile filter (tags) popup is opened
            - Dialog over an embedded window is opened (FixAirspace)
         */
-        if (SelectedApplication == null || SettingsViewIsOpen || IsProfileFileDropDownOpened ||
+        if (SelectedApplication == null ||
+            // MainWindow
+            SettingsViewIsOpen ||
+            IsProfileFileDropDownOpened ||
             TextBoxApplicationSearchIsFocused ||
+            // Global dialogs
+            ConfigurationManager.Current.IsProfileFilterPopupOpen ||
             ConfigurationManager.Current.FixAirspace)
             return;
 

--- a/Source/NETworkManager/ViewModels/AWSSessionManagerHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/AWSSessionManagerHostViewModel.cs
@@ -599,6 +599,8 @@ public class AWSSessionManagerHostViewModel : ViewModelBase, IProfileManager
 
     private void OpenProfileFilterAction()
     {
+        ConfigurationManager.Current.IsProfileFilterPopupOpen = true;
+        
         ProfileFilterIsOpen = true;
     }
 
@@ -1183,6 +1185,11 @@ public class AWSSessionManagerHostViewModel : ViewModelBase, IProfileManager
         IsProfileFilterSet = !string.IsNullOrEmpty(filter.Search) || filter.Tags.Any();
     }
 
+    public void OnProfileFilterClosed()
+    {
+        ConfigurationManager.Current.IsProfileFilterPopupOpen = false;
+    }
+    
     public void OnProfileManagerDialogOpen()
     {
         ConfigurationManager.OnDialogOpen();

--- a/Source/NETworkManager/ViewModels/PowerShellHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PowerShellHostViewModel.cs
@@ -233,10 +233,10 @@ public class PowerShellHostViewModel : ViewModelBase, IProfileManager
             OnPropertyChanged();
         }
     }
-    
+
     private readonly GroupExpanderStateStore _groupExpanderStateStore = new();
     public GroupExpanderStateStore GroupExpanderStateStore => _groupExpanderStateStore;
-    
+
     private bool _canProfileWidthChange = true;
     private double _tempProfileWidth;
 
@@ -492,6 +492,8 @@ public class PowerShellHostViewModel : ViewModelBase, IProfileManager
 
     private void OpenProfileFilterAction()
     {
+        ConfigurationManager.Current.IsProfileFilterPopupOpen = true;
+
         ProfileFilterIsOpen = true;
     }
 
@@ -517,7 +519,7 @@ public class PowerShellHostViewModel : ViewModelBase, IProfileManager
         IsProfileFilterSet = false;
         ProfileFilterIsOpen = false;
     }
-    
+
     public ICommand ExpandAllProfileGroupsCommand => new RelayCommand(_ => ExpandAllProfileGroupsAction());
 
     private void ExpandAllProfileGroupsAction()
@@ -531,7 +533,7 @@ public class PowerShellHostViewModel : ViewModelBase, IProfileManager
     {
         SetIsExpandedForAllProfileGroups(false);
     }
-    
+
     public ICommand OpenSettingsCommand => new RelayCommand(_ => OpenSettingsAction());
 
     private static void OpenSettingsAction()
@@ -674,7 +676,7 @@ public class PowerShellHostViewModel : ViewModelBase, IProfileManager
         foreach (var group in Profiles.Groups.Cast<CollectionViewGroup>())
             GroupExpanderStateStore[group.Name.ToString()] = isExpanded;
     }
-    
+
     private void ResizeProfile(bool dueToChangedSize)
     {
         _canProfileWidthChange = false;
@@ -766,7 +768,7 @@ public class PowerShellHostViewModel : ViewModelBase, IProfileManager
             ProfileFilterTags.Add(new ProfileFilterTagsInfo(false, tag));
         }
     }
-    
+
     private void SetProfilesView(ProfileFilterInfo filter, ProfileInfo profile = null)
     {
         Profiles = new CollectionViewSource
@@ -809,6 +811,11 @@ public class PowerShellHostViewModel : ViewModelBase, IProfileManager
         }, SelectedProfile);
     }
 
+    public void OnProfileFilterClosed()
+    {
+        ConfigurationManager.Current.IsProfileFilterPopupOpen = false;
+    }
+
     public void OnProfileManagerDialogOpen()
     {
         ConfigurationManager.OnDialogOpen();
@@ -841,7 +848,7 @@ public class PowerShellHostViewModel : ViewModelBase, IProfileManager
     private void ProfileManager_OnProfilesUpdated(object sender, EventArgs e)
     {
         CreateTags();
-        
+
         RefreshProfiles();
     }
 

--- a/Source/NETworkManager/ViewModels/PuTTYHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PuTTYHostViewModel.cs
@@ -503,6 +503,8 @@ public class PuTTYHostViewModel : ViewModelBase, IProfileManager
 
     private void OpenProfileFilterAction()
     {
+        ConfigurationManager.Current.IsProfileFilterPopupOpen = true;
+        
         ProfileFilterIsOpen = true;
     }
 
@@ -901,6 +903,11 @@ public class PuTTYHostViewModel : ViewModelBase, IProfileManager
         IsProfileFilterSet = !string.IsNullOrEmpty(filter.Search) || filter.Tags.Any();
     }
 
+    public void OnProfileFilterClosed()
+    {
+        ConfigurationManager.Current.IsProfileFilterPopupOpen = false;
+    }
+    
     public void OnProfileManagerDialogOpen()
     {
         ConfigurationManager.OnDialogOpen();

--- a/Source/NETworkManager/Views/AWSSessionManagerHostView.xaml
+++ b/Source/NETworkManager/Views/AWSSessionManagerHostView.xaml
@@ -402,6 +402,7 @@
                             </Button>
                             <Popup PlacementTarget="{Binding ElementName=ButtonProfileFilter}"
                                    Placement="Bottom" StaysOpen="False"
+                                   Closed="PopupProfileFilter_Closed"
                                    IsOpen="{Binding ProfileFilterIsOpen}"
                                    Width="220">
                                 <Border Background="{DynamicResource MahApps.Brushes.Window.Background}"

--- a/Source/NETworkManager/Views/AWSSessionManagerHostView.xaml.cs
+++ b/Source/NETworkManager/Views/AWSSessionManagerHostView.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using MahApps.Metro.Controls.Dialogs;
@@ -53,5 +54,10 @@ public partial class AWSSessionManagerHostView
     public void FocusEmbeddedWindow()
     {
         _viewModel.FocusEmbeddedWindow();
+    }
+
+    private void PopupProfileFilter_Closed(object sender, EventArgs e)
+    {
+        _viewModel.OnProfileFilterClosed();
     }
 }

--- a/Source/NETworkManager/Views/PowerShellHostView.xaml
+++ b/Source/NETworkManager/Views/PowerShellHostView.xaml
@@ -360,6 +360,7 @@
                             </Button>
                             <Popup PlacementTarget="{Binding ElementName=ButtonProfileFilter}"
                                    Placement="Bottom" StaysOpen="False"
+                                   Closed="PopupProfileFilter_Closed"
                                    IsOpen="{Binding ProfileFilterIsOpen}"
                                    Width="220">
                                 <Border Background="{DynamicResource MahApps.Brushes.Window.Background}"

--- a/Source/NETworkManager/Views/PowerShellHostView.xaml.cs
+++ b/Source/NETworkManager/Views/PowerShellHostView.xaml.cs
@@ -61,4 +61,9 @@ public partial class PowerShellHostView
     {
         _viewModel.FocusEmbeddedWindow();
     }
+
+    private void PopupProfileFilter_Closed(object sender, System.EventArgs e)
+    {
+        _viewModel.OnProfileFilterClosed();
+    }
 }

--- a/Source/NETworkManager/Views/PuTTYHostView.xaml
+++ b/Source/NETworkManager/Views/PuTTYHostView.xaml
@@ -373,6 +373,7 @@
                             </Button>
                             <Popup PlacementTarget="{Binding ElementName=ButtonProfileFilter}"
                                    Placement="Bottom" StaysOpen="False"
+                                   Closed="PopupProfileFilter_Closed"
                                    IsOpen="{Binding ProfileFilterIsOpen}"
                                    Width="220">
                                 <Border Background="{DynamicResource MahApps.Brushes.Window.Background}"

--- a/Source/NETworkManager/Views/PuTTYHostView.xaml.cs
+++ b/Source/NETworkManager/Views/PuTTYHostView.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -60,5 +61,10 @@ public partial class PuTTYHostView
     public void FocusEmbeddedWindow()
     {
         _viewModel.FocusEmbeddedWindow();
+    }
+
+    private void PopupProfileFilter_Closed(object sender, EventArgs e)
+    {
+        _viewModel.OnProfileFilterClosed();
     }
 }

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -31,6 +31,8 @@ Release date: **xx.xx.2025**
 
 ## Bug Fixes
 
+- The new profile filter popup indroduced in version `2025.10.18.0` was instantly closed when a `PuTTY`, `PowerShell` or `AWS Session Manager` session was opened and the respective application / view was selected. [#3219](https://github.com/BornToBeRoot/NETworkManager/pull/3219)
+
 ## Dependencies, Refactoring & Documentation
 
 - Documentation updated


### PR DESCRIPTION
## Changes proposed in this pull request

- Profile filter dialog closing when putty/powershell console is open
-

ToDo:

- [x] PowerShell
- [x] PuTTY
- [x] AWS Session Manager

## Related issue(s)

- Fixes #3219 

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request introduces a new mechanism for tracking the open/closed state of the profile filter popup and ensures that the popup remains open under appropriate conditions. It adds a new property to the configuration, updates logic to check this state before focusing embedded windows, and hooks up the popup's close event to update the state accordingly. Additionally, a bug fix is documented for the popup closing unexpectedly when certain sessions were opened.

**Profile Filter Popup State Management:**

* Added a new property `IsProfileFilterPopupOpen` to `ConfigurationInfo.cs` to track whether the profile filter popup is open.
* Updated `FocusEmbeddedWindow()` logic in `MainWindow.xaml.cs` to check `IsProfileFilterPopupOpen` before focusing an embedded window, preventing unintended focus changes when the popup is open.
* Set `IsProfileFilterPopupOpen` to `true` when opening the profile filter in `PowerShellHostViewModel.cs`, and added an event handler to set it to `false` when the popup is closed. [[1]](diffhunk://#diff-0a216588b4c5da978a7f923c2641527b8b683001f63747b19cd57a8433791fecR495-R496) [[2]](diffhunk://#diff-0a216588b4c5da978a7f923c2641527b8b683001f63747b19cd57a8433791fecR814-R818)

**UI Event Handling:**

* Hooked up the `Closed` event for the profile filter popup in `PowerShellHostView.xaml`, and implemented the corresponding event handler in `PowerShellHostView.xaml.cs` to update the popup state. [[1]](diffhunk://#diff-24abb507ee2cfdaf4fd1ee45c02cc40e266a492d57cba46da27580e45de2e6a8R363) [[2]](diffhunk://#diff-2bd9fad55d6601a1232fa072da77e03c0744d40aeefdf9a309bcc1aeee039b61R64-R68)

**Documentation:**

* Added a changelog entry documenting the bug fix for the profile filter popup closing unexpectedly when certain sessions were opened.

</details>

## To-Do

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
