### PR TITLE
Feature: Refresh button

### DIFF
--- a/Source/NETworkManager/StatusWindow.xaml
+++ b/Source/NETworkManager/StatusWindow.xaml
@@ -60,21 +60,7 @@
         </mah:WindowCommands>
     </mah:MetroWindow.LeftWindowCommands>
     <mah:MetroWindow.RightWindowCommands>
-        <mah:WindowCommands ShowSeparators="False">            
-            <Button Command="{Binding Path=ReloadCommand}"
-                    ToolTip="{x:Static Member=localization:Strings.Reload}"
-                    Cursor="Hand"
-                    Focusable="False"
-                    Margin="0,0,5,0">
-                <StackPanel Orientation="Horizontal">
-                    <Rectangle Width="16" Height="16"
-                               Fill="{Binding RelativeSource={RelativeSource AncestorType=Button}, Path=Foreground}">
-                        <Rectangle.OpacityMask>
-                            <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=Refresh}" />
-                        </Rectangle.OpacityMask>
-                    </Rectangle>
-                </StackPanel>
-            </Button>
+        <mah:WindowCommands ShowSeparators="False">
             <Button Command="{Binding Path=ShowMainWindowCommand}"                    
                     ToolTip="{x:Static Member=localization:Strings.Show}"
                     Cursor="Hand"

--- a/Source/NETworkManager/StatusWindow.xaml.cs
+++ b/Source/NETworkManager/StatusWindow.xaml.cs
@@ -96,13 +96,6 @@ public partial class StatusWindow : INotifyPropertyChanged
 
     #region ICommands & Actions
 
-    public ICommand ReloadCommand => new RelayCommand(_ => ReloadAction());
-
-    private void ReloadAction()
-    {
-        Check();
-    }
-
     public ICommand ShowMainWindowCommand => new RelayCommand(_ => ShowMainWindowAction());
 
     private void ShowMainWindowAction()

--- a/Source/NETworkManager/ViewModels/IPApiDNSResolverWidgetViewModel.cs
+++ b/Source/NETworkManager/ViewModels/IPApiDNSResolverWidgetViewModel.cs
@@ -70,17 +70,9 @@ public class IPApiDNSResolverWidgetViewModel : ViewModelBase
     #region ICommands & Actions
 
     /// <summary>
-    /// Gets the command to check via hotkey.
+    /// Gets the command to check the DNS resolver.
     /// </summary>
-    public ICommand CheckViaHotkeyCommand => new RelayCommand(_ => CheckViaHotkeyAction());
-
-    /// <summary>
-    /// Action to check via hotkey.
-    /// </summary>
-    private void CheckViaHotkeyAction()
-    {
-        Check();
-    }
+    public ICommand CheckCommand => new RelayCommand(_ => Check(), _ => !IsRunning);
 
     #endregion
 
@@ -101,10 +93,6 @@ public class IPApiDNSResolverWidgetViewModel : ViewModelBase
     {
         // Check is disabled via settings
         if (!SettingsManager.Current.Dashboard_CheckIPApiDNSResolver)
-            return;
-
-        // Don't check multiple times if already running
-        if (IsRunning)
             return;
 
         IsRunning = true;

--- a/Source/NETworkManager/ViewModels/IPApiDNSResolverWidgetViewModel.cs
+++ b/Source/NETworkManager/ViewModels/IPApiDNSResolverWidgetViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using NETworkManager.Models.IPApi;
 using NETworkManager.Settings;
@@ -55,6 +55,7 @@ public class IPApiDNSResolverWidgetViewModel : ViewModelBase
     public IPApiDNSResolverWidgetViewModel()
     {
         LoadSettings();
+        Check();
     }
 
     /// <summary>
@@ -81,7 +82,7 @@ public class IPApiDNSResolverWidgetViewModel : ViewModelBase
     /// <summary>
     /// Checks the DNS resolver.
     /// </summary>
-    public void Check()
+    private void Check()
     {
         _ = CheckAsync();
     }
@@ -98,7 +99,7 @@ public class IPApiDNSResolverWidgetViewModel : ViewModelBase
         IsRunning = true;
         Result = null;
 
-        // Make the user happy, let him see a reload animation (and he cannot spam the reload command)        
+        // Make the user happy, let him see a reload animation (and he cannot spam the reload command)
         await Task.Delay(GlobalStaticConfiguration.ApplicationUIRefreshInterval);
 
         Result = await DNSResolverService.GetInstance().GetDNSResolverAsync();

--- a/Source/NETworkManager/ViewModels/IPApiIPGeolocationWidgetViewModel.cs
+++ b/Source/NETworkManager/ViewModels/IPApiIPGeolocationWidgetViewModel.cs
@@ -72,17 +72,9 @@ public class IPApiIPGeolocationWidgetViewModel : ViewModelBase
     #region ICommands & Actions
 
     /// <summary>
-    /// Gets the command to check via hotkey.
+    /// Gets the command to check the IP geolocation.
     /// </summary>
-    public ICommand CheckViaHotkeyCommand => new RelayCommand(_ => CheckViaHotkeyAction());
-
-    /// <summary>
-    /// Action to check via hotkey.
-    /// </summary>
-    private void CheckViaHotkeyAction()
-    {
-        Check();
-    }
+    public ICommand CheckCommand => new RelayCommand(_ => Check(), _ => !IsRunning);
 
     #endregion
 
@@ -103,10 +95,6 @@ public class IPApiIPGeolocationWidgetViewModel : ViewModelBase
     {
         // Check is disabled via settings
         if (!SettingsManager.Current.Dashboard_CheckIPApiIPGeolocation)
-            return;
-
-        // Don't check multiple times if already running
-        if (IsRunning)
             return;
 
         IsRunning = true;

--- a/Source/NETworkManager/ViewModels/IPApiIPGeolocationWidgetViewModel.cs
+++ b/Source/NETworkManager/ViewModels/IPApiIPGeolocationWidgetViewModel.cs
@@ -58,6 +58,7 @@ public class IPApiIPGeolocationWidgetViewModel : ViewModelBase
     public IPApiIPGeolocationWidgetViewModel()
     {
         LoadSettings();
+        Check();
     }
 
     /// <summary>
@@ -83,7 +84,7 @@ public class IPApiIPGeolocationWidgetViewModel : ViewModelBase
     /// <summary>
     /// Checks the IP geolocation.
     /// </summary>
-    public void Check()
+    private void Check()
     {
         _ = CheckAsync();
     }

--- a/Source/NETworkManager/ViewModels/NetworkConnectionWidgetViewModel.cs
+++ b/Source/NETworkManager/ViewModels/NetworkConnectionWidgetViewModel.cs
@@ -476,6 +476,22 @@ public class NetworkConnectionWidgetViewModel : ViewModelBase
     /// </summary>
     public bool CheckPublicIPAddressEnabled => SettingsManager.Current.Dashboard_CheckPublicIPAddress;
 
+    /// <summary>
+    /// Gets or sets a value indicating whether a check is currently running.
+    /// </summary>
+    public bool IsChecking
+    {
+        get;
+        private set
+        {
+            if (value == field)
+                return;
+
+            field = value;
+            OnPropertyChanged();
+        }
+    }
+
     #endregion
 
     #region Constructor, load settings
@@ -500,17 +516,9 @@ public class NetworkConnectionWidgetViewModel : ViewModelBase
     #region ICommands & Actions
 
     /// <summary>
-    /// Gets the command to check connections via hotkey.
+    /// Gets the command to check connections.
     /// </summary>
-    public ICommand CheckViaHotkeyCommand => new RelayCommand(_ => CheckViaHotkeyAction());
-
-    /// <summary>
-    /// Executes the check via hotkey action.
-    /// </summary>
-    private void CheckViaHotkeyAction()
-    {
-        Check();
-    }
+    public ICommand CheckCommand => new RelayCommand(_ => Check());
 
     #endregion
 
@@ -564,6 +572,8 @@ public class NetworkConnectionWidgetViewModel : ViewModelBase
         _cancellationTokenSource = new CancellationTokenSource();
         var wasCanceled = false;
 
+        IsChecking = true;
+
         try
         {
             _checkTask = RunTask(_cancellationTokenSource.Token);
@@ -576,6 +586,8 @@ public class NetworkConnectionWidgetViewModel : ViewModelBase
         }
         finally
         {
+            IsChecking = false;
+
             if (!wasCanceled)
                 Log.Info("Network connection check completed.");
         }

--- a/Source/NETworkManager/ViewModels/NetworkConnectionWidgetViewModel.cs
+++ b/Source/NETworkManager/ViewModels/NetworkConnectionWidgetViewModel.cs
@@ -502,6 +502,7 @@ public class NetworkConnectionWidgetViewModel : ViewModelBase
     public NetworkConnectionWidgetViewModel()
     {
         LoadSettings();
+        Check();
     }
 
     /// <summary>
@@ -587,6 +588,7 @@ public class NetworkConnectionWidgetViewModel : ViewModelBase
         finally
         {
             IsChecking = false;
+            _cancellationTokenSource.Dispose();
 
             if (!wasCanceled)
                 Log.Info("Network connection check completed.");

--- a/Source/NETworkManager/Views/ConnectionsView.xaml
+++ b/Source/NETworkManager/Views/ConnectionsView.xaml
@@ -67,6 +67,7 @@
                         </ComboBox>
                         <Button Command="{Binding Path=RefreshCommand}"
                                 Style="{StaticResource CleanButton}"
+                                ToolTip="{x:Static localization:Strings.Refresh}"
                                 Margin="0,0,10,0">
                             <Rectangle Width="16" Height="16"
                                        wpfHelpers:ReloadAnimationHelper.IsReloading="{Binding IsRefreshing}">

--- a/Source/NETworkManager/Views/DashboardView.xaml.cs
+++ b/Source/NETworkManager/Views/DashboardView.xaml.cs
@@ -24,29 +24,21 @@ public partial class DashboardView
         ContentControlSpeedTest.Content = _speedTestWidgetView;
 
         // Check all widgets
-        Check();
+        _networkConnectionWidgetView.Check();
+        _ipApiIPGeolocationWidgetView.Check();
+        _ipApiDNSResolverWidgetView.Check();
     }
 
     public void OnViewVisible()
     {
         _viewModel.OnViewVisible();
 
-        // Check all widgets
-        Check();
+        // Check network connection
+        _networkConnectionWidgetView.Check();
     }
 
     public void OnViewHide()
     {
         _viewModel.OnViewHide();
-    }
-
-    /// <summary>
-    /// Check all widgets
-    /// </summary>
-    private void Check()
-    {
-        _networkConnectionWidgetView.Check();
-        _ipApiIPGeolocationWidgetView.Check();
-        _ipApiDNSResolverWidgetView.Check();
     }
 }

--- a/Source/NETworkManager/Views/DashboardView.xaml.cs
+++ b/Source/NETworkManager/Views/DashboardView.xaml.cs
@@ -22,11 +22,6 @@ public partial class DashboardView
         ContentControlIPApiIPGeolocation.Content = _ipApiIPGeolocationWidgetView;
         ContentControlIPApiDNSResolver.Content = _ipApiDNSResolverWidgetView;
         ContentControlSpeedTest.Content = _speedTestWidgetView;
-
-        // Check all widgets
-        _networkConnectionWidgetView.Check();
-        _ipApiIPGeolocationWidgetView.Check();
-        _ipApiDNSResolverWidgetView.Check();
     }
 
     public void OnViewVisible()

