### PR TITLE
Feature: Daily settings backup

### DIFF
--- a/Source/NETworkManager.Profiles/ProfileManager.cs
+++ b/Source/NETworkManager.Profiles/ProfileManager.cs
@@ -1,4 +1,6 @@
-﻿using NETworkManager.Settings;
+﻿using log4net;
+using NETworkManager.Models.Network;
+using NETworkManager.Settings;
 using NETworkManager.Utilities;
 using System;
 using System.Collections.Generic;
@@ -13,19 +15,8 @@ namespace NETworkManager.Profiles;
 
 public static class ProfileManager
 {
-    #region Constructor
-
-    /// <summary>
-    ///     Static constructor. Load all profile files on startup.
-    /// </summary>
-    static ProfileManager()
-    {
-        LoadProfileFiles();
-    }
-
-    #endregion
-
     #region Variables
+    private static readonly ILog Log = LogManager.GetLogger(typeof(ProfileManager));
 
     /// <summary>
     ///     Profiles directory name.
@@ -81,6 +72,18 @@ public static class ProfileManager
     ///     Indicates if profiles have changed.
     /// </summary>
     public static bool ProfilesChanged { get; set; }
+
+    #endregion
+
+    #region Constructor
+
+    /// <summary>
+    ///     Static constructor. Load all profile files on startup.
+    /// </summary>
+    static ProfileManager()
+    {
+        LoadProfileFiles();
+    }
 
     #endregion
 
@@ -202,7 +205,7 @@ public static class ProfileManager
 
         Directory.CreateDirectory(GetProfilesFolderLocation());
 
-        SerializeToFile(profileFileInfo.Path, new List<GroupInfo>());
+        SerializeToFile(profileFileInfo.Path, []);
 
         ProfileFiles.Add(profileFileInfo);
     }
@@ -219,7 +222,6 @@ public static class ProfileManager
         if (LoadedProfileFile != null && LoadedProfileFile.Equals(profileFileInfo))
         {
             Save();
-
             switchProfile = true;
         }
 
