### PR TITLE
Feature: Migrate profile files from xml to json

### DIFF
--- a/Source/NETworkManager.Profiles/ProfileManager.cs
+++ b/Source/NETworkManager.Profiles/ProfileManager.cs
@@ -481,13 +481,9 @@ public static class ProfileManager
             GlobalStaticConfiguration.Profile_EncryptionKeySize,
             GlobalStaticConfiguration.Profile_EncryptionIterations);
 
-        List<GroupInfo> profiles;
-
-        if (IsXmlContent(decryptedBytes))
-            profiles = DeserializeFromXmlByteArray(decryptedBytes);
-        else
-            profiles = DeserializeFromByteArray(decryptedBytes);
-
+        List<GroupInfo> profiles = IsXmlContent(decryptedBytes)
+            ? DeserializeFromXmlByteArray(decryptedBytes)
+            : DeserializeFromByteArray(decryptedBytes);
         // Save the decrypted profiles to the profile file
         SerializeToFile(newProfileFileInfo.Path, profiles);
 

--- a/Source/NETworkManager.Profiles/ProfileManager.cs
+++ b/Source/NETworkManager.Profiles/ProfileManager.cs
@@ -361,13 +361,9 @@ public static class ProfileManager
             IsPasswordValid = true
         };
 
-        List<GroupInfo> profiles;
-
-        if (Path.GetExtension(profileFileInfo.Path) == LegacyProfileFileExtension)
-            profiles = DeserializeFromXmlFile(profileFileInfo.Path);
-        else
-            profiles = DeserializeFromFile(profileFileInfo.Path);
-
+        List<GroupInfo> profiles = Path.GetExtension(profileFileInfo.Path) == LegacyProfileFileExtension
+            ? DeserializeFromXmlFile(profileFileInfo.Path)
+            : DeserializeFromFile(profileFileInfo.Path);
         // Save the encrypted file
         var decryptedBytes = SerializeToByteArray(profiles);
         var encryptedBytes = CryptoHelper.Encrypt(decryptedBytes,

--- a/Source/NETworkManager.Profiles/ProfileManager.cs
+++ b/Source/NETworkManager.Profiles/ProfileManager.cs
@@ -428,10 +428,9 @@ public static class ProfileManager
 
         List<GroupInfo> profiles;
 
-        if (IsXmlContent(decryptedBytes))
-            profiles = DeserializeFromXmlByteArray(decryptedBytes);
-        else
-            profiles = DeserializeFromByteArray(decryptedBytes);
+        profiles = IsXmlContent(decryptedBytes)
+            ? DeserializeFromXmlByteArray(decryptedBytes)
+            : DeserializeFromByteArray(decryptedBytes);
 
         // Save the encrypted file
         decryptedBytes = SerializeToByteArray(profiles);

--- a/Source/NETworkManager.Settings/SettingsManager.cs
+++ b/Source/NETworkManager.Settings/SettingsManager.cs
@@ -327,10 +327,10 @@ public static class SettingsManager
     /// <summary>
     /// Creates a backup of the specified settings file in the given backup folder with the provided backup file name.
     /// </summary>
-    /// <param name="settingsFilePath">The full path to the settings file to back up. Cannot be null or empty.</param>
+    /// <param name="filePath">The full path to the settings file to back up. Cannot be null or empty.</param>
     /// <param name="backupFolderPath">The directory path where the backup file will be stored. If the directory does not exist, it will be created.</param>
     /// <param name="backupFileName">The name to use for the backup file within the backup folder. Cannot be null or empty.</param>
-    private static void Backup(string settingsFilePath, string backupFolderPath, string backupFileName)
+    private static void Backup(string filePath, string backupFolderPath, string backupFileName)
     {
         // Create the backup directory if it does not exist
         Directory.CreateDirectory(backupFolderPath);
@@ -339,7 +339,7 @@ public static class SettingsManager
         var backupFilePath = Path.Combine(backupFolderPath, backupFileName);
 
         // Copy the current settings file to the backup location
-        File.Copy(settingsFilePath, backupFilePath, true);
+        File.Copy(filePath, backupFilePath, true);
 
         Log.Info($"Backup created: {backupFilePath}");
     }

--- a/Source/NETworkManager/MainWindow.xaml.cs
+++ b/Source/NETworkManager/MainWindow.xaml.cs
@@ -1472,7 +1472,7 @@ public sealed partial class MainWindow : INotifyPropertyChanged
     /// <param name="sender"></param>
     /// <param name="e"></param>
     private void ProfileManager_OnLoadedProfileFileChangedEvent(object sender, ProfileFileInfoArgs e)
-    {
+    {        
         _isProfileFileUpdating = e.ProfileFileUpdating;
 
         SelectedProfileFile = ProfileFiles.SourceCollection.Cast<ProfileFileInfo>()

--- a/Source/NETworkManager/MainWindow.xaml.cs
+++ b/Source/NETworkManager/MainWindow.xaml.cs
@@ -33,7 +33,6 @@ using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Markup;
 using System.Windows.Threading;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 using Application = System.Windows.Application;
 using ContextMenu = System.Windows.Controls.ContextMenu;
 using MouseEventArgs = System.Windows.Forms.MouseEventArgs;
@@ -1376,6 +1375,8 @@ public sealed partial class MainWindow : INotifyPropertyChanged
         _isProfileFilesLoading = false;
 
         ProfileManager.OnLoadedProfileFileChangedEvent += ProfileManager_OnLoadedProfileFileChangedEvent;
+        ProfileManager.OnProfileMigrationStarted += ProfileManager_OnProfileMigrationStarted;
+        ProfileManager.OnProfileMigrationCompleted += ProfileManager_OnProfileMigrationCompleted;
 
         SelectedProfileFile = ProfileFiles.SourceCollection.Cast<ProfileFileInfo>()
             .FirstOrDefault(x => x.Name == SettingsManager.Current.Profiles_LastSelected);
@@ -1472,13 +1473,23 @@ public sealed partial class MainWindow : INotifyPropertyChanged
     /// <param name="sender"></param>
     /// <param name="e"></param>
     private void ProfileManager_OnLoadedProfileFileChangedEvent(object sender, ProfileFileInfoArgs e)
-    {        
+    {
         _isProfileFileUpdating = e.ProfileFileUpdating;
 
         SelectedProfileFile = ProfileFiles.SourceCollection.Cast<ProfileFileInfo>()
             .FirstOrDefault(x => x.Equals(e.ProfileFileInfo));
 
         _isProfileFileUpdating = false;
+    }
+
+    private void ProfileManager_OnProfileMigrationCompleted(object sender, EventArgs e)
+    {
+        _isProfileFileUpdating = false;
+    }
+
+    private void ProfileManager_OnProfileMigrationStarted(object sender, EventArgs e)
+    {
+        _isProfileFileUpdating = true;
     }
 
     #endregion

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -29,6 +29,16 @@ Release date: **xx.xx.2025**
 
   :::
 
+- Profile and settings files have been migrated from `XML` to `JSON`. Existing files will be automatically converted to `JSON` on first load after the update. [#3282](https://github.com/BornToBeRoot/NETworkManager/pull/3282) [#3299](https://github.com/BornToBeRoot/NETworkManager/pull/3299)
+
+  :::info
+
+  Starting with this release, new profile and settings files are created in `JSON` format. Existing `XML` files will be converted automatically on first load after upgrading. Automatic support for the migration will be provided until at least `2027`; after that only `JSON` files will be supported and very old installations may require an interim update.
+
+  The migration process creates a backup of the original files in the `Backups` subfolder of the settings and profiles directories. You can restore the originals from that folder if needed, but it's recommended to make a separate backup of your profile and settings files before updating.
+  
+  :::
+
 ## What's new?
 
 - New language Ukrainian (`uk-UA`) has been added. Thanks to [@vadickkt](https://github.com/vadickkt) [#3240](https://github.com/BornToBeRoot/NETworkManager/pull/3240)
@@ -47,13 +57,14 @@ Release date: **xx.xx.2025**
 
 **Profiles**
 
+- Profile file format migrated from `XML` to `JSON`. The profile file will be automatically converted on first load after the update. [#3299](https://github.com/BornToBeRoot/NETworkManager/pull/3299)
 - Profile file creation flow improved — when adding a new profile you are now prompted to enable profile-file encryption to protect stored credentials and settings. [#3227](https://github.com/BornToBeRoot/NETworkManager/pull/3227)
 - Profile file dialog migrated to a child window to improve usability. [#3227](https://github.com/BornToBeRoot/NETworkManager/pull/3227)
 - Credential dialogs migrated to child windows to improve usability. [#3231](https://github.com/BornToBeRoot/NETworkManager/pull/3231)
 
 **Settings**
 
-- Settings format migrated from `XML` to `JSON`. The settings file will be automatically converted on first start after the update. [#3282](https://github.com/BornToBeRoot/NETworkManager/pull/3282)
+- Settings file format migrated from `XML` to `JSON`. The settings file will be automatically converted on first load after the update. [#3282](https://github.com/BornToBeRoot/NETworkManager/pull/3282)
 - Create a daily backup of the settings file before saving changes. Up to `10` backup files are kept in the `Backups` subfolder of the settings directory. [#3283](https://github.com/BornToBeRoot/NETworkManager/pull/3283)
 
 **Dashboard**


### PR DESCRIPTION
## Changes proposed in this pull request

- Migrate profile files from xml to json

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request introduces a major migration for profile storage in `ProfileManager.cs`, moving from XML-based profiles to a new JSON-based format. It adds support for detecting, migrating, and backing up legacy XML profiles, ensures consistent JSON serialization, and updates all relevant serialization logic. The changes also introduce events and logging to track the migration process, and provide backup mechanisms for legacy files.

**Profile format migration and serialization updates:**

* Changed the default profile file extension from `.xml` to `.json`, added a legacy XML extension for migration, and implemented consistent JSON serialization options using `System.Text.Json`.
* Updated all serialization and deserialization methods to use JSON by default, including writing and reading profiles, and provided methods to handle both JSON and legacy XML formats for backward compatibility. [[1]](diffhunk://#diff-2b98b117cc7c105936ddc0504f8717e094806db2f64f9bbf51987f0ff39a44c9L562-R742) [[2]](diffhunk://#diff-2b98b117cc7c105936ddc0504f8717e094806db2f64f9bbf51987f0ff39a44c9L580-R752) [[3]](diffhunk://#diff-2b98b117cc7c105936ddc0504f8717e094806db2f64f9bbf51987f0ff39a44c9L542-R730) [[4]](diffhunk://#diff-2b98b117cc7c105936ddc0504f8717e094806db2f64f9bbf51987f0ff39a44c9L291-R369)

**Legacy XML profile migration and backup:**

* Implemented detection and migration logic for legacy XML profile files (including encrypted files): on loading, the code now detects XML content, migrates it to JSON, creates backups, and removes the old files after migration. [[1]](diffhunk://#diff-2b98b117cc7c105936ddc0504f8717e094806db2f64f9bbf51987f0ff39a44c9R522-R526) [[2]](diffhunk://#diff-2b98b117cc7c105936ddc0504f8717e094806db2f64f9bbf51987f0ff39a44c9L444-R633) [[3]](diffhunk://#diff-2b98b117cc7c105936ddc0504f8717e094806db2f64f9bbf51987f0ff39a44c9L402-R490) [[4]](diffhunk://#diff-2b98b117cc7c105936ddc0504f8717e094806db2f64f9bbf51987f0ff39a44c9L351-R434)
* Added a backup folder and methods to store backups of legacy XML files before migration, and updated file discovery to include both JSON and legacy XML profiles. [[1]](diffhunk://#diff-2b98b117cc7c105936ddc0504f8717e094806db2f64f9bbf51987f0ff39a44c9R198-R206) [[2]](diffhunk://#diff-2b98b117cc7c105936ddc0504f8717e094806db2f64f9bbf51987f0ff39a44c9L171-R240)

**Migration process events and logging:**

* Added events (`OnProfileMigrationStarted`, `OnProfileMigrationCompleted`) and corresponding methods to signal the start and completion of profile migration, along with detailed logging throughout the migration process for better traceability. [[1]](diffhunk://#diff-2b98b117cc7c105936ddc0504f8717e094806db2f64f9bbf51987f0ff39a44c9R137-R166) [[2]](diffhunk://#diff-2b98b117cc7c105936ddc0504f8717e094806db2f64f9bbf51987f0ff39a44c9R522-R526) [[3]](diffhunk://#diff-2b98b117cc7c105936ddc0504f8717e094806db2f64f9bbf51987f0ff39a44c9L444-R633)

These changes ensure a smooth transition from XML to JSON profile storage, improve maintainability, and provide robust handling and auditing of the migration process.

</details>

## To-Do

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
