### PR TITLE
Fix: App crash when double click on port profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,3 +257,4 @@ Build/
 .vscode/
 *.exe
 *.dll
+ToDo.md

--- a/Source/NETworkManager/Views/PortProfilesChildWindow.xaml.cs
+++ b/Source/NETworkManager/Views/PortProfilesChildWindow.xaml.cs
@@ -35,7 +35,7 @@ public partial class PortProfilesChildWindow
 
     private void DataGridRow_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
     {
-        var x = (SNMPOIDProfilesViewModel)DataContext;
+        var x = (PortProfilesViewModel)DataContext;
 
         if (x.OKCommand.CanExecute(null))
             x.OKCommand.Execute(null);

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -1,7 +1,15 @@
 ---
 sidebar_position: 0
 description: "Changelog for the next NETworkManager release — upcoming features, improvements, and bug fixes."
-keywords: [NETworkManager, changelog, release notes, next release, upcoming features, bug fixes]
+keywords:
+  [
+    NETworkManager,
+    changelog,
+    release notes,
+    next release,
+    upcoming features,
+    bug fixes,
+  ]
 ---
 
 # Next Release
@@ -31,9 +39,13 @@ Release date: **xx.xx.2025**
 
 ## Improvements
 
-- Redesign Status Window to make it more compact [#3359](https://github.com/BornToBeRoot/NETworkManager/pull/3359)
+- Redesign Status Window to make it more compact. [#3359](https://github.com/BornToBeRoot/NETworkManager/pull/3359)
 
 ## Bug Fixes
+
+**Port Scanner**
+
+- Fixed an app crash when double-clicking a port profile. [#3382](https://github.com/BornToBeRoot/NETworkManager/pull/3382)
 
 **PowerShell**
 


### PR DESCRIPTION
## Changes proposed in this pull request

-  App crash when double click on port profile

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes
