### PR TITLE
Fix: Possible Dispatcher.ShutdownStarted handler memory leak in Tabs

### DIFF
--- a/Source/NETworkManager/Controls/PowerShellControl.xaml.cs
+++ b/Source/NETworkManager/Controls/PowerShellControl.xaml.cs
@@ -259,6 +259,10 @@ public partial class PowerShellControl : UserControlBase, IDragablzTabItem, IEmb
 
         _closed = true;
 
+        // Detach the app-lifetime handler so this transient tab control can be collected
+        // after the tab is closed (the process itself is released by Disconnect()).
+        Dispatcher.ShutdownStarted -= Dispatcher_ShutdownStarted;
+
         // Disconnect the session
         Disconnect();
 

--- a/Source/NETworkManager/Controls/PuTTYControl.xaml.cs
+++ b/Source/NETworkManager/Controls/PuTTYControl.xaml.cs
@@ -280,6 +280,10 @@ public partial class PuTTYControl : UserControlBase, IDragablzTabItem, IEmbedded
 
         _closed = true;
 
+        // Detach the app-lifetime handler so this transient tab control can be collected
+        // after the tab is closed (the process itself is released by Disconnect()).
+        Dispatcher.ShutdownStarted -= Dispatcher_ShutdownStarted;
+
         // Disconnect the session
         Disconnect();
 

--- a/Source/NETworkManager/Controls/RemoteDesktopControl.xaml.cs
+++ b/Source/NETworkManager/Controls/RemoteDesktopControl.xaml.cs
@@ -517,6 +517,10 @@ public partial class RemoteDesktopControl : UserControlBase, IDragablzTabItem
 
         _closed = true;
 
+        // Detach the app-lifetime handler so this transient tab control can be collected
+        // after the tab is closed (the RDP session is released by Disconnect()).
+        Dispatcher.ShutdownStarted -= Dispatcher_ShutdownStarted;
+
         // Disconnect the session
         Disconnect();
 

--- a/Source/NETworkManager/Controls/TigerVNCControl.xaml.cs
+++ b/Source/NETworkManager/Controls/TigerVNCControl.xaml.cs
@@ -244,6 +244,10 @@ public partial class TigerVNCControl : UserControlBase, IDragablzTabItem
 
         _closed = true;
 
+        // Detach the app-lifetime handler so this transient tab control can be collected
+        // after the tab is closed (the process itself is released by Disconnect()).
+        Dispatcher.ShutdownStarted -= Dispatcher_ShutdownStarted;
+
         // Disconnect the session
         Disconnect();
 

--- a/Source/NETworkManager/Controls/WebConsoleControl.xaml.cs
+++ b/Source/NETworkManager/Controls/WebConsoleControl.xaml.cs
@@ -4,6 +4,7 @@ using NETworkManager.Models.WebConsole;
 using NETworkManager.Settings;
 using NETworkManager.Utilities;
 using System;
+using System.Threading;
 using System.Windows;
 using System.Windows.Input;
 
@@ -17,6 +18,7 @@ public partial class WebConsoleControl : UserControlBase, IDragablzTabItem
 
     private bool _initialized;
     private bool _closed;
+    private readonly CancellationTokenSource _loadCancellationTokenSource = new();
 
     private readonly Guid _tabId;
     private readonly WebConsoleSessionInfo _sessionInfo;