@@ -472,7 +474,12 @@ public static class ProfileManager
     public static void Save()
     {
         if (LoadedProfileFile == null)
+        {
+            Log.Warn("Cannot save profiles because no profile file is loaded. The profile file may be encrypted and not yet unlocked.");
+
             return;
+        }
+            
 
         Directory.CreateDirectory(GetProfilesFolderLocation());
 

--- a/Source/NETworkManager.Settings/GlobalStaticConfiguration.cs
+++ b/Source/NETworkManager.Settings/GlobalStaticConfiguration.cs
@@ -46,6 +46,9 @@ public static class GlobalStaticConfiguration
     public static string ZipFileExtensionFilter => "ZIP Archive (*.zip)|*.zip";
     public static string XmlFileExtensionFilter => "XML-File (*.xml)|*.xml";
 
+    // Backup settings
+    public static int Backup_MaximumNumberOfBackups => 10;
+
     #endregion
 
     #region Default settings

--- a/Source/NETworkManager.Settings/SettingsInfo.cs
+++ b/Source/NETworkManager.Settings/SettingsInfo.cs
@@ -112,10 +112,10 @@ public class SettingsInfo : INotifyPropertyChanged
     /// <summary>
     /// Private field for the <see cref="LastBackup" /> property.
     /// </summary>
-    private DateTime _lastBackup = DateTime.Now.Date;
+    private DateTime _lastBackup = DateTime.MinValue;
 
     /// <summary>
-    /// Store the date and time of the last backup of the settings file.
+    /// Stores the date of the last backup of the settings file.
     /// </summary>
     public DateTime LastBackup
     {

--- a/Source/NETworkManager.Settings/SettingsInfo.cs
+++ b/Source/NETworkManager.Settings/SettingsInfo.cs
@@ -124,7 +124,7 @@ public class SettingsInfo : INotifyPropertyChanged
         {
             if (value == _lastBackup)
                 return;
-     
+
             _lastBackup = value;
             OnPropertyChanged();
         }
@@ -1237,7 +1237,7 @@ public class SettingsInfo : INotifyPropertyChanged
 
     #region Port Scanner
 
-    private ObservableCollection<string> _portScanner_HostHistory = new();
+    private ObservableCollection<string> _portScanner_HostHistory = [];
 
     public ObservableCollection<string> PortScanner_HostHistory
     {
@@ -1252,7 +1252,7 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     }
 
-    private ObservableCollection<string> _portScanner_PortHistory = new();
+    private ObservableCollection<string> _portScanner_PortHistory = [];
 
     public ObservableCollection<string> PortScanner_PortHistory
     {
@@ -1267,7 +1267,7 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     }
 
-    private ObservableCollection<PortProfileInfo> _portScanner_PortProfiles = new();
+    private ObservableCollection<PortProfileInfo> _portScanner_PortProfiles = [];
 
     public ObservableCollection<PortProfileInfo> PortScanner_PortProfiles
     {
@@ -1590,7 +1590,7 @@ public class SettingsInfo : INotifyPropertyChanged
 
     #region Traceroute
 
-    private ObservableCollection<string> _traceroute_HostHistory = new();
+    private ObservableCollection<string> _traceroute_HostHistory = [];
 
     public ObservableCollection<string> Traceroute_HostHistory
     {
@@ -2020,7 +2020,7 @@ public class SettingsInfo : INotifyPropertyChanged
 
     #region Remote Desktop
 
-    private ObservableCollection<string> _remoteDesktop_HostHistory = new();
+    private ObservableCollection<string> _remoteDesktop_HostHistory = [];
 
     public ObservableCollection<string> RemoteDesktop_HostHistory
     {
@@ -2600,7 +2600,7 @@ public class SettingsInfo : INotifyPropertyChanged
 
     #region PowerShell
 
-    private ObservableCollection<string> _powerShell_HostHistory = new();
+    private ObservableCollection<string> _powerShell_HostHistory = [];
 
     public ObservableCollection<string> PowerShell_HostHistory
     {
@@ -2710,7 +2710,7 @@ public class SettingsInfo : INotifyPropertyChanged
 
     #region PuTTY
 
-    private ObservableCollection<string> _puTTY_HostHistory = new();
+    private ObservableCollection<string> _puTTY_HostHistory = [];
 
     public ObservableCollection<string> PuTTY_HostHistory
     {
@@ -2860,7 +2860,7 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     }
 
-    private ObservableCollection<string> _puTTY_SerialLineHistory = new();
+    private ObservableCollection<string> _puTTY_SerialLineHistory = [];
 
     public ObservableCollection<string> PuTTY_SerialLineHistory
     {
@@ -2875,7 +2875,7 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     }
 
-    private ObservableCollection<string> _puTTY_PortHistory = new();
+    private ObservableCollection<string> _puTTY_PortHistory = [];
 
     public ObservableCollection<string> PuTTY_PortHistory
     {
@@ -2890,7 +2890,7 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     }
 
-    private ObservableCollection<string> _puTTY_BaudHistory = new();
+    private ObservableCollection<string> _puTTY_BaudHistory = [];
 
     public ObservableCollection<string> PuTTY_BaudHistory
     {
@@ -2905,7 +2905,7 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     }
 
-    private ObservableCollection<string> _puTTY_UsernameHistory = new();
+    private ObservableCollection<string> _puTTY_UsernameHistory = [];
 
     public ObservableCollection<string> PuTTY_UsernameHistory
     {
@@ -2920,7 +2920,7 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     }
 
-    private ObservableCollection<string> _puTTY_PrivateKeyFileHistory = new();
+    private ObservableCollection<string> _puTTY_PrivateKeyFileHistory = [];
 
     public ObservableCollection<string> PuTTY_PrivateKeyFileHistory
     {
@@ -2935,7 +2935,7 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     }
 
-    private ObservableCollection<string> _puTTY_ProfileHistory = new();
+    private ObservableCollection<string> _puTTY_ProfileHistory = [];
 
     public ObservableCollection<string> PuTTY_ProfileHistory
     {
@@ -3090,7 +3090,7 @@ public class SettingsInfo : INotifyPropertyChanged
 
     #region TigerVNC
 
-    private ObservableCollection<string> _tigerVNC_HostHistory = new();
+    private ObservableCollection<string> _tigerVNC_HostHistory = [];
 
     public ObservableCollection<string> TigerVNC_HostHistory
     {
@@ -3105,7 +3105,7 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     }
 
-    private ObservableCollection<int> _tigerVNC_PortHistory = new();
+    private ObservableCollection<int> _tigerVNC_PortHistory = [];
 
     public ObservableCollection<int> TigerVNC_PortHistory
     {
@@ -3184,7 +3184,7 @@ public class SettingsInfo : INotifyPropertyChanged
 
     #region Web Console
 
-    private ObservableCollection<string> _webConsole_UrlHistory = new();
+    private ObservableCollection<string> _webConsole_UrlHistory = [];
 
     public ObservableCollection<string> WebConsole_UrlHistory
     {
@@ -3278,7 +3278,7 @@ public class SettingsInfo : INotifyPropertyChanged
 
     #region SNMP
 
-    private ObservableCollection<string> _snmp_HostHistory = new();
+    private ObservableCollection<string> _snmp_HostHistory = [];
 
     public ObservableCollection<string> SNMP_HostHistory
     {
@@ -3293,7 +3293,7 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     }
 
-    private ObservableCollection<string> _snmp_OidHistory = new();
+    private ObservableCollection<string> _snmp_OidHistory = [];
 
     public ObservableCollection<string> SNMP_OidHistory
     {
@@ -3308,7 +3308,7 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     }
 
-    private ObservableCollection<SNMPOIDProfileInfo> _snmp_OidProfiles = new();
+    private ObservableCollection<SNMPOIDProfileInfo> _snmp_OidProfiles = [];
 
     public ObservableCollection<SNMPOIDProfileInfo> SNMP_OidProfiles
     {
@@ -3702,7 +3702,7 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     }
 
-    private ObservableCollection<string> _wakeOnLan_MACAddressHistory = new();
+    private ObservableCollection<string> _wakeOnLan_MACAddressHistory = [];
 
     public ObservableCollection<string> WakeOnLan_MACAddressHistory
     {
@@ -3717,7 +3717,7 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     }
 
-    private ObservableCollection<string> _wakeOnLan_BroadcastHistory = new();
+    private ObservableCollection<string> _wakeOnLan_BroadcastHistory = [];
 
     public ObservableCollection<string> WakeOnLan_BroadcastHistory
     {
@@ -3766,7 +3766,7 @@ public class SettingsInfo : INotifyPropertyChanged
 
     #region Whois
 
-    private ObservableCollection<string> _whois_DomainHistory = new();
+    private ObservableCollection<string> _whois_DomainHistory = [];
 
     public ObservableCollection<string> Whois_DomainHistory
     {
@@ -3845,7 +3845,7 @@ public class SettingsInfo : INotifyPropertyChanged
 
     #region IP Geolocation
 
-    private ObservableCollection<string> _ipGeolocation_HostHistory = new();
+    private ObservableCollection<string> _ipGeolocation_HostHistory = [];
 
     public ObservableCollection<string> IPGeolocation_HostHistory
     {
@@ -3926,7 +3926,7 @@ public class SettingsInfo : INotifyPropertyChanged
 
     #region Calculator
 
-    private ObservableCollection<string> _subnetCalculator_Calculator_SubnetHistory = new();
+    private ObservableCollection<string> _subnetCalculator_Calculator_SubnetHistory = [];
 
     public ObservableCollection<string> SubnetCalculator_Calculator_SubnetHistory
     {
@@ -3945,7 +3945,7 @@ public class SettingsInfo : INotifyPropertyChanged
 
     #region Subnetting
 
-    private ObservableCollection<string> _subnetCalculator_Subnetting_SubnetHistory = new();
+    private ObservableCollection<string> _subnetCalculator_Subnetting_SubnetHistory = [];
 
     public ObservableCollection<string> SubnetCalculator_Subnetting_SubnetHistory
     {
@@ -3960,7 +3960,7 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     }
 
-    private ObservableCollection<string> _subnetCalculator_Subnetting_NewSubnetmaskHistory = new();
+    private ObservableCollection<string> _subnetCalculator_Subnetting_NewSubnetmaskHistory = [];
 
     public ObservableCollection<string> SubnetCalculator_Subnetting_NewSubnetmaskHistory
     {
@@ -4010,7 +4010,7 @@ public class SettingsInfo : INotifyPropertyChanged
 
     #region WideSubnet
 
-    private ObservableCollection<string> _subnetCalculator_WideSubnet_Subnet1 = new();
+    private ObservableCollection<string> _subnetCalculator_WideSubnet_Subnet1 = [];
 
     public ObservableCollection<string> SubnetCalculator_WideSubnet_Subnet1
     {
@@ -4025,7 +4025,7 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     }
 
-    private ObservableCollection<string> _subnetCalculator_WideSubnet_Subnet2 = new();
+    private ObservableCollection<string> _subnetCalculator_WideSubnet_Subnet2 = [];
 
     public ObservableCollection<string> SubnetCalculator_WideSubnet_Subnet2
     {
@@ -4046,7 +4046,7 @@ public class SettingsInfo : INotifyPropertyChanged
 
     #region Bit Calculator
 
-    private ObservableCollection<string> _bitCalculator_InputHistory = new();
+    private ObservableCollection<string> _bitCalculator_InputHistory = [];
 
     public ObservableCollection<string> BitCalculator_InputHistory
     {

--- a/Source/NETworkManager.Settings/SettingsInfo.cs
+++ b/Source/NETworkManager.Settings/SettingsInfo.cs
@@ -109,6 +109,27 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     }
 
+    /// <summary>
+    /// Private field for the <see cref="LastBackup" /> property.
+    /// </summary>
+    private DateTime _lastBackup = DateTime.Now.Date;
+
+    /// <summary>
+    /// Store the date and time of the last backup of the settings file.
+    /// </summary>
+    public DateTime LastBackup
+    {
+        get => _lastBackup;
+        set
+        {
+            if (value == _lastBackup)
+                return;
+     
+            _lastBackup = value;
+            OnPropertyChanged();
+        }
+    }
+
     #region General
 
     // General   
@@ -1400,7 +1421,7 @@ public class SettingsInfo : INotifyPropertyChanged
 
     #region Ping Monitor
 
-    private ObservableCollection<string> _pingMonitor_HostHistory = new();
+    private ObservableCollection<string> _pingMonitor_HostHistory = [];
 
     public ObservableCollection<string> PingMonitor_HostHistory
     {

--- a/Source/NETworkManager.Settings/SettingsManager.cs
+++ b/Source/NETworkManager.Settings/SettingsManager.cs
@@ -181,7 +181,7 @@ public static class SettingsManager
             Backup(legacyFilePath,
                 GetSettingsBackupFolderLocation(),
                 $"{TimestampHelper.GetTimestamp()}_{GetLegacySettingsFileName()}");
-            
+
             File.Delete(legacyFilePath);
 
             Log.Info("Settings migration from XML to JSON completed successfully.");

--- a/Source/NETworkManager.Settings/SettingsManager.cs
+++ b/Source/NETworkManager.Settings/SettingsManager.cs
@@ -303,7 +303,7 @@ public static class SettingsManager
     private static void CleanupBackups(string backupFolderPath, string settingsFileName, int maxBackupFiles)
     {
         var backupFiles = Directory.GetFiles(backupFolderPath)
-            .Where(f => f.EndsWith(settingsFileName) || f.EndsWith(Path.Combine(GetLegacySettingsFileName())))
+            .Where(f => f.EndsWith(settingsFileName) || f.EndsWith(GetLegacySettingsFileName()))
             .OrderByDescending(f => File.GetCreationTime(f))
             .ToList();
 
@@ -325,10 +325,10 @@ public static class SettingsManager
     /// <summary>
     /// Creates a backup of the specified settings file in the given backup folder with the provided backup file name.
     /// </summary>
-    /// <param name="setingsFilePath">The full path to the settings file to back up. Cannot be null or empty.</param>
+    /// <param name="settingsFilePath">The full path to the settings file to back up. Cannot be null or empty.</param>
     /// <param name="backupFolderPath">The directory path where the backup file will be stored. If the directory does not exist, it will be created.</param>
     /// <param name="backupFileName">The name to use for the backup file within the backup folder. Cannot be null or empty.</param>
-    private static void Backup(string setingsFilePath, string backupFolderPath, string backupFileName)
+    private static void Backup(string settingsFilePath, string backupFolderPath, string backupFileName)
     {
         // Create the backup directory if it does not exist
         Directory.CreateDirectory(backupFolderPath);
@@ -337,7 +337,7 @@ public static class SettingsManager
         var backupFilePath = Path.Combine(backupFolderPath, backupFileName);
 
         // Copy the current settings file to the backup location
-        File.Copy(setingsFilePath, backupFilePath, true);
+        File.Copy(settingsFilePath, backupFilePath, true);
 
         Log.Info($"Backup created: {backupFilePath}");
     }

--- a/Source/NETworkManager.Settings/SettingsManager.cs
+++ b/Source/NETworkManager.Settings/SettingsManager.cs
@@ -178,16 +178,11 @@ public static class SettingsManager
             Save();
 
             // Create a backup of the legacy XML file and delete the original
-            Directory.CreateDirectory(GetSettingsBackupFolderLocation());
-
-            var backupFilePath = Path.Combine(GetSettingsBackupFolderLocation(),
+            Backup(legacyFilePath,
+                GetSettingsBackupFolderLocation(),
                 $"{TimestampHelper.GetTimestamp()}_{GetLegacySettingsFileName()}");
-
-            File.Copy(legacyFilePath, backupFilePath, true);
-
+            
             File.Delete(legacyFilePath);
-
-            Log.Info($"Legacy XML settings file backed up to: {backupFilePath}");
 
             Log.Info("Settings migration from XML to JSON completed successfully.");
 

--- a/Source/NETworkManager.Utilities/TimestampHelper.cs
+++ b/Source/NETworkManager.Utilities/TimestampHelper.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.IO;
 
 namespace NETworkManager.Utilities;
 
@@ -7,5 +9,49 @@ public static class TimestampHelper
     public static string GetTimestamp()
     {
         return DateTime.Now.ToString("yyyyMMddHHmmss");
+    }
+
+    /// <summary>
+    /// Generates a filename by prefixing the specified filename with a timestamp string.
+    /// </summary>
+    /// <param name="fileName">The original filename to be prefixed with a timestamp. Cannot be null or empty.</param>
+    /// <returns>A string containing the timestamp followed by an underscore and the original filename.</returns>
+    public static string GetTimestampFilename(string fileName)
+    {
+        return $"{GetTimestamp()}_{fileName}";
+    }
+
+    /// <summary>
+    /// Determines whether the specified file name begins with a valid timestamp in the format "yyyyMMddHHmmss".
+    /// </summary>
+    /// <remarks>This method checks only the first 14 characters of the file name for a valid timestamp and
+    /// does not validate the remainder of the file name.</remarks>
+    /// <param name="fileName">The file name to evaluate. The file name is expected to start with a 14-digit timestamp followed by an
+    /// underscore and at least one additional character.</param>
+    /// <returns>true if the file name starts with a valid timestamp in the format "yyyyMMddHHmmss"; otherwise, false.</returns>
+    public static bool IsTimestampedFilename(string fileName)
+    {
+        // Ensure the filename is long enough to contain a timestamp, an underscore, and at least one character after it
+        if (fileName.Length < 16)
+            return false;
+
+        var timestampString = fileName.Substring(0, 14);
+
+        return DateTime.TryParseExact(timestampString, "yyyyMMddHHmmss", CultureInfo.InvariantCulture, DateTimeStyles.None, out _);
+    }
+
+    /// <summary>
+    /// Extracts the timestamp from a filename that starts with a timestamp prefix.
+    /// </summary>
+    /// <remarks>Filenames are expected to start with yyyyMMddHHmmss_* format (14 characters). 
+    /// This method extracts the timestamp portion and parses it as a DateTime.</remarks>
+    /// <param name="fileName">The full path to the file or just the filename.</param>
+    /// <returns>The timestamp extracted from the filename.</returns>
+    public static DateTime ExtractTimestampFromFilename(string fileName)
+    {
+        // Extract the timestamp prefix (yyyyMMddHHmmss format, 14 characters)
+        var timestampString = fileName.Substring(0, 14);
+
+        return DateTime.ParseExact(timestampString, "yyyyMMddHHmmss", CultureInfo.InvariantCulture);
     }
 }

--- a/Source/NETworkManager/App.xaml.cs
+++ b/Source/NETworkManager/App.xaml.cs
@@ -94,7 +94,7 @@ public partial class App
         catch (InvalidOperationException ex)
         {
             Log.Error("Could not load application settings!", ex);
-            
+
             HandleCorruptedSettingsFile();
         }
         catch (JsonException ex)

--- a/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
@@ -760,7 +760,7 @@ public class PingMonitorHostViewModel : ViewModelBase, IProfileManager
     private void AddHostToHistory(string host)
     {
         // Create the new list
-        var list = ListHelper.Modify(SettingsManager.Current.PingMonitor_HostHistory.ToList(), host,
+        var list = ListHelper.Modify([.. SettingsManager.Current.PingMonitor_HostHistory], host,
             SettingsManager.Current.General_HistoryListEntries);
 
         // Clear the old items
@@ -768,7 +768,7 @@ public class PingMonitorHostViewModel : ViewModelBase, IProfileManager
         OnPropertyChanged(nameof(Host)); // Raise property changed again, after the collection has been cleared
 
         // Fill with the new items
-        list.ForEach(x => SettingsManager.Current.PingMonitor_HostHistory.Add(x));
+        list.ForEach(SettingsManager.Current.PingMonitor_HostHistory.Add);
     }
 
     private void SetIsExpandedForAllProfileGroups(bool isExpanded)

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -54,6 +54,7 @@ Release date: **xx.xx.2025**
 **Settings**
 
 - Settings format migrated from `XML` to `JSON`. The settings file will be automatically converted on first start after the update. [#3282](https://github.com/BornToBeRoot/NETworkManager/pull/3282)
+- Create a daily backup of the settings file before saving changes. Up to `10` backup files are kept in the `Backups` subfolder of the settings directory. [#3283](https://github.com/BornToBeRoot/NETworkManager/pull/3283)
 
 **DNS Lookup**
 

--- a/Website/docs/settings/settings.md
+++ b/Website/docs/settings/settings.md
@@ -18,9 +18,22 @@ Folder where the application settings are stored.
 | Portable       | `<APP_FOLDER>\Settings`                           |
 
 :::note
-It is recommended to backup the above files on a regular basis.
 
-To restore the settings, close the application and copy the files from the backup to the above location.
+**Recommendation**  
+It is strongly recommended to regularly back up your settings files.
+
+**Automatic backups**  
+NETworkManager automatically creates a backup of the settings files before applying any changes.
+- Location: `Settings\Backups` subfolder (relative to the main configuration directory)
+- Naming: timestamped (e.g. `yyyyMMddHHmmss_Settings.json`)
+- Frequency: **once per day** at most (even if multiple changes occur)
+- Retention: keeps the **10 most recent backups**
+
+**Restoring settings**  
+1. Completely close NETworkManager
+2. Locate the desired backup in `Settings\Backups`
+3. Copy the file(s) back to the original configuration folder (overwriting existing files)
+4. Restart the application
 
 :::
 


### PR DESCRIPTION
## Changes proposed in this pull request

- Create a daily backup
- Cleanup backups older than 10 files

## Related issue(s)

- #2679

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request introduces a daily backup system for the application's settings file, ensuring that a backup is created only once per day and that old backups are cleaned up according to a configurable retention limit. It also adds tracking of the last backup date and improves backup management during settings migration and saving.

**Backup and retention improvements:**

* Added a `CreateDailyBackupIfNeeded` method in `SettingsManager.cs` to create a backup of the settings file only if one hasn't been created for the current day, and to clean up old backups based on a configurable maximum.
* Introduced a `CleanupBackups` method to retain only the most recent backups up to the configured maximum, deleting older ones to manage disk usage.
* Added a `Backup` method to encapsulate the logic for copying the settings file to the backup location, used during both migration and daily backup routines. [[1]](diffhunk://#diff-334664a85ae2b53595a06f22244c964f82558a9fc5db92047b089bbc242b8e4aL261-L269) [[2]](diffhunk://#diff-334664a85ae2b53595a06f22244c964f82558a9fc5db92047b089bbc242b8e4aL181-L191)
* Added `Backup_MaximumNumberOfBackups` constant to `GlobalStaticConfiguration.cs` to configure the maximum number of retained backups.

**Settings tracking and migration:**

* Added a `LastBackup` property to `SettingsInfo.cs` to track the date of the last performed backup, ensuring daily backups are not duplicated.
* Updated the settings migration logic to use the new `Backup` method for legacy file backup, streamlining and unifying backup operations.
* Modified the `Save` method in `SettingsManager.cs` to call `CreateDailyBackupIfNeeded` before saving, ensuring backups are consistently created as needed.

**Other code improvements:**

* Used collection initializer syntax (`[]`) for the `_pingMonitor_HostHistory` field in `SettingsInfo.cs` for conciseness.

</details>

## To-Do

- [ ] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs) to reflect this changes
- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
