### PR TITLE
Fix: Detect local IP address (& 169.254) as fallback when routing is not available

### DIFF
--- a/Source/NETworkManager.Models/Network/NetworkInterface.cs
+++ b/Source/NETworkManager.Models/Network/NetworkInterface.cs
@@ -288,7 +288,7 @@ public sealed class NetworkInterface
             });
 
             // Return first non-link-local or first candidate if none found (might be null - no addresses at all)
-            return nonLinkLocal.Any() ? nonLinkLocal.First() : candidates.First();
+            return nonLinkLocal.Any() ? nonLinkLocal.First() : candidates.FirstOrDefault();
         }
 
         // IPv6

--- a/Source/NETworkManager.Models/Network/NetworkInterface.cs
+++ b/Source/NETworkManager.Models/Network/NetworkInterface.cs
@@ -272,7 +272,7 @@ public sealed class NetworkInterface
 
         // IPv4
         if (addressFamily == AddressFamily.InterNetwork)
-        {           
+        {
             foreach (var networkInterface in networkInterfaces)
             {
                 foreach (var ipAddress in networkInterface.IPv4Address)

--- a/Source/NETworkManager.Models/Network/NetworkInterface.cs
+++ b/Source/NETworkManager.Models/Network/NetworkInterface.cs
@@ -352,7 +352,7 @@ public sealed class NetworkInterface
             {
                 if (networkInterface.IPv6Address.Contains(localIPAddress))
                     return networkInterface.IPv6Gateway.FirstOrDefault();
-            }            
+            }
         }
 
         return null;

--- a/Source/NETworkManager.Models/Network/NetworkInterface.cs
+++ b/Source/NETworkManager.Models/Network/NetworkInterface.cs
@@ -231,7 +231,7 @@ public sealed class NetworkInterface
 
             if (socket.LocalEndPoint is IPEndPoint ipAddress)
                 return ipAddress.Address;
-        }
+        }        
         catch (SocketException) { }
 
         return null;
@@ -296,20 +296,18 @@ public sealed class NetworkInterface
         {
             // First try to get global or unique local addresses
             foreach (var networkInterface in networkInterfaces)
-            {
                 candidates.AddRange(networkInterface.IPv6Address);
-            }
 
             // Return first candidate if any found
             if (candidates.Count != 0)
                 return candidates.First();
 
             // Fallback to link-local addresses
-            foreach (var networkInterface in networkInterfaces)
-            {
-                if (networkInterface.IPv6AddressLinkLocal.Length != 0)
-                    return networkInterface.IPv6AddressLinkLocal.First();
-            }
+            var firstWithLinkLocal = networkInterfaces
+               .FirstOrDefault(ni => ni.IPv6AddressLinkLocal.Length != 0);
+
+            if (firstWithLinkLocal != null)
+                return firstWithLinkLocal.IPv6AddressLinkLocal.First();
         }
 
         return null;

--- a/Source/NETworkManager.Models/Network/NetworkInterface.cs
+++ b/Source/NETworkManager.Models/Network/NetworkInterface.cs
@@ -231,7 +231,7 @@ public sealed class NetworkInterface
 
             if (socket.LocalEndPoint is IPEndPoint ipAddress)
                 return ipAddress.Address;
-        }        
+        }
         catch (SocketException) { }
 
         return null;

--- a/Source/NETworkManager.Profiles/ProfileManager.cs
+++ b/Source/NETworkManager.Profiles/ProfileManager.cs
@@ -479,7 +479,7 @@ public static class ProfileManager
 
             return;
         }
-            
+
 
         Directory.CreateDirectory(GetProfilesFolderLocation());
 