--- a/Source/NETworkManager/Views/FirewallView.xaml
+++ b/Source/NETworkManager/Views/FirewallView.xaml
@@ -57,6 +57,7 @@
                                     HorizontalAlignment="Right">
                             <Button Command="{Binding Path=RefreshCommand}"
                                     Style="{StaticResource CleanButton}"
+                                    ToolTip="{x:Static localization:Strings.Refresh}"
                                     Margin="0,0,10,0">
                                 <Rectangle Width="16" Height="16"
                                            wpfHelpers:ReloadAnimationHelper.IsReloading="{Binding IsRefreshing}">

--- a/Source/NETworkManager/Views/HostsFileEditorView.xaml
+++ b/Source/NETworkManager/Views/HostsFileEditorView.xaml
@@ -51,6 +51,7 @@
                                 HorizontalAlignment="Right">
                         <Button Command="{Binding Path=RefreshCommand}"
                                 Style="{StaticResource CleanButton}"
+                                ToolTip="{x:Static localization:Strings.Refresh}"
                                 Margin="0,0,10,0">
                             <Rectangle Width="16" Height="16"
                                        wpfHelpers:ReloadAnimationHelper.IsReloading="{Binding IsRefreshing}">

--- a/Source/NETworkManager/Views/IPApiDNSResolverWidgetView.xaml
+++ b/Source/NETworkManager/Views/IPApiDNSResolverWidgetView.xaml
@@ -10,10 +10,11 @@
              xmlns:settings="clr-namespace:NETworkManager.Settings;assembly=NETworkManager.Settings"
              xmlns:viewModels="clr-namespace:NETworkManager.ViewModels"
              xmlns:system="clr-namespace:System;assembly=mscorlib"
