### PR TITLE
Fix: Race condition on host/port scanned

### DIFF
--- a/Source/NETworkManager/ViewModels/PortScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PortScannerViewModel.cs
@@ -565,14 +565,19 @@ public class PortScannerViewModel : ViewModelBase
 
     private void ScanComplete(object sender, EventArgs e)
     {
-        if (Results.Count == 0)
+        // Run in UI thread with lower priority than PortScanned event
+        // to ensure all results are added first #3285
+        Application.Current.Dispatcher.Invoke(() =>
         {
-            StatusMessage = Strings.NoOpenPortsFound;
-            IsStatusMessageDisplayed = true;
-        }
+            if (Results.Count == 0)
+            {
+                StatusMessage = Strings.NoOpenPortsFound;
+                IsStatusMessageDisplayed = true;
+            }
 
-        IsCanceling = false;
-        IsRunning = false;
+            IsCanceling = false;
+            IsRunning = false;
+        }, DispatcherPriority.Background);
     }
 
     private void UserHasCanceled(object sender, EventArgs e)

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -84,6 +84,14 @@ Release date: **xx.xx.2025**
 
 ## Bug Fixes
 
+**IP Scanner**
+
+- Fix race condition when scan is complete but not all results have been processed yet, causing a wrong error message to be displayed. [#3287](https://github.com/BornToBeRoot/NETworkManager/pull/3287)
+
+**Port Scanner**
+
+- Fix race condition when scan is complete but not all results have been processed yet, causing a wrong error message to be displayed. [#3287](https://github.com/BornToBeRoot/NETworkManager/pull/3287)
+
 **PowerShell**
 
 - Resolve the actual path to `pwsh.exe` under `C:\Program Files\WindowsApps\` instead of relying on the stub located at `%LocalAppData%\Microsoft\WindowsApps\`. The stub simply redirects to the real executable, and settings such as themes are applied only to the real binary via the registry. [#3246](https://github.com/BornToBeRoot/NETworkManager/pull/3246)


### PR DESCRIPTION
## Changes proposed in this pull request

- Fix race condition on host / port scanned. Scan is completed (Result == 0), but Hosts is up, but not added
- Use ScanComplete in UI Thread with lower prio

## Related issue(s)

- Fixes #3285

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request makes improvements to the scan completion logic in both the IP scanner and port scanner view models to ensure UI updates occur in the correct order and with appropriate thread priority. It also updates the IP range detection logic to use a configurable public IP address. The most important changes are grouped below.

**UI Threading and Scan Completion Ordering:**

* In both `IPScannerViewModel.cs` and `PortScannerViewModel.cs`, the `ScanComplete` event handler now runs on the UI thread with `DispatcherPriority.Background` to ensure all scan results are added before updating scan state, preventing race conditions and improving UI consistency. [[1]](diffhunk://#diff-882ce58ad55ffedec5fc73cf73c8dec483b06e0624c9ad2a2b1c2a157a173cc9R740-R743) [[2]](diffhunk://#diff-882ce58ad55ffedec5fc73cf73c8dec483b06e0624c9ad2a2b1c2a157a173cc9R753) [[3]](diffhunk://#diff-4d2b4707950f9f800c394de1fd8f415894170064d1f3fafc683877661c0e9440R567-R570) [[4]](diffhunk://#diff-4d2b4707950f9f800c394de1fd8f415894170064d1f3fafc683877661c0e9440R580)
* Added comments to clarify the reasoning for the change in dispatcher priority, referencing issue #3285 for context. [[1]](diffhunk://#diff-882ce58ad55ffedec5fc73cf73c8dec483b06e0624c9ad2a2b1c2a157a173cc9R740-R743) [[2]](diffhunk://#diff-4d2b4707950f9f800c394de1fd8f415894170064d1f3fafc683877661c0e9440R567-R570)

**IP Range Detection Logic:**

* Updated the IP range detection in `DetectIPRange()` to use `GlobalStaticConfiguration.Dashboard_PublicIPv4Address` instead of a hardcoded IP address, making the detection logic configurable and more robust.

**Minor UI Consistency:**

* Minor formatting change in the `HostScanned` event handler in `IPScannerViewModel.cs` for improved readability.

</details>

## To-Do

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
