### PR TITLE
Feature: Redesign Status Window

### DIFF
--- a/Source/NETworkManager.Converters/TimeToStrokeDashOffsetConverter.cs
+++ b/Source/NETworkManager.Converters/TimeToStrokeDashOffsetConverter.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace NETworkManager.Converters;
+
+/// <summary>
+///     Converts <c>Time</c> (values[0]) and <c>TimeMax</c> (values[1]) into a <see cref="double" />
+///     stroke dash offset for a circular countdown ring. <c>ConverterParameter</c> must be the full
+///     circumference of the ring in <c>StrokeDashArray</c> units (circumference / StrokeThickness).
+/// </summary>
+public sealed class TimeToStrokeDashOffsetConverter : IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (parameter is not string circumferenceStr ||
+            !double.TryParse(circumferenceStr, NumberStyles.Float, CultureInfo.InvariantCulture,
+                out var circumference))
+            return 0.0;
+        
+        if (values.Length < 2 ||
+            values[0] is not double time ||
+            values[1] is not double timeMax ||
+            timeMax == 0 ||
+            time <= 0)
+            return circumference + 1.0;
+
+        var progress = (double)time / timeMax;
+
+        return (1.0 - progress) * circumference;
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
+++ b/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
@@ -6121,6 +6121,15 @@ namespace NETworkManager.Localization.Resources {
         }
         
         /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Network connection ähnelt.