+             xmlns:wpfHelpers="clr-namespace:NETworkManager.Utilities.WPF;assembly=NETworkManager.Utilities.WPF"
              mc:Ignorable="d" MinHeight="200"
              d:DataContext="{d:DesignInstance viewModels:IPApiDNSResolverWidgetViewModel}">
     <UserControl.InputBindings>
-        <KeyBinding Key="F5" Command="{Binding CheckViaHotkeyCommand}" />
+        <KeyBinding Key="F5" Command="{Binding CheckCommand}" />
     </UserControl.InputBindings>
     <UserControl.Resources>
         <converters:BooleanReverseToVisibilityCollapsedConverter x:Key="BooleanReverseToVisibilityCollapsedConverter" />
@@ -37,15 +38,42 @@
                     <RowDefinition Height="Auto" />                    
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
-                <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Left" Margin="10">
-                    <Rectangle Width="32" Height="32" Fill="{DynamicResource MahApps.Brushes.Gray3}">
-                        <Rectangle.OpacityMask>
-                            <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=SearchWeb}" />
-                        </Rectangle.OpacityMask>
-                    </Rectangle>
-                    <TextBlock Text="{x:Static localization:Strings.DNSResolver}"
-                               Style="{StaticResource MessageTextBlock}" Margin="10,0,0,0" />
-                </StackPanel>
+                <Grid Grid.Row="0" Margin="10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                        <Rectangle Width="32" Height="32" Fill="{DynamicResource MahApps.Brushes.Gray3}">
+                            <Rectangle.OpacityMask>
+                                <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=SearchWeb}" />
+                            </Rectangle.OpacityMask>
+                        </Rectangle>
+                        <TextBlock Text="{x:Static localization:Strings.DNSResolver}"
+                                   Style="{StaticResource MessageTextBlock}" Margin="10,0,0,0" />
+                    </StackPanel>
+                    <Button Grid.Column="2" Command="{Binding CheckCommand}"
+                            Style="{StaticResource CleanButton}"
+                            VerticalAlignment="Center">
+                        <Rectangle Width="20" Height="20"
+                                   wpfHelpers:ReloadAnimationHelper.IsReloading="{Binding IsRunning}">
+                            <Rectangle.OpacityMask>
+                                <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=Refresh}" />
+                            </Rectangle.OpacityMask>
+                            <Rectangle.Style>
+                                <Style TargetType="{x:Type Rectangle}">
+                                    <Setter Property="Fill" Value="{DynamicResource MahApps.Brushes.Gray3}" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Button}}, Path=IsMouseOver}" Value="True">
+                                            <Setter Property="Fill" Value="{DynamicResource MahApps.Brushes.Gray5}" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Rectangle.Style>
+                        </Rectangle>
+                    </Button>
+                </Grid>
                 <Grid Grid.Column="0" Grid.Row="2" Margin="10"
                       Visibility="{Binding Source={x:Static Member=settings:SettingsManager.Current}, Path=Dashboard_CheckIPApiDNSResolver, Converter={StaticResource ResourceKey=BooleanToVisibilityCollapsedConverter}}">
                     <!-- Result-->

--- a/Source/NETworkManager/Views/IPApiDNSResolverWidgetView.xaml
+++ b/Source/NETworkManager/Views/IPApiDNSResolverWidgetView.xaml
@@ -55,6 +55,7 @@
                     </StackPanel>
                     <Button Grid.Column="2" Command="{Binding CheckCommand}"
                             Style="{StaticResource CleanButton}"
+                            ToolTip="{x:Static localization:Strings.Refresh}"
                             VerticalAlignment="Center">
                         <Rectangle Width="20" Height="20"
                                    wpfHelpers:ReloadAnimationHelper.IsReloading="{Binding IsRunning}">

--- a/Source/NETworkManager/Views/IPApiDNSResolverWidgetView.xaml.cs
+++ b/Source/NETworkManager/Views/IPApiDNSResolverWidgetView.xaml.cs
@@ -1,3 +1,4 @@
+
 ﻿using NETworkManager.ViewModels;
 
 namespace NETworkManager.Views;
@@ -12,8 +13,4 @@ public partial class IPApiDNSResolverWidgetView
         DataContext = _viewModel;
     }
 
-    public void Check()
-    {
-        _viewModel.Check();
-    }
 }

--- a/Source/NETworkManager/Views/IPApiIPGeolocationWidgetView.xaml
+++ b/Source/NETworkManager/Views/IPApiIPGeolocationWidgetView.xaml
@@ -10,10 +10,11 @@
              xmlns:viewModels="clr-namespace:NETworkManager.ViewModels"
              xmlns:settings="clr-namespace:NETworkManager.Settings;assembly=NETworkManager.Settings"
              xmlns:system="clr-namespace:System;assembly=mscorlib"
+             xmlns:wpfHelpers="clr-namespace:NETworkManager.Utilities.WPF;assembly=NETworkManager.Utilities.WPF"
              mc:Ignorable="d" MinHeight="200"
              d:DataContext="{d:DesignInstance viewModels:IPApiIPGeolocationWidgetViewModel}">
     <UserControl.InputBindings>
-        <KeyBinding Key="F5" Command="{Binding CheckViaHotkeyCommand}" />
+        <KeyBinding Key="F5" Command="{Binding CheckCommand}" />
     </UserControl.InputBindings>
     <UserControl.Resources>
         <converters:BooleanReverseToVisibilityCollapsedConverter x:Key="BooleanReverseToVisibilityCollapsedConverter" />
@@ -40,15 +41,42 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
-                <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Left" Margin="10">
-                    <Rectangle Width="32" Height="32" Fill="{DynamicResource MahApps.Brushes.Gray3}">
-                        <Rectangle.OpacityMask>
-                            <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=MapMarkerOutline}" />
-                        </Rectangle.OpacityMask>
-                    </Rectangle>
-                    <TextBlock Text="{x:Static localization:Strings.IPGeolocation}"
-                               Style="{StaticResource MessageTextBlock}" Margin="10,0,0,0" />
-                </StackPanel>
+                <Grid Grid.Row="0" Margin="10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                        <Rectangle Width="32" Height="32" Fill="{DynamicResource MahApps.Brushes.Gray3}">
+                            <Rectangle.OpacityMask>
+                                <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=MapMarkerOutline}" />
+                            </Rectangle.OpacityMask>
+                        </Rectangle>
+                        <TextBlock Text="{x:Static localization:Strings.IPGeolocation}"
+                                   Style="{StaticResource MessageTextBlock}" Margin="10,0,0,0" />
+                    </StackPanel>
+                    <Button Grid.Column="2" Command="{Binding CheckCommand}"
+                            Style="{StaticResource CleanButton}"
+                            VerticalAlignment="Center">
+                        <Rectangle Width="20" Height="20"
+                                   wpfHelpers:ReloadAnimationHelper.IsReloading="{Binding IsRunning}">
+                            <Rectangle.OpacityMask>
+                                <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=Refresh}" />
+                            </Rectangle.OpacityMask>
+                            <Rectangle.Style>
+                                <Style TargetType="{x:Type Rectangle}">
+                                    <Setter Property="Fill" Value="{DynamicResource MahApps.Brushes.Gray3}" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Button}}, Path=IsMouseOver}" Value="True">
+                                            <Setter Property="Fill" Value="{DynamicResource MahApps.Brushes.Gray5}" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Rectangle.Style>
+                        </Rectangle>
+                    </Button>
+                </Grid>
                 <Grid Grid.Column="0" Grid.Row="2" Margin="10"
                       Visibility="{Binding Source={x:Static Member=settings:SettingsManager.Current}, Path=Dashboard_CheckIPApiIPGeolocation, Converter={StaticResource ResourceKey=BooleanToVisibilityCollapsedConverter}}">
                     <!-- Result -->

--- a/Source/NETworkManager/Views/IPApiIPGeolocationWidgetView.xaml
+++ b/Source/NETworkManager/Views/IPApiIPGeolocationWidgetView.xaml
@@ -58,6 +58,7 @@
                     </StackPanel>
                     <Button Grid.Column="2" Command="{Binding CheckCommand}"
                             Style="{StaticResource CleanButton}"
+                            ToolTip="{x:Static localization:Strings.Refresh}"
                             VerticalAlignment="Center">
                         <Rectangle Width="20" Height="20"
                                    wpfHelpers:ReloadAnimationHelper.IsReloading="{Binding IsRunning}">

--- a/Source/NETworkManager/Views/IPApiIPGeolocationWidgetView.xaml.cs
+++ b/Source/NETworkManager/Views/IPApiIPGeolocationWidgetView.xaml.cs
@@ -12,8 +12,4 @@ public partial class IPApiIPGeolocationWidgetView
         DataContext = _viewModel;
     }
 
-    public void Check()
-    {
-        _viewModel.Check();
-    }
 }

--- a/Source/NETworkManager/Views/ListenersView.xaml
+++ b/Source/NETworkManager/Views/ListenersView.xaml
@@ -66,6 +66,7 @@
                         </ComboBox>
                         <Button Command="{Binding Path=RefreshCommand}"
                                 Style="{StaticResource CleanButton}"
+                                ToolTip="{x:Static localization:Strings.Refresh}"
                                 Margin="0,0,10,0">
                             <Rectangle Width="16" Height="16"
                                        wpfHelpers:ReloadAnimationHelper.IsReloading="{Binding IsRefreshing}">

--- a/Source/NETworkManager/Views/NeighborTableView.xaml
+++ b/Source/NETworkManager/Views/NeighborTableView.xaml
@@ -76,6 +76,7 @@
                         </ComboBox>
                         <Button Command="{Binding Path=RefreshCommand}"
                                 Style="{StaticResource CleanButton}"
+                                ToolTip="{x:Static localization:Strings.Refresh}"
                                 Margin="0,0,10,0">
                             <Rectangle Width="16" Height="16"
                                        wpfHelpers:ReloadAnimationHelper.IsReloading="{Binding IsRefreshing}">

--- a/Source/NETworkManager/Views/NetworkConnectionWidgetView.xaml
+++ b/Source/NETworkManager/Views/NetworkConnectionWidgetView.xaml
@@ -8,10 +8,11 @@
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:viewModels="clr-namespace:NETworkManager.ViewModels"
+             xmlns:wpfHelpers="clr-namespace:NETworkManager.Utilities.WPF;assembly=NETworkManager.Utilities.WPF"
              mc:Ignorable="d"
              d:DataContext="{d:DesignInstance viewModels:NetworkConnectionWidgetViewModel}">
     <UserControl.InputBindings>
-        <KeyBinding Key="F5" Command="{Binding CheckViaHotkeyCommand}" />
+        <KeyBinding Key="F5" Command="{Binding CheckCommand}" />
     </UserControl.InputBindings>
     <UserControl.Resources>
         <converters:BooleanReverseToVisibilityCollapsedConverter x:Key="BooleanReverseToVisibilityCollapsedConverter" />
@@ -20,8 +21,8 @@
     </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="1*" />            
-            <ColumnDefinition Width="1*" />            
+            <ColumnDefinition Width="1*" />
+            <ColumnDefinition Width="1*" />
             <ColumnDefinition Width="1*" />
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
@@ -167,15 +168,42 @@
                         <RowDefinition Height="Auto" />                        
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
-                    <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Left" Margin="10">
-                        <Rectangle Width="32" Height="32" Fill="{DynamicResource MahApps.Brushes.Gray3}">
-                            <Rectangle.OpacityMask>
-                                <VisualBrush Stretch="Uniform" Visual="{iconPacks:Modern Kind=Globe}" />
-                            </Rectangle.OpacityMask>
-                        </Rectangle>
-                        <TextBlock Text="{x:Static localization:Strings.Internet}"
-                                   Style="{StaticResource MessageTextBlock}" Margin="10,0,0,0" />
-                    </StackPanel>
+                    <Grid Grid.Row="0" Margin="10">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                            <Rectangle Width="32" Height="32" Fill="{DynamicResource MahApps.Brushes.Gray3}">
+                                <Rectangle.OpacityMask>
+                                    <VisualBrush Stretch="Uniform" Visual="{iconPacks:Modern Kind=Globe}" />
+                                </Rectangle.OpacityMask>
+                            </Rectangle>
+                            <TextBlock Text="{x:Static localization:Strings.Internet}"
+                                       Style="{StaticResource MessageTextBlock}" Margin="10,0,0,0" />
+                        </StackPanel>
+                        <Button Grid.Column="2" Command="{Binding CheckCommand}"
+                                Style="{StaticResource CleanButton}"
+                                VerticalAlignment="Center">
+                            <Rectangle Width="20" Height="20"
+                                       wpfHelpers:ReloadAnimationHelper.IsReloading="{Binding IsChecking}">
+                                <Rectangle.OpacityMask>
+                                    <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=Refresh}" />
+                                </Rectangle.OpacityMask>
+                                <Rectangle.Style>
+                                    <Style TargetType="{x:Type Rectangle}">
+                                        <Setter Property="Fill" Value="{DynamicResource MahApps.Brushes.Gray3}" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Button}}, Path=IsMouseOver}" Value="True">
+                                                <Setter Property="Fill" Value="{DynamicResource MahApps.Brushes.Gray5}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Rectangle.Style>
+                            </Rectangle>
+                        </Button>
+                    </Grid>
                     <Grid Grid.Row="1" HorizontalAlignment="Left" Margin="10"
                           Visibility="{Binding CheckPublicIPAddressEnabled, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                         <Grid.ColumnDefinitions>