@@ -92,25 +94,44 @@ public partial class WebConsoleControl : UserControlBase, IDragablzTabItem
     private async void UserControl_Loaded(object sender, RoutedEventArgs e)
     {
         // Connect after the control is drawn and only on the first init
-        if (_initialized)
+        if (_initialized || _closed || _loadCancellationTokenSource.IsCancellationRequested)
             return;
 
-        // Set user data folder - Fix #382            
-        var webView2Environment =
-            await CoreWebView2Environment.CreateAsync(null, GlobalStaticConfiguration.WebConsole_Cache);
+        try
+        {
+            // Set user data folder - Fix #382
+            var webView2Environment =
+                await CoreWebView2Environment.CreateAsync(null, GlobalStaticConfiguration.WebConsole_Cache);
 
-        await Browser.EnsureCoreWebView2Async(webView2Environment);
+            if (_closed || _loadCancellationTokenSource.IsCancellationRequested)
+                return;
 
-        Log.Debug($"UserControl_Loaded - WebView2 profile path: {Browser.CoreWebView2.Profile.ProfilePath}");
+            await Browser.EnsureCoreWebView2Async(webView2Environment);
 
-        // Set the default settings
-        Browser.CoreWebView2.Settings.IsStatusBarEnabled = SettingsManager.Current.WebConsole_IsStatusBarEnabled;
-        Browser.CoreWebView2.Settings.IsPasswordAutosaveEnabled =
-            SettingsManager.Current.WebConsole_IsPasswordSaveEnabled;
+            if (_closed || _loadCancellationTokenSource.IsCancellationRequested || Browser.CoreWebView2 == null)
+                return;
 
-        Navigate(_sessionInfo.Url);
+            Log.Debug($"UserControl_Loaded - WebView2 profile path: {Browser.CoreWebView2.Profile.ProfilePath}");
 
-        _initialized = true;
+            // Set the default settings
+            Browser.CoreWebView2.Settings.IsStatusBarEnabled = SettingsManager.Current.WebConsole_IsStatusBarEnabled;
+            Browser.CoreWebView2.Settings.IsPasswordAutosaveEnabled =
+                SettingsManager.Current.WebConsole_IsPasswordSaveEnabled;
+
+            Navigate(_sessionInfo.Url);
+
+            _initialized = true;
+        }
+        catch (ObjectDisposedException)
+        {
+            if (!_closed && !_loadCancellationTokenSource.IsCancellationRequested)
+                throw;
+        }
+        catch (InvalidOperationException)
+        {
+            if (!_closed && !_loadCancellationTokenSource.IsCancellationRequested)
+                throw;
+        }
     }
 
     #endregion
@@ -198,6 +219,8 @@ public partial class WebConsoleControl : UserControlBase, IDragablzTabItem
             return;
 
         _closed = true;
+        _loadCancellationTokenSource.Cancel();
+        _loadCancellationTokenSource.Dispose();
 
         // Release the subscriptions that would otherwise keep this transient per-tab
         // control (and its heavyweight WebView2 instance) alive for the lifetime of the

--- a/Source/NETworkManager/Controls/WebConsoleControl.xaml.cs
+++ b/Source/NETworkManager/Controls/WebConsoleControl.xaml.cs
@@ -199,6 +199,17 @@ public partial class WebConsoleControl : UserControlBase, IDragablzTabItem
 
         _closed = true;
 
+        // Release the subscriptions that would otherwise keep this transient per-tab
+        // control (and its heavyweight WebView2 instance) alive for the lifetime of the
+        // application, then dispose the browser to free the native resources.
+        SettingsManager.Current.PropertyChanged -= Current_PropertyChanged;
+        Dispatcher.ShutdownStarted -= Dispatcher_ShutdownStarted;
+
+        Browser.NavigationStarting -= Browser2_NavigationStarting;
+        Browser.NavigationCompleted -= Browser2_NavigationCompleted;
+        Browser.SourceChanged -= Browser2_SourceChanged;
+        Browser.Dispose();
+
         ConfigurationManager.Current.WebConsoleTabCount--;
     }
 

--- a/Source/NETworkManager/Views/DNSLookupView.xaml.cs
+++ b/Source/NETworkManager/Views/DNSLookupView.xaml.cs
@@ -23,6 +23,10 @@ public partial class DNSLookupView : IDragablzTabItem
 
     public void CloseTab()
     {
+        // Detach the app-lifetime handler so this transient tab view (and its view model)
+        // can be collected after the tab is closed.
+        Dispatcher.ShutdownStarted -= Dispatcher_ShutdownStarted;
+
         _viewModel.OnClose();
     }
 

--- a/Source/NETworkManager/Views/IPGeolocationView.xaml.cs
+++ b/Source/NETworkManager/Views/IPGeolocationView.xaml.cs
@@ -22,6 +22,10 @@ public partial class IPGeolocationView : IDragablzTabItem
 
     public void CloseTab()
     {
+        // Detach the app-lifetime handler so this transient tab view (and its view model)
+        // can be collected after the tab is closed.
+        Dispatcher.ShutdownStarted -= Dispatcher_ShutdownStarted;
+
         _viewModel.OnClose();
     }
 

--- a/Source/NETworkManager/Views/IPScannerView.xaml.cs
+++ b/Source/NETworkManager/Views/IPScannerView.xaml.cs
@@ -30,6 +30,10 @@ public partial class IPScannerView : IDragablzTabItem
 
     public void CloseTab()
     {
+        // Detach the app-lifetime handler so this transient tab view (and its view model)
+        // can be collected after the tab is closed.
+        Dispatcher.ShutdownStarted -= Dispatcher_ShutdownStarted;
+
         _viewModel.OnClose();
     }
 

--- a/Source/NETworkManager/Views/PortScannerView.xaml.cs
+++ b/Source/NETworkManager/Views/PortScannerView.xaml.cs
@@ -23,6 +23,10 @@ public partial class PortScannerView : IDragablzTabItem
 
     public void CloseTab()
     {
+        // Detach the app-lifetime handler so this transient tab view (and its view model)
+        // can be collected after the tab is closed.
+        Dispatcher.ShutdownStarted -= Dispatcher_ShutdownStarted;
+
         _viewModel.OnClose();
     }
 

--- a/Source/NETworkManager/Views/SNMPView.xaml.cs
+++ b/Source/NETworkManager/Views/SNMPView.xaml.cs
@@ -28,6 +28,10 @@ public partial class SNMPView : IDragablzTabItem
 
     public void CloseTab()
     {
+        // Detach the app-lifetime handler so this transient tab view (and its view model)
+        // can be collected after the tab is closed.
+        Dispatcher.ShutdownStarted -= Dispatcher_ShutdownStarted;
+
         _viewModel.OnClose();
     }
 

--- a/Source/NETworkManager/Views/SNTPLookupView.xaml.cs
+++ b/Source/NETworkManager/Views/SNTPLookupView.xaml.cs
@@ -23,6 +23,10 @@ public partial class SNTPLookupView : IDragablzTabItem
 
     public void CloseTab()
     {
+        // Detach the app-lifetime handler so this transient tab view (and its view model)
+        // can be collected after the tab is closed.
+        Dispatcher.ShutdownStarted -= Dispatcher_ShutdownStarted;
+
         _viewModel.OnClose();
     }
 

--- a/Source/NETworkManager/Views/TracerouteView.xaml.cs
+++ b/Source/NETworkManager/Views/TracerouteView.xaml.cs
@@ -23,6 +23,10 @@ public partial class TracerouteView : IDragablzTabItem
 
     public void CloseTab()
     {
+        // Detach the app-lifetime handler so this transient tab view (and its view model)
+        // can be collected after the tab is closed.
+        Dispatcher.ShutdownStarted -= Dispatcher_ShutdownStarted;
+
         _viewModel.OnClose();
     }
 

--- a/Source/NETworkManager/Views/WhoisView.xaml.cs
+++ b/Source/NETworkManager/Views/WhoisView.xaml.cs
@@ -22,6 +22,10 @@ public partial class WhoisView : IDragablzTabItem
 
     public void CloseTab()
     {
+        // Detach the app-lifetime handler so this transient tab view (and its view model)
+        // can be collected after the tab is closed.
+        Dispatcher.ShutdownStarted -= Dispatcher_ShutdownStarted;
+
         _viewModel.OnClose();
     }
 

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -118,6 +118,7 @@ Release date: **xx.xx.2025**
 
 - Migrated from `LiveCharts` to `LiveCharts2` (`LiveChartsCore.SkiaSharpView.WPF`) for chart rendering. [#3449](https://github.com/BornToBeRoot/NETworkManager/pull/3449)
 - Fixed `CancellationTokenSource` leak in `IPScanner`, `PortScanner`, `Traceroute`, `PingMonitor`, `PingMonitorHost` and `SNMP` ViewModels. The previous instance was never disposed before being overwritten on each run, leaking the underlying `WaitHandle`. [#3448](https://github.com/BornToBeRoot/NETworkManager/pull/3448)
+- Fixed a `Dispatcher.ShutdownStarted` handler leak in the Dragablz tab items (PowerShell, PuTTY, TigerVNC, Remote Desktop and Web Console controls, plus the IP Scanner, Port Scanner, Traceroute, DNS Lookup, IP Geolocation, SNMP, SNTP Lookup and Whois views). The handler was subscribed in the constructor but never removed, keeping each closed tab (view and view model) alive until the application exited. It is now unsubscribed in `CloseTab()`; the Web Console additionally disposes its WebView2 instance. [#3454](https://github.com/BornToBeRoot/NETworkManager/pull/3454)
 - Replace fire-and-forget `.ConfigureAwait(false)` calls with explicit discard assignments (`_ = SomeAsyncOperation()`) across command handlers, startup/load paths and profile callbacks. [#3441](https://github.com/BornToBeRoot/NETworkManager/pull/3441)
 - Code cleanup & refactoring
 - Language files updated via [#transifex](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Ftransifex-integration)


### PR DESCRIPTION
## Changes proposed in this pull request

- Fix possible handler memory leak by unsubscribing

## Related issue(s)

Feedback from Copilot and Claude review

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request improves resource management in the application by ensuring that event handlers and subscriptions are properly detached when closing various transient tab controls and views. This change helps prevent memory leaks by allowing these controls and their associated resources to be garbage collected after the tab is closed.

Resource cleanup and event detachment for tab controls:

* Detached the `Dispatcher.ShutdownStarted` event handler in the `CloseTab()` method for all transient tab controls (`PowerShellControl`, `PuTTYControl`, `RemoteDesktopControl`, `TigerVNCControl`, and `WebConsoleControl`) to ensure they can be collected after the tab is closed. [[1]](diffhunk://#diff-66eb161ae8de4357190469771b8b9c8e6563d6571b9dba36f081ec9adf83b5e5R262-R265) [[2]](diffhunk://#diff-5561a4ddc839f5031a7af7c0b114c5a64a3f82a255b6648b2a5ef75a2e897840R283-R286) [[3]](diffhunk://#diff-12cd39721d86b0dfa0e88a33ab58efdb58f74b01b9b722ddcf7901c7cdd82e32R520-R523) [[4]](diffhunk://#diff-ef839fdd80987f1358239e486ebbb9b330491d8e62083047ca53b81eaab76935R247-R250) [[5]](diffhunk://#diff-da32516b8dc5f25458a2aae24464629a320c17297c77df2cbe5d6cc981e34525R202-R212)
* For `WebConsoleControl`, additionally removed property change and browser event subscriptions, and disposed of the `Browser` instance to release native resources.

Resource cleanup for tab views:

* Detached the `Dispatcher.ShutdownStarted` event handler in the `CloseTab()` method for all transient tab views (`DNSLookupView`, `IPGeolocationView`, `IPScannerView`, `PortScannerView`, `SNMPView`, `SNTPLookupView`, `TracerouteView`, and `WhoisView`) to ensure both the view and its view model can be collected after the tab is closed. [[1]](diffhunk://#diff-70c3b474b19a4d92703b21b8b1e164901dd63a8cb6e0ac081f7ea4f674135b48R26-R29) [[2]](diffhunk://#diff-7877f9062600c2f209326dc3aa189eebffa2ffa38c5422659c9f9171d1e1f9aaR25-R28) [[3]](diffhunk://#diff-dd75f1c0c17470ddee9fdac4af75cf6116a3f0a34c6d7f7d2b7dfe1fbc62a0e8R33-R36) [[4]](diffhunk://#diff-8e5f9f69f6099e54ca7070ca67afa0649f5585d4d4cb327a33f9d115b46773e5R26-R29) [[5]](diffhunk://#diff-7c8d7000025d3ca5e95c71d79b990a022dfdc17e2c716c3717488188653dfdfdR31-R34) [[6]](diffhunk://#diff-6d79b0c722b4a7a896232cca0d0fed248e17828e2db9c518f8eb9d7fa3806f43R26-R29) [[7]](diffhunk://#diff-b91ee06f277db6432dcbe9370f7d9dd386a0e2c15b83329bd2fbe663fc75bda5R26-R29) [[8]](diffhunk://#diff-f936b6883afac8874c43760d3ebf0a7c66750ef70f68ca2b574288edd459fc6fR25-R28)

</details>

## To-Do

- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
