### PR TITLE
Docs: standardize WiFi page and clarify format-app-doc command.

### DIFF
--- a/.claude/commands/format-app-doc.md
+++ b/.claude/commands/format-app-doc.md
@@ -40,7 +40,7 @@ Any `:::note` blocks that describe input format or input combination rules (e.g.
 
 **Example:**
 
-```
+```markdown
 ### Example inputs
 
 | Host | Type | Description |
@@ -61,9 +61,9 @@ Only for standalone application behavior facts that don't fit elsewhere (e.g. au
 
 ### 10. Actions
 
-Place action subsections directly after the screenshot — never inside a wrapping `## Actions` section. This applies to both single-view pages and multi-tab pages:
+Place action subsections directly after `### Example inputs` (if present) and the optional `:::note` from step 9. If those sections are not present, place actions directly after the screenshot. Never wrap them in a `## Actions` section. This applies to both single-view pages and multi-tab pages:
 
-- **Single-view pages:** `### Toolbar`, `### Context menu`, and `### Keyboard shortcuts` appear directly after the screenshot (and the optional `:::note` from step 9, if present).
+- **Single-view pages:** `### Toolbar`, `### Context menu`, and `### Keyboard shortcuts` appear in that location directly after the screenshot flow.
 - **Multi-tab pages** (page organized as `## Tab Name` sections, each with its own screenshot): place the same subsections inline within each tab section, directly after its screenshot. Simple single-action notes (e.g. "Right-click on the result to copy the information.") can remain as `:::note` blocks after the screenshot instead of a full subsection.
 
 Include only the subsections that apply. Omit subsections with no content.
@@ -129,4 +129,4 @@ Fix obvious typos (e.g. `ipadress` → `IP address`, `Multipe` → `Multiple`) a
 - **Omit** any `## Actions` subsection that has no content for this page.
 - Preserve all existing links, anchors (`#section-name`), and image references exactly.
 - Do not change field types, examples, or possible values.
-- Do not add new top-level sections (`##`) that do not exist in the source, except `## Actions`.
+- Do not add new top-level sections (`##`) that do not exist in the source.

--- a/Website/docs/application/wifi.md
+++ b/Website/docs/application/wifi.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-description: "Analyze available WiFi networks with details on channels, signal strength, and encryption. NETworkManager WiFi Analyzer supports 2.4, 5, and 6 GHz bands."
+description: "Analyze available WiFi networks, including channels, signal strength, and encryption details across the 2.4, 5, and 6 GHz bands."
 keywords:
   [
     NETworkManager,
@@ -16,19 +16,25 @@ keywords:
 
 # WiFi
 
-The **WiFi** tool shows all available wireless networks with details such as channel, signal strength, and encryption type.
+The **WiFi** tool shows available wireless networks, including channel, signal strength, and encryption details.
 
 Hidden wireless networks are shown as `Hidden Network`.
 
+:::info
+
+Wi-Fi is a wireless networking technology based on IEEE 802.11 standards. Access points periodically advertise network information (such as SSID and security capabilities), which clients can scan and display.
+
+:::
+
 ## WiFi
 
-On the **WiFi** tab, you can select which wireless network adapter is used to scan for wireless networks. Wireless networks can be filtered by 2.4 GHz, 5 GHz, and 6 GHz.
+On the **WiFi** tab, you can select which wireless adapter is used for scanning. Results can be filtered by the 2.4 GHz, 5 GHz, and 6 GHz bands.
 
-In the search field, you can filter the wireless networks by `SSID`, `Security`, `Frequency`, `Channel`, `BSSID (MAC Address)`, `Vendor`, and `Phy kind`. The search is case-insensitive.
+In the search field, you can filter wireless networks by `SSID`, `Security`, `Frequency`, `Channel`, `BSSID (MAC Address)`, `Vendor`, and `PHY kind`. Search is case-insensitive.
 
 :::note
 
-Starting with Windows 11 24H2, you need to allow access to the Wi-Fi adapter.
+Starting with Windows 11 24H2, you must allow access to the Wi-Fi adapter.
 
 Open `Windows Settings > Privacy & security > Location`, enable access for Desktop Apps / NETworkManager, then restart the application.
 
@@ -53,7 +59,7 @@ Open `Windows Settings > Privacy & security > Location`, enable access for Deskt
 
 ## Channels
 
-On the **Channels** tab, all wireless networks of the selected wireless network adapter are displayed in a graphical view with channel, channel width, and signal strength. This can be useful to identify overlapping wireless networks that do not originate from the same access point.
+On the **Channels** tab, all wireless networks of the selected wireless adapter are displayed in a graphical view with channel, channel width, and signal strength. This helps identify overlapping wireless networks that do not originate from the same access point.
 
 The tab is split into two sub-tabs:
 


### PR DESCRIPTION
## Summary
- Align `Website/docs/application/wifi.md` with the project's standard page structure: improved description, added `:::info` block about IEEE 802.11, tightened prose, and corrected `PHY kind` capitalization.
- Clarify `format-app-doc` command rules: actions now correctly placed after `### Example inputs` when present, and removed the contradictory `## Actions` exception.

## Test plan
- [x] `npm run build` in `Website/` succeeds without errors