--- a/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
@@ -729,8 +729,9 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
     private void HostScanned(object sender, IPScannerHostScannedArgs e)
     {
         Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal,
-            new Action(delegate { 
-                Results.Add(e.Args); 
+            new Action(delegate
+            {
+                Results.Add(e.Args);
             }));
     }
 

--- a/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
@@ -555,7 +555,8 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
                 .First(x => x.IPv4Address.Any(y => y.Item1.Equals(localIP)));
 
             // If found, get subnetmask
-            if (networkInterface != null) {
+            if (networkInterface != null)
+            {
 
                 // Find the correct IP address and the associated subnetmask
                 var ipAddressWithSubnet = networkInterface.IPv4Address.First(x => x.Item1.Equals(localIP));

--- a/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
@@ -552,7 +552,7 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
 
             // Get network interfaces, where local IP address is assigned
             var networkInterface = (await NetworkInterface.GetNetworkInterfacesAsync())
-                .First(x => x.IPv4Address.Any(y => y.Item1.Equals(localIP)));
+                .FirstOrDefault(x => x.IPv4Address.Any(y => y.Item1.Equals(localIP)));
 
             // If found, get subnetmask
             if (networkInterface != null)

--- a/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
@@ -347,7 +347,7 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
 
     private void DetectSubnetAction()
     {
-        DetectIPRange().ConfigureAwait(false);
+        DetectSubnet().ConfigureAwait(false);
     }
 
     /// <summary>
@@ -530,34 +530,46 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
     }
 
     /// <summary>
-    /// Detects the local IP subnet.
+    /// Attempts to detect the local subnet and updates the host information accordingly.
     /// </summary>
-    private async Task DetectIPRange()
+    /// <remarks>If the subnet or local IP address cannot be detected, an error message is displayed to the
+    /// user. The method updates the Host property with the detected subnet in CIDR notation when successful.</remarks>
+    /// <returns>A task that represents the asynchronous subnet detection operation.</returns>
+    private async Task DetectSubnet()
     {
         IsSubnetDetectionRunning = true;
 
+        // Try to detect local IP address based on routing to public IP
         var localIP = await NetworkInterface.DetectLocalIPAddressBasedOnRoutingAsync(IPAddress.Parse(GlobalStaticConfiguration.Dashboard_PublicIPv4Address));
 
-        // Could not detect local ip address
+        // Fallback: Try to detect local IP address from network interfaces -> Prefer non link-local addresses
+        localIP ??= await NetworkInterface.DetectLocalIPAddressFromNetworkInterfaceAsync(System.Net.Sockets.AddressFamily.InterNetwork);
+
+        // If local IP address detected, try to find subnetmask from network interfaces
         if (localIP != null)
         {
-            var subnetmaskDetected = false;
+            var subnetDetected = false;
 
-            // Get subnetmask, based on ip address
-            foreach (var networkInterface in (await NetworkInterface.GetNetworkInterfacesAsync()).Where(
-                         networkInterface => networkInterface.IPv4Address.Any(x => x.Item1.Equals(localIP))))
-            {
-                subnetmaskDetected = true;
+            // Get network interfaces, where local IP address is assigned
+            var networkInterface = (await NetworkInterface.GetNetworkInterfacesAsync())
+                .First(x => x.IPv4Address.Any(y => y.Item1.Equals(localIP)));
 
-                Host = $"{localIP}/{Subnetmask.ConvertSubnetmaskToCidr(networkInterface.IPv4Address.First().Item2)}";
+            // If found, get subnetmask
+            if (networkInterface != null) {
+
+                // Find the correct IP address and the associated subnetmask
+                var ipAddressWithSubnet = networkInterface.IPv4Address.First(x => x.Item1.Equals(localIP));
+
+                Host = $"{ipAddressWithSubnet.Item1}/{Subnetmask.ConvertSubnetmaskToCidr(ipAddressWithSubnet.Item2)}";
+
+                subnetDetected = true;
 
                 // Fix: If the user clears the TextBox and then clicks again on the button, the TextBox remains empty...
                 OnPropertyChanged(nameof(Host));
-
-                break;
             }
 
-            if (!subnetmaskDetected)
+            // Show error message if subnet could not be detected
+            if (!subnetDetected)
             {
                 var window = Application.Current.Windows.OfType<Window>().FirstOrDefault(x => x.IsActive);
 

--- a/Source/NETworkManager/ViewModels/NetworkConnectionWidgetViewModel.cs
+++ b/Source/NETworkManager/ViewModels/NetworkConnectionWidgetViewModel.cs
@@ -901,7 +901,7 @@ public class NetworkConnectionWidgetViewModel : ViewModelBase
                 Log.Debug("CheckConnectionRouterAsync - Computer IPv4 address detected: " + detectedLocalIPv4Address);
 
                 var detectedRouterIPv4 =
-                    await NetworkInterface.DetectGatewayBasedOnLocalIPAddressAsync(
+                    await NetworkInterface.DetectGatewayFromLocalIPAddressAsync(
                         detectedLocalIPv4Address);
 
                 if (detectedRouterIPv4 != null)
@@ -944,7 +944,7 @@ public class NetworkConnectionWidgetViewModel : ViewModelBase
                 Log.Debug("CheckConnectionRouterAsync - Computer IPv6 address detected: " + detectedComputerIPv6);
 
                 var detectedRouterIPv6 =
-                    await NetworkInterface.DetectGatewayBasedOnLocalIPAddressAsync(detectedComputerIPv6);
+                    await NetworkInterface.DetectGatewayFromLocalIPAddressAsync(detectedComputerIPv6);
 
                 if (detectedRouterIPv6 != null)
                 {

--- a/Website/docs/application/ip-scanner.md
+++ b/Website/docs/application/ip-scanner.md
@@ -27,7 +27,16 @@ Example: `10.0.0.0/24; 10.0.[10-20]1`
 
 :::
 
-The button to the left of the `Scan` button determines the IP address and subnet mask of the network interface currently in use in order to scan the local subnet for active devices.
+The button to the left of the `Scan` button determines the IP address and subnet mask of the network interface
+currently in use in order to scan the local subnet for active devices.
+
+:::note
+
+The local IP address (and subnet mask) is determined by trying to route to a public IP address. If this fails (e.g. 
+no network connection), NETworkManager iterates over active network adapters and selects the first valid IPv4 address,
+with link-local addresses (`169.254.x.x`) given lower priority.
+
+:::
 
 If you right-click on a selected result, you can forward the device information to other applications (e.g. Port Scanner, Remote Desktop, etc), create a new profile with this information or execute a [custom command](#custom-commands).
 

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -56,6 +56,10 @@ Release date: **xx.xx.2025**
 - Settings format migrated from `XML` to `JSON`. The settings file will be automatically converted on first start after the update. [#3282](https://github.com/BornToBeRoot/NETworkManager/pull/3282)
 - Create a daily backup of the settings file before saving changes. Up to `10` backup files are kept in the `Backups` subfolder of the settings directory. [#3283](https://github.com/BornToBeRoot/NETworkManager/pull/3283)
 
+**IP Scanner**
+
+- Improved local subnet detection: If local IP cannot be determined via routing, now iterates over active network adapters and selects the first valid IPv4 address (with link-local addresses (`169.254.x.x`) given lower priority). [#3288](https://github.com/BornToBeRoot/NETworkManager/pull/3288)
+
 **DNS Lookup**
 
 - Allow hostname as server address in addition to IP address in the add/edit server dialog. [#3261](https://github.com/BornToBeRoot/NETworkManager/pull/3261)


### PR DESCRIPTION
## Changes proposed in this pull request

- Detect local ip address from interfaces that are up if routing is not available
- Detect link local if none available

## Related issue(s)

- Fixes #3277

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request refactors and improves the detection and handling of local IP addresses and gateways in the network interface logic, modernizes collection initializations, and clarifies method names and documentation. The changes also enhance subnet detection in the IP scanner view model and ensure more robust fallback mechanisms.

**Major improvements and refactoring:**

* Refactored and renamed several methods in `NetworkInterface` for clarity and consistency (e.g., `DetectLocalIPAddressBasedOnRoutingAsync` → `DetectLocalIPAddressFromRoutingAsync`, `DetectGatewayBasedOnLocalIPAddressAsync` → `DetectGatewayFromLocalIPAddressAsync`). Enhanced documentation to clarify return values and behaviors, and improved error handling to return `null` instead of throwing exceptions. [[1]](diffhunk://#diff-4c6706c381e0739b2a42f2fa27781247cab3deb8cdb25fa8b1f32b6f08827a54L153-R204) [[2]](diffhunk://#diff-4c6706c381e0739b2a42f2fa27781247cab3deb8cdb25fa8b1f32b6f08827a54L204-L241) [[3]](diffhunk://#diff-d433fd5ed775f354b653f012667807524aae308862a71b409fc37881d129682dL904-R904) [[4]](diffhunk://#diff-d433fd5ed775f354b653f012667807524aae308862a71b409fc37881d129682dL947-R947)
* Added new methods to detect the local IP address from operational network interfaces, preferring non-link-local addresses for IPv4 and global/unique-local for IPv6, with appropriate fallbacks.

**Modernization and code quality:**

* Updated collection initializations to use C# collection expressions (e.g., `[.. list]` and `[]`), simplifying and modernizing the codebase. [[1]](diffhunk://#diff-4c6706c381e0739b2a42f2fa27781247cab3deb8cdb25fa8b1f32b6f08827a54L50-R54) [[2]](diffhunk://#diff-4c6706c381e0739b2a42f2fa27781247cab3deb8cdb25fa8b1f32b6f08827a54L153-R204)
* Improved and clarified comments and XML documentation throughout the code, making method purposes and behaviors clearer for future maintenance. [[1]](diffhunk://#diff-4c6706c381e0739b2a42f2fa27781247cab3deb8cdb25fa8b1f32b6f08827a54L110-R121) [[2]](diffhunk://#diff-4c6706c381e0739b2a42f2fa27781247cab3deb8cdb25fa8b1f32b6f08827a54L153-R204) [[3]](diffhunk://#diff-882ce58ad55ffedec5fc73cf73c8dec483b06e0624c9ad2a2b1c2a157a173cc9L533-R572)

**Subnet and IP detection logic improvements:**

* Enhanced the subnet detection logic in `IPScannerViewModel` to use the new fallback mechanism for local IP detection, and to more robustly extract subnet information from detected network interfaces. Improved error handling and user feedback when detection fails. [[1]](diffhunk://#diff-882ce58ad55ffedec5fc73cf73c8dec483b06e0624c9ad2a2b1c2a157a173cc9L350-R350) [[2]](diffhunk://#diff-882ce58ad55ffedec5fc73cf73c8dec483b06e0624c9ad2a2b1c2a157a173cc9L533-R572)

**Code organization:**

* Moved the `UserHasCanceled` event and its handler to the end of the `NetworkInterface` class for better code organization. [[1]](diffhunk://#diff-4c6706c381e0739b2a42f2fa27781247cab3deb8cdb25fa8b1f32b6f08827a54L19-R33) [[2]](diffhunk://#diff-4c6706c381e0739b2a42f2fa27781247cab3deb8cdb25fa8b1f32b6f08827a54R486-R501)

**Other minor changes:**

* Added a `using System.Diagnostics;` statement, possibly for future debugging purposes.

These changes collectively improve code clarity, maintainability, and robustness, especially around network interface and subnet detection logic.

</details>

## To-Do

- [x] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs) to reflect this changes
- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
