### PR TITLE
Fix CancellationTokenSource leak in ViewModels

### DIFF
--- a/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
@@ -440,6 +440,7 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
 
         DragablzTabItem.SetTabHeader(_tabId, Host);
 
+        _cancellationTokenSource?.Dispose();
         _cancellationTokenSource = new CancellationTokenSource();
 
         // Resolve hostnames

--- a/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
@@ -627,6 +627,7 @@ public class PingMonitorHostViewModel : ViewModelBase, IProfileManager
         IsStatusMessageDisplayed = false;
         IsRunning = true;
 
+        _cancellationTokenSource?.Dispose();
         _cancellationTokenSource = new CancellationTokenSource();
 
         // Resolve hostnames

--- a/Source/NETworkManager/ViewModels/PingMonitorViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PingMonitorViewModel.cs
@@ -400,6 +400,7 @@ public class PingMonitorViewModel : ViewModelBase
         // Reset chart
         ResetTimeChart();
 
+        _cancellationTokenSource?.Dispose();
         _cancellationTokenSource = new CancellationTokenSource();
 
         var ping = new Ping

--- a/Source/NETworkManager/ViewModels/PortScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PortScannerViewModel.cs
@@ -390,6 +390,7 @@ public class PortScannerViewModel : ViewModelBase
 
         DragablzTabItem.SetTabHeader(_tabId, Host);
 
+        _cancellationTokenSource?.Dispose();
         _cancellationTokenSource = new CancellationTokenSource();
 
         // Resolve hostnames

--- a/Source/NETworkManager/ViewModels/SNMPViewModel.cs
+++ b/Source/NETworkManager/ViewModels/SNMPViewModel.cs
@@ -502,6 +502,7 @@ public class SNMPViewModel : ViewModelBase
             ipAddress = dnsResult.Value;
         }
 
+        _cancellationTokenSource?.Dispose();
         _cancellationTokenSource = new CancellationTokenSource();
 
         // SNMP...

--- a/Source/NETworkManager/ViewModels/TracerouteViewModel.cs
+++ b/Source/NETworkManager/ViewModels/TracerouteViewModel.cs
@@ -323,6 +323,7 @@ public class TracerouteViewModel : ViewModelBase
 
         DragablzTabItem.SetTabHeader(_tabId, Host);
 
+        _cancellationTokenSource?.Dispose();
         _cancellationTokenSource = new CancellationTokenSource();
 
         // Try to parse the string into an IP-Address

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -110,6 +110,7 @@ Release date: **xx.xx.2025**
 
 ## Dependencies, Refactoring & Documentation
 
+- Fixed `CancellationTokenSource` leak in `IPScanner`, `PortScanner`, `Traceroute`, `PingMonitor`, `PingMonitorHost` and `SNMP` ViewModels. The previous instance was never disposed before being overwritten on each run, leaking the underlying `WaitHandle`. [#3448](https://github.com/BornToBeRoot/NETworkManager/pull/3448)
 - Replace fire-and-forget `.ConfigureAwait(false)` calls with explicit discard assignments (`_ = SomeAsyncOperation()`) across command handlers, startup/load paths and profile callbacks. [#3441](https://github.com/BornToBeRoot/NETworkManager/pull/3441)
 - Code cleanup & refactoring
 - Language files updated via [#transifex](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Ftransifex-integration)


### PR DESCRIPTION
## Summary

- Dispose the previous `CancellationTokenSource` before overwriting it in `IPScannerViewModel`, `PortScannerViewModel`, `TracerouteViewModel`, `PingMonitorViewModel`, `PingMonitorHostViewModel`, and `SNMPViewModel`
- Each `Start()` call created a new `CancellationTokenSource` without disposing the previous instance, leaking the underlying `WaitHandle` on every run
- Fix is a single `_cancellationTokenSource?.Dispose()` line before each reassignment — safe because `CanExecute` guards ensure `IsRunning` is false before `Start()` is called again

## Test plan

- [ ] Start and stop IP Scanner multiple times — no leak
- [ ] Start and stop Port Scanner multiple times — no leak
- [ ] Start and stop Traceroute multiple times — no leak
- [ ] Start and stop Ping Monitor multiple times — no leak
- [ ] Start and stop SNMP multiple times — no leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)