### PR TITLE
Fix: Resolve correct pwsh path if installed via Windows Store

### DIFF
--- a/Source/NETworkManager/Views/PowerShellHostView.xaml
+++ b/Source/NETworkManager/Views/PowerShellHostView.xaml
@@ -8,7 +8,6 @@
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:converters="clr-namespace:NETworkManager.Converters;assembly=NETworkManager.Converters"
              xmlns:controls="clr-namespace:NETworkManager.Controls;assembly=NETworkManager.Controls"
-             xmlns:dialogs="clr-namespace:MahApps.Metro.Controls.Dialogs;assembly=MahApps.Metro"
              xmlns:viewModels="clr-namespace:NETworkManager.ViewModels"
              xmlns:localization="clr-namespace:NETworkManager.Localization.Resources;assembly=NETworkManager.Localization"
              xmlns:settings="clr-namespace:NETworkManager.Settings;assembly=NETworkManager.Settings"
@@ -18,7 +17,6 @@
              xmlns:profiles="clr-namespace:NETworkManager.Profiles;assembly=NETworkManager.Profiles"
              xmlns:wpfHelpers="clr-namespace:NETworkManager.Utilities.WPF;assembly=NETworkManager.Utilities.WPF"
              xmlns:networkManager="clr-namespace:NETworkManager"
-             dialogs:DialogParticipation.Register="{Binding}"
              Loaded="UserControl_Loaded"
              mc:Ignorable="d" d:DataContext="{d:DesignInstance viewModels:PowerShellHostViewModel}">
     <UserControl.Resources>

--- a/Source/NETworkManager/Views/PowerShellHostView.xaml.cs
+++ b/Source/NETworkManager/Views/PowerShellHostView.xaml.cs
@@ -1,5 +1,4 @@
-﻿using MahApps.Metro.Controls.Dialogs;
-using NETworkManager.ViewModels;
+﻿using NETworkManager.ViewModels;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -9,7 +8,7 @@ namespace NETworkManager.Views;
 
 public partial class PowerShellHostView
 {
-    private readonly PowerShellHostViewModel _viewModel = new(DialogCoordinator.Instance);
+    private readonly PowerShellHostViewModel _viewModel = new();
 
     private bool _loaded;
 

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -63,7 +63,14 @@ Release date: **xx.xx.2025**
 
 ## Bug Fixes
 
-- The new profile filter popup introduced in version `2025.10.18.0` was instantly closed when a `PuTTY`, `PowerShell` or `AWS Session Manager` session was opened and the respective application / view was selected. [#3219](https://github.com/BornToBeRoot/NETworkManager/pull/3219)
+**PowerShell**
+
+- Resolve the actual path to `pwsh.exe` under `C:\Program Files\WindowsApps\` instead of relying on the stub located at `%LocalAppData%\Microsoft\WindowsApps\`. The stub simply redirects to the real executable, and settings such as themes are applied only to the real binary via the registry. [#3246](https://github.com/BornToBeRoot/NETworkManager/pull/3246)
+- The new profile filter popup introduced in version `2025.10.18.0` was instantly closed when a `PowerShell` session was opened and the respective application / view was selected. [#3219](https://github.com/BornToBeRoot/NETworkManager/pull/3219)
+
+**PuTTY**
+
+- The new profile filter popup introduced in version `2025.10.18.0` was instantly closed when a `PuTTY` session was opened and the respective application / view was selected. [#3219](https://github.com/BornToBeRoot/NETworkManager/pull/3219)
 
 ## Dependencies, Refactoring & Documentation
 


### PR DESCRIPTION
## Changes proposed in this pull request

- Resolve correct pwsh path if installed via Windows Store to apply theme
-

## Related issue(s)

- Fixes #3223

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request improves the handling of PowerShell executable detection, specifically addressing issues with Microsoft Store installations, and removes unused dialog-related dependencies from the `PowerShellHostViewModel` and its associated view. The main focus is to ensure the application can correctly resolve the real path of PowerShell when installed via the Microsoft Store, and to simplify the codebase by removing unnecessary dialog coordinator logic.

**PowerShell executable detection improvements:**

* Added a workaround in `PowerShellHostViewModel` to detect when `pwsh.exe` is a proxy stub from a Microsoft Store installation (located in `AppData\Local\Microsoft\WindowsApps`) and resolve its actual installation path using a new helper method `FindRealPwshPath`. This addresses issues where the application could not find the real PowerShell executable. [[1]](diffhunk://#diff-0a216588b4c5da978a7f923c2641527b8b683001f63747b19cd57a8433791fecL572-R583) [[2]](diffhunk://#diff-0a216588b4c5da978a7f923c2641527b8b683001f63747b19cd57a8433791fecR593-R647)
* If the real path cannot be resolved, the logic falls back to searching for Windows PowerShell.

**Removal of dialog-related dependencies:**

* Removed the `IDialogCoordinator` dependency from the `PowerShellHostViewModel` constructor and class, as it is no longer used. [[1]](diffhunk://#diff-0a216588b4c5da978a7f923c2641527b8b683001f63747b19cd57a8433791fecL35) [[2]](diffhunk://#diff-0a216588b4c5da978a7f923c2641527b8b683001f63747b19cd57a8433791fecL310-R317)
* Cleaned up related XAML by removing the `MahApps.Metro` dialogs namespace and the `DialogParticipation.Register` binding from `PowerShellHostView.xaml`. [[1]](diffhunk://#diff-24abb507ee2cfdaf4fd1ee45c02cc40e266a492d57cba46da27580e45de2e6a8L11) [[2]](diffhunk://#diff-24abb507ee2cfdaf4fd1ee45c02cc40e266a492d57cba46da27580e45de2e6a8L21)
* Removed the `MahApps.Metro.Controls.Dialogs` using directive and updated the instantiation of `PowerShellHostViewModel` to use the parameterless constructor in `PowerShellHostView.xaml.cs`. [[1]](diffhunk://#diff-2bd9fad55d6601a1232fa072da77e03c0744d40aeefdf9a309bcc1aeee039b61L1-R1) [[2]](diffhunk://#diff-2bd9fad55d6601a1232fa072da77e03c0744d40aeefdf9a309bcc1aeee039b61L12-R11)

</details>

## To-Do

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