--- a/Source/NETworkManager/Views/NetworkConnectionWidgetView.xaml
+++ b/Source/NETworkManager/Views/NetworkConnectionWidgetView.xaml
@@ -185,6 +185,7 @@
                         </StackPanel>
                         <Button Grid.Column="2" Command="{Binding CheckCommand}"
                                 Style="{StaticResource CleanButton}"
+                                ToolTip="{x:Static localization:Strings.Refresh}"
                                 VerticalAlignment="Center">
                             <Rectangle Width="20" Height="20"
                                        wpfHelpers:ReloadAnimationHelper.IsReloading="{Binding IsChecking}">

--- a/Source/NETworkManager/Views/NetworkInterfaceView.xaml
+++ b/Source/NETworkManager/Views/NetworkInterfaceView.xaml
@@ -161,6 +161,7 @@
                                         Height="{Binding ElementName=ComboBoxNetworkInterfaceProfiles, Path=ActualHeight}"
                                         Command="{Binding ReloadNetworkInterfacesCommand}"
                                         Style="{StaticResource CleanButton}"
+                                        ToolTip="{x:Static localization:Strings.Refresh}"
                                         IsEnabled="{Binding IsNetworkInterfaceLoading, Converter={StaticResource BooleanReverseConverter}}"
                                         Margin="10,0,0,0">
                                     <Rectangle Width="24" Height="24"
@@ -803,6 +804,7 @@
                                         Height="{Binding ElementName=ComboBoxNetworkInterfaceProfiles, Path=ActualHeight}"
                                         Command="{Binding ReloadNetworkInterfacesCommand}"
                                         Style="{StaticResource CleanButton}"
+                                        ToolTip="{x:Static localization:Strings.Refresh}"
                                         IsEnabled="{Binding IsNetworkInterfaceLoading, Converter={StaticResource BooleanReverseConverter}}"
                                         Margin="10,0,0,0">
                                     <Rectangle Width="24" Height="24"
@@ -1042,6 +1044,7 @@
                                             Height="{Binding ElementName=ComboBoxNetworkInterfaceProfiles, Path=ActualHeight}"
                                             Command="{Binding ReloadNetworkInterfacesCommand}"
                                             Style="{StaticResource CleanButton}"
+                                            ToolTip="{x:Static localization:Strings.Refresh}"
                                             IsEnabled="{Binding IsNetworkInterfaceLoading, Converter={StaticResource BooleanReverseConverter}}"
                                             Margin="10,0,0,0">
                                         <Rectangle Width="24" Height="24"

--- a/Source/NETworkManager/Views/WiFiView.xaml
+++ b/Source/NETworkManager/Views/WiFiView.xaml
@@ -169,6 +169,7 @@
                                                 Height="{Binding ElementName=ComboBoxAdapters, Path=ActualHeight}"
                                                 Command="{Binding Path=ReloadAdaptersCommand}"
                                                 Style="{StaticResource CleanButton}"
+                                                ToolTip="{x:Static localization:Strings.Refresh}"
                                                 Margin="10,0,0,0">
                                             <Rectangle Width="24" Height="24"
                                                        wpfHelpers:ReloadAnimationHelper.IsReloading="{Binding IsAdaptersLoading}">
@@ -241,8 +242,9 @@
                                             </ComboBox>
                                             <Button Command="{Binding Path=ScanNetworksCommand}"
                                                     Style="{StaticResource CleanButton}"
+                                                    ToolTip="{x:Static localization:Strings.Refresh}"
                                                     Margin="0,0,10,0">
-                                                <Rectangle Width="24" Height="24"
+                                                <Rectangle Width="16" Height="16"
                                                            wpfHelpers:ReloadAnimationHelper.IsReloading="{Binding Path=IsBackgroundSearchRunning}">
                                                     <Rectangle.OpacityMask>
                                                         <VisualBrush Stretch="Uniform"

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -67,6 +67,7 @@ Release date: **xx.xx.2025**
 
 **Dashboard**
 