+        /// </summary>
+        public static string NetworkConnection {
+            get {
+                return ResourceManager.GetString("NetworkConnection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die Network connections.... ähnelt.
         /// </summary>
         public static string NetworkConnectionsDots {
@@ -6180,6 +6189,15 @@ namespace NETworkManager.Localization.Resources {
         public static string Networks {
             get {
                 return ResourceManager.GetString("Networks", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Network Status ähnelt.
+        /// </summary>
+        public static string NetworkStatus {
+            get {
+                return ResourceManager.GetString("NetworkStatus", resourceCulture);
             }
         }
         

--- a/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
+++ b/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
@@ -10666,6 +10666,15 @@ namespace NETworkManager.Localization.Resources {
         }
         
         /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Reload ähnelt.
+        /// </summary>
+        public static string ToolTip_Reload {
+            get {
+                return ResourceManager.GetString("ToolTip_Reload", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die Report an issue or create a feature request. ähnelt.
         /// </summary>
         public static string ToolTip_ReportIssueOrCreateFeatureRequest {
@@ -10689,6 +10698,15 @@ namespace NETworkManager.Localization.Resources {
         public static string ToolTip_RunCommandWithHotKey {
             get {
                 return ResourceManager.GetString("ToolTip_RunCommandWithHotKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Show ähnelt.
+        /// </summary>
+        public static string ToolTip_Show {
+            get {
+                return ResourceManager.GetString("ToolTip_Show", resourceCulture);
             }
         }
         

--- a/Source/NETworkManager.Localization/Resources/Strings.resx
+++ b/Source/NETworkManager.Localization/Resources/Strings.resx
@@ -3998,4 +3998,10 @@ You can copy your profile files from “{0}” to “{1}” to migrate your exis
 
 You can copy your profile files from “{0}” to “{1}” to migrate your existing profiles, if necessary. The application must be closed for this to prevent the profiles from being overwritten.</value>
   </data>
+  <data name="NetworkConnection" xml:space="preserve">
+    <value>Network connection</value>
+  </data>
+  <data name="NetworkStatus" xml:space="preserve">
+    <value>Network Status</value>
+  </data>
 </root>

--- a/Source/NETworkManager.Localization/Resources/Strings.resx
+++ b/Source/NETworkManager.Localization/Resources/Strings.resx
@@ -4004,4 +4004,10 @@ You can copy your profile files from “{0}” to “{1}” to migrate your exis
   <data name="NetworkStatus" xml:space="preserve">
     <value>Network Status</value>
   </data>
+  <data name="ToolTip_Show" xml:space="preserve">
+    <value>Show</value>
+  </data>
+  <data name="ToolTip_Reload" xml:space="preserve">
+    <value>Reload</value>
+  </data>
 </root>

--- a/Source/NETworkManager/StatusWindow.xaml
+++ b/Source/NETworkManager/StatusWindow.xaml
@@ -8,49 +8,88 @@
                  xmlns:resources="clr-namespace:NETworkManager.Properties"
                  xmlns:networkManager="clr-namespace:NETworkManager"
                  xmlns:converters="clr-namespace:NETworkManager.Converters;assembly=NETworkManager.Converters"
+                 xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
                  mc:Ignorable="d" d:DataContext="{d:DesignInstance networkManager:StatusWindow}"
-                 Title="{x:Static resources:Resources.NETworkManager_ProjectName}"
+                 TitleAlignment="Left"
                  Style="{DynamicResource DefaultWindow}"
-                 Deactivated="MetroWindow_Deactivated"
-                 Height="280" Width="950"
+                 Deactivated="MetroWindow_Deactivated"                 
                  Topmost="True"
                  ShowInTaskbar="False"
+                 Width="950"
+                 Height="241"                 
                  ResizeMode="NoResize"
                  IsWindowDraggable="False"
                  ShowMinButton="False"
                  ShowMaxRestoreButton="False"
-                 ShowCloseButton="False"
-                 ShowTitleBar="False"
+                 ShowCloseButton="True"
+                 ShowTitleBar="True"
                  Closing="MetroWindow_Closing">
     <mah:MetroWindow.Resources>
         <converters:BooleanToVisibilityCollapsedConverter x:Key="BooleanToVisibilityCollapsedConverter" />
+        <converters:TimeToStrokeDashOffsetConverter x:Key="TimeToStrokeDashOffsetConverter" />
     </mah:MetroWindow.Resources>
-    <Grid Margin="10">
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*" />
-                <RowDefinition Height="10" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-            <ContentControl x:Name="ContentControlNetworkConnection" Grid.Row="0" />
-            <Grid Grid.Row="2">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="10" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-                <mah:MetroProgressBar Grid.Column="0" Minimum="0" Maximum="{Binding TimeMax}" Value="{Binding Time}"
-                                      Visibility="{Binding ShowTime, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
-                                      VerticalAlignment="Bottom" HorizontalAlignment="Left" Width="150" />
-                <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right">
-                    <Button Content="{x:Static localization:Strings.Reload}" Command="{Binding ReloadCommand}"
-                            Style="{StaticResource DefaultButton}" Margin="0,0,10,0" />
-                    <Button Content="{x:Static localization:Strings.Show}" Command="{Binding ShowMainWindowCommand}"
-                            Style="{StaticResource DefaultButton}" Margin="0,0,10,0" />
-                    <Button Content="{x:Static localization:Strings.Close}" Command="{Binding CloseCommand}"
-                            Style="{StaticResource DefaultButton}" />
-                </StackPanel>
+    <mah:MetroWindow.LeftWindowCommands>
+        <mah:WindowCommands ShowSeparators="False">
+            <!-- Countdown progress ring -->
+            <Grid Width="20" Height="20"
+                  Visibility="{Binding ShowTime, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
+                  VerticalAlignment="Center"
+                  Margin="10,0,0,0">
+                <!-- Track (background ring) -->
+                <Ellipse StrokeThickness="2.5"
+                         Stroke="{DynamicResource MahApps.Brushes.Accent}"
+                         Opacity="0.2" />
+                <!-- Foreground arc that shrinks as time counts down -->
+                <Ellipse StrokeThickness="2.5"
+                         Stroke="{DynamicResource MahApps.Brushes.Accent}"
+                         StrokeDashCap="Round"
+                         StrokeDashArray="22 100"
+                         RenderTransformOrigin="0.5,0.5">
+                    <Ellipse.RenderTransform>
+                        <RotateTransform Angle="-90" />
+                    </Ellipse.RenderTransform>
+                    <Ellipse.StrokeDashOffset>
+                        <MultiBinding Converter="{StaticResource TimeToStrokeDashOffsetConverter}"
+                                      ConverterParameter="22.0">
+                            <Binding Path="Time" />
+                            <Binding Path="TimeMax" />
+                        </MultiBinding>
+                    </Ellipse.StrokeDashOffset>
+                </Ellipse>
             </Grid>
-        </Grid>
-    </Grid>
+        </mah:WindowCommands>
+    </mah:MetroWindow.LeftWindowCommands>
+    <mah:MetroWindow.RightWindowCommands>
+        <mah:WindowCommands ShowSeparators="False">            
+            <Button Command="{Binding Path=ReloadCommand}"
+                    ToolTip="{x:Static Member=localization:Strings.ToolTip_RunCommandWithHotKey}"
+                    Cursor="Hand"
+                    Focusable="False"
+                    Margin="0,0,5,0">
+                <StackPanel Orientation="Horizontal">
+                    <Rectangle Width="16" Height="16"
+                               Fill="{Binding RelativeSource={RelativeSource AncestorType=Button}, Path=Foreground}">
+                        <Rectangle.OpacityMask>
+                            <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=Refresh}" />
+                        </Rectangle.OpacityMask>
+                    </Rectangle>
+                </StackPanel>
+            </Button>
+            <Button Command="{Binding Path=ShowMainWindowCommand}"                    
+                    ToolTip="{x:Static Member=localization:Strings.ToolTip_RunCommandWithHotKey}"
+                    Cursor="Hand"
+                    Focusable="False"
+                    Margin="0,0,5,0">
+                <StackPanel Orientation="Horizontal">
+                    <Rectangle Width="16" Height="16"
+                               Fill="{Binding RelativeSource={RelativeSource AncestorType=Button}, Path=Foreground}">
+                        <Rectangle.OpacityMask>
+                            <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=OpenInNew}" />
+                        </Rectangle.OpacityMask>
+                    </Rectangle>
+                </StackPanel>
+            </Button>            
+        </mah:WindowCommands>
+    </mah:MetroWindow.RightWindowCommands>
+    <ContentControl Margin="10,5,10,10" x:Name="ContentControlNetworkConnection" />
 </mah:MetroWindow>

--- a/Source/NETworkManager/StatusWindow.xaml
+++ b/Source/NETworkManager/StatusWindow.xaml
@@ -62,7 +62,7 @@
     <mah:MetroWindow.RightWindowCommands>
         <mah:WindowCommands ShowSeparators="False">            
             <Button Command="{Binding Path=ReloadCommand}"
-                    ToolTip="{x:Static Member=localization:Strings.ToolTip_RunCommandWithHotKey}"
+                    ToolTip="{x:Static Member=localization:Strings.ToolTip_Reload}"
                     Cursor="Hand"
                     Focusable="False"
                     Margin="0,0,5,0">
@@ -76,7 +76,7 @@
                 </StackPanel>
             </Button>
             <Button Command="{Binding Path=ShowMainWindowCommand}"                    
-                    ToolTip="{x:Static Member=localization:Strings.ToolTip_RunCommandWithHotKey}"
+                    ToolTip="{x:Static Member=localization:Strings.ToolTip_Show}"
                     Cursor="Hand"
                     Focusable="False"
                     Margin="0,0,5,0">

--- a/Source/NETworkManager/StatusWindow.xaml.cs
+++ b/Source/NETworkManager/StatusWindow.xaml.cs
@@ -168,8 +168,6 @@ public partial class StatusWindow : INotifyPropertyChanged
 
         // Focus the window
         Activate();
-
-        Debug.WriteLine(Height);
     }
 
     private void SetupCloseTimer()

--- a/Source/NETworkManager/StatusWindow.xaml.cs
+++ b/Source/NETworkManager/StatusWindow.xaml.cs
@@ -3,7 +3,9 @@ using NETworkManager.Utilities;
 using NETworkManager.Views;
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Threading;
@@ -19,9 +21,11 @@ public partial class StatusWindow : INotifyPropertyChanged
         InitializeComponent();
         DataContext = this;
 
+        Title = $"NETworkManager {AssemblyManager.Current.Version} - {Localization.Resources.Strings.NetworkStatus}";
+
         _mainWindow = mainWindow;
 
-        _dispatcherTimerClose.Interval = new TimeSpan(0, 0, 0, 0, 250);
+        _dispatcherTimerClose.Interval = TimeSpan.FromMilliseconds(16);
         _dispatcherTimerClose.Tick += DispatcherTimerTime_Tick;
 
         _networkConnectionView = new NetworkConnectionWidgetView();
@@ -43,8 +47,8 @@ public partial class StatusWindow : INotifyPropertyChanged
 
     #region Variables
 
-    // Set priority to make the ui smoother
-    private readonly DispatcherTimer _dispatcherTimerClose = new(DispatcherPriority.Normal);
+    private readonly DispatcherTimer _dispatcherTimerClose = new(DispatcherPriority.Render);
+    private readonly Stopwatch _stopwatch = new();
 
     private readonly MainWindow _mainWindow;
     private readonly NetworkConnectionWidgetView _networkConnectionView;
@@ -64,9 +68,9 @@ public partial class StatusWindow : INotifyPropertyChanged
         }
     }
 
-    private int _timeMax;
+    private double _timeMax;
 
-    public int TimeMax
+    public double TimeMax
     {
         get => _timeMax;
         private set
@@ -79,9 +83,9 @@ public partial class StatusWindow : INotifyPropertyChanged
         }
     }
 
-    private int _time;
+    private double _time;
 
-    public int Time
+    public double Time
     {
         get => _time;
         set
@@ -153,6 +157,8 @@ public partial class StatusWindow : INotifyPropertyChanged
         // Check the network connection
         Check();
 
+        enableCloseTimer = true;
+
         // Close the window after a certain time
         if (enableCloseTimer)
         {
@@ -162,13 +168,16 @@ public partial class StatusWindow : INotifyPropertyChanged
 
         // Focus the window
         Activate();
+
+        Debug.WriteLine(Height);
     }
 
     private void SetupCloseTimer()
     {
-        Time = SettingsManager.Current.Status_WindowCloseTime * 4;
-        TimeMax = Time;
+        TimeMax = SettingsManager.Current.Status_WindowCloseTime;
+        Time = TimeMax;
 
+        _stopwatch.Restart();
         ShowTime = true;
         _dispatcherTimerClose.Start();
     }
@@ -189,14 +198,18 @@ public partial class StatusWindow : INotifyPropertyChanged
         Hide();
     }
 
-    private void DispatcherTimerTime_Tick(object sender, EventArgs e)
+    private async void DispatcherTimerTime_Tick(object sender, EventArgs e)
     {
-        Time--;
+        Time = Math.Max(0.0, TimeMax - _stopwatch.Elapsed.TotalSeconds);
 
         if (Time > 0)
             return;
 
         _dispatcherTimerClose.Stop();
+        _stopwatch.Stop();
+
+        await Task.Delay(250);
+
         ShowTime = false;
 
         Hide();

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -29,6 +29,8 @@ Release date: **xx.xx.2025**
 
 ## Improvements
 
+- Redesign Status Window to make it more compact [#3359](https://github.com/BornToBeRoot/NETworkManager/pull/3359)
+
 ## Bug Fixes
 
 **PowerShell**


### PR DESCRIPTION
## Changes proposed in this pull request

- Re-design status window

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request introduces enhancements to the status window countdown functionality and improves localization support. The most significant changes include implementing a smooth, visually appealing countdown ring using a new converter, updating timer logic for accuracy and smoother UI, and adding new localized strings for better user experience.

Countdown ring and timer improvements:
* Added `TimeToStrokeDashOffsetConverter` to calculate the stroke dash offset for a circular countdown ring, enabling a smooth visual countdown in the status window (`TimeToStrokeDashOffsetConverter.cs`).
* Refactored timer logic in `StatusWindow.xaml.cs` to use `double` for `Time` and `TimeMax`, a `Stopwatch` for precise timing, and updated the dispatcher timer to `DispatcherPriority.Render` for smoother UI. The countdown is now based on elapsed time rather than decrementing an integer. [[1]](diffhunk://#diff-46037487ae3be020a6d241311a3890f70c39467522b5808275959d5069752c22L46-R51) [[2]](diffhunk://#diff-46037487ae3be020a6d241311a3890f70c39467522b5808275959d5069752c22L67-R73) [[3]](diffhunk://#diff-46037487ae3be020a6d241311a3890f70c39467522b5808275959d5069752c22L82-R88) [[4]](diffhunk://#diff-46037487ae3be020a6d241311a3890f70c39467522b5808275959d5069752c22R171-R180) [[5]](diffhunk://#diff-46037487ae3be020a6d241311a3890f70c39467522b5808275959d5069752c22L192-R212)
* Updated the XAML for `StatusWindow.xaml` to display a circular countdown ring using the new converter, reorganized window command buttons with icon pack visuals, and restored the title bar and close button for improved usability.

Localization enhancements:
* Added new string resources `NetworkConnection` and `NetworkStatus` to `Strings.resx` and exposed them in `Strings.Designer.cs` for use in UI elements and window titles. [[1]](diffhunk://#diff-aa5828c7aa59a68d20ce70a1088e4bd1038a53bac7f9eac6398a7b6e466f9df8R4001-R4006) [[2]](diffhunk://#diff-fd26c2c2130e727ae40f1060c182242ce89c894d95f0168fa6443e230da8e4e0R6123-R6131) [[3]](diffhunk://#diff-fd26c2c2130e727ae40f1060c182242ce89c894d95f0168fa6443e230da8e4e0R6195-R6203)
* Updated the window title in `StatusWindow.xaml.cs` to include the localized `NetworkStatus` string and application version.

These changes collectively improve the user interface responsiveness, provide a more intuitive countdown visualization, and enhance localization support.

</details>

## To-Do

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