+- Added a **Refresh** button (with animated feedback) to the **Network Connection**, **IP Geolocation**, and **DNS Resolver** widgets. The global reload button in the Status Window has been removed, as each widget now has its own. [#3447](https://github.com/BornToBeRoot/NETworkManager/pull/3447)
 - Redesign Status Window to make it more compact. [#3359](https://github.com/BornToBeRoot/NETworkManager/pull/3359)
 
 **Network Interface**


### PR DESCRIPTION
## Changes proposed in this pull request

- Refresh button in widgets

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request refactors and streamlines the check/reload functionality across the dashboard widgets in the application. It replaces the previous "Reload" and "Check via hotkey" commands with a unified `CheckCommand` for each widget, updates the UI to include consistent reload buttons with animated feedback, and simplifies the codebase by removing redundant commands and methods. Additionally, it improves the user experience by providing visual feedback during ongoing checks.

**Command and Code Refactoring:**

* Replaced all `ReloadCommand` and `CheckViaHotkeyCommand` implementations with a single `CheckCommand` for each widget's ViewModel, and removed associated redundant methods and actions (`ReloadAction`, `CheckViaHotkeyAction`). The new command also disables itself while a check is running for better UX. [[1]](diffhunk://#diff-46037487ae3be020a6d241311a3890f70c39467522b5808275959d5069752c22L99-L105) [[2]](diffhunk://#diff-1c81f227db3f9300f05952365c4d85ad2a61ff2cac12de254519b5060b3ac1b9L73-R75) [[3]](diffhunk://#diff-960f766a3ea32aa1e7101dfe225f3f44b64c5ce2a4bcfe8d48c7b1422d713b71L75-R77) [[4]](diffhunk://#diff-d433fd5ed775f354b653f012667807524aae308862a71b409fc37881d129682dL503-R521)
* Removed unnecessary duplicate checks for `IsRunning` in async check methods, as this is now handled by command logic. [[1]](diffhunk://#diff-1c81f227db3f9300f05952365c4d85ad2a61ff2cac12de254519b5060b3ac1b9L106-L109) [[2]](diffhunk://#diff-960f766a3ea32aa1e7101dfe225f3f44b64c5ce2a4bcfe8d48c7b1422d713b71L108-L111)

**UI/UX Improvements:**

* Updated the XAML for each widget to bind F5 and the reload button to `CheckCommand` instead of the old commands, and added a reload button with a spinning animation during checks, providing immediate visual feedback to the user. [[1]](diffhunk://#diff-2c3485b8631573e0aadf5163dc2a9ea8b91227945e7359380aa99c63c2103c77R13-R17) [[2]](diffhunk://#diff-2c3485b8631573e0aadf5163dc2a9ea8b91227945e7359380aa99c63c2103c77L40-R47) [[3]](diffhunk://#diff-2c3485b8631573e0aadf5163dc2a9ea8b91227945e7359380aa99c63c2103c77R56-R76) [[4]](diffhunk://#diff-1b81b2b5df2fc31e1dad500c01b9e3003cec75e86a008c18d130020be509474bR13-R17) [[5]](diffhunk://#diff-1b81b2b5df2fc31e1dad500c01b9e3003cec75e86a008c18d130020be509474bL43-R50) [[6]](diffhunk://#diff-1b81b2b5df2fc31e1dad500c01b9e3003cec75e86a008c18d130020be509474bR59-R79) [[7]](diffhunk://#diff-a53dce7f3dc0af19bae4bb764b5e1ccbd6678c086ba6736e2d5ebcc6ac74b8afR11-R15) [[8]](diffhunk://#diff-a53dce7f3dc0af19bae4bb764b5e1ccbd6678c086ba6736e2d5ebcc6ac74b8afL170-R177) [[9]](diffhunk://#diff-a53dce7f3dc0af19bae4bb764b5e1ccbd6678c086ba6736e2d5ebcc6ac74b8afR186-R206)

**Widget State Management:**

* Introduced an `IsChecking` property in `NetworkConnectionWidgetViewModel` (and used `IsRunning` in others) to track when a check is in progress, updating the UI accordingly. [[1]](diffhunk://#diff-d433fd5ed775f354b653f012667807524aae308862a71b409fc37881d129682dR479-R494) [[2]](diffhunk://#diff-d433fd5ed775f354b653f012667807524aae308862a71b409fc37881d129682dR575-R576) [[3]](diffhunk://#diff-d433fd5ed775f354b653f012667807524aae308862a71b409fc37881d129682dR589-R590)

**Dashboard Coordination:**

* Simplified dashboard logic by removing the global `Check()` method and directly invoking individual widget checks, ensuring all widgets are checked on dashboard load and only the network connection widget is checked when the view becomes visible.

**Cleanup and Consistency:**

* Removed the old reload button from the window command bar, as each widget now has its own reload button for better clarity and user experience.

</details>

## To-Do

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
