### PR TITLE
Feature: (Ping - Host up/down) Notifications

### DIFF
--- a/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
+++ b/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
@@ -11118,7 +11118,97 @@ namespace NETworkManager.Localization.Resources {
                 return ResourceManager.GetString("StatusChange", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Notification.
+        /// </summary>
+        public static string PingMonitorNotification {
+            get {
+                return ResourceManager.GetString("PingMonitorNotification", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Show notification popup on status change.
+        /// </summary>
+        public static string ShowNotificationPopupOnStatusChange {
+            get {
+                return ResourceManager.GetString("ShowNotificationPopupOnStatusChange", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Play sound on status change.
+        /// </summary>
+        public static string PlaySoundOnStatusChange {
+            get {
+                return ResourceManager.GetString("PlaySoundOnStatusChange", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Success threshold.
+        /// </summary>
+        public static string NotificationSuccessThreshold {
+            get {
+                return ResourceManager.GetString("NotificationSuccessThreshold", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Number of consecutive successful pings required before an &quot;Host is up&quot; notification is shown. Higher values reduce noise from flapping hosts.
+        /// </summary>
+        public static string HelpMessage_NotificationSuccessThreshold {
+            get {
+                return ResourceManager.GetString("HelpMessage_NotificationSuccessThreshold", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Failure threshold.
+        /// </summary>
+        public static string NotificationFailureThreshold {
+            get {
+                return ResourceManager.GetString("NotificationFailureThreshold", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Number of consecutive failed pings (timeouts) required before an &quot;Host is down&quot; notification is shown. Higher values reduce noise from flapping hosts.
+        /// </summary>
+        public static string HelpMessage_NotificationFailureThreshold {
+            get {
+                return ResourceManager.GetString("HelpMessage_NotificationFailureThreshold", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Display duration (seconds).
+        /// </summary>
+        public static string NotificationDurationInSeconds {
+            get {
+                return ResourceManager.GetString("NotificationDurationInSeconds", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Host is up.
+        /// </summary>
+        public static string HostIsUp {
+            get {
+                return ResourceManager.GetString("HostIsUp", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Host is down.
+        /// </summary>
+        public static string HostIsDown {
+            get {
+                return ResourceManager.GetString("HostIsDown", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Status window.
         /// </summary>

--- a/Source/NETworkManager.Localization/Resources/Strings.resx
+++ b/Source/NETworkManager.Localization/Resources/Strings.resx
@@ -2386,7 +2386,7 @@ $$hostname$$	--&gt;	Hostname</value>
     <value>Failure threshold</value>
   </data>
   <data name="HelpMessage_NotificationFailureThreshold" xml:space="preserve">
-    <value>Number of consecutive failed pings (timeouts) required before an "Host is down" notification is shown. Higher values reduce noise from flapping hosts.</value>
+    <value>Number of consecutive failed pings (timeouts) required before a "Host is down" notification is shown. Higher values reduce noise from flapping hosts.</value>
   </data>
   <data name="NotificationDurationInSeconds" xml:space="preserve">
     <value>Display duration (seconds)</value>

--- a/Source/NETworkManager.Localization/Resources/Strings.resx
+++ b/Source/NETworkManager.Localization/Resources/Strings.resx
@@ -2380,7 +2380,7 @@ $$hostname$$	--&gt;	Hostname</value>
     <value>Success threshold</value>
   </data>
   <data name="HelpMessage_NotificationSuccessThreshold" xml:space="preserve">
-    <value>Number of consecutive successful pings required before an "Host is up" notification is shown. Higher values reduce noise from flapping hosts.</value>
+    <value>Number of consecutive successful pings required before a "Host is up" notification is shown. Higher values reduce noise from flapping hosts.</value>
   </data>
   <data name="NotificationFailureThreshold" xml:space="preserve">
     <value>Failure threshold</value>

--- a/Source/NETworkManager.Localization/Resources/Strings.resx
+++ b/Source/NETworkManager.Localization/Resources/Strings.resx
@@ -2367,6 +2367,36 @@ $$hostname$$	--&gt;	Hostname</value>
   <data name="CouldNotResolveIPAddressFor" xml:space="preserve">
     <value>Could not resolve ip address for: "{0}"</value>
   </data>
+  <data name="PingMonitorNotification" xml:space="preserve">
+    <value>Notification</value>
+  </data>
+  <data name="ShowNotificationPopupOnStatusChange" xml:space="preserve">
+    <value>Show notification popup on status change</value>
+  </data>
+  <data name="PlaySoundOnStatusChange" xml:space="preserve">
+    <value>Play sound on status change</value>
+  </data>
+  <data name="NotificationSuccessThreshold" xml:space="preserve">
+    <value>Success threshold</value>
+  </data>
+  <data name="HelpMessage_NotificationSuccessThreshold" xml:space="preserve">
+    <value>Number of consecutive successful pings required before an "Host is up" notification is shown. Higher values reduce noise from flapping hosts.</value>
+  </data>
+  <data name="NotificationFailureThreshold" xml:space="preserve">
+    <value>Failure threshold</value>
+  </data>
+  <data name="HelpMessage_NotificationFailureThreshold" xml:space="preserve">
+    <value>Number of consecutive failed pings (timeouts) required before an "Host is down" notification is shown. Higher values reduce noise from flapping hosts.</value>
+  </data>
+  <data name="NotificationDurationInSeconds" xml:space="preserve">
+    <value>Display duration (seconds)</value>
+  </data>
+  <data name="HostIsUp" xml:space="preserve">
+    <value>Host is up</value>
+  </data>
+  <data name="HostIsDown" xml:space="preserve">
+    <value>Host is down</value>
+  </data>
   <data name="TheApplicationWillBeRestarted" xml:space="preserve">
     <value>The application will be restarted...</value>
   </data>

--- a/Source/NETworkManager.Settings/GlobalStaticConfiguration.cs
+++ b/Source/NETworkManager.Settings/GlobalStaticConfiguration.cs
@@ -30,6 +30,11 @@ public static class GlobalStaticConfiguration
     // Network config
     public static int NetworkChangeDetectionDelay => 5000;
 
+    // Notification config
+    // Minimum interval (ms) between two notification sounds, so a burst of near-simultaneous
+    // status changes collapses into a single sound instead of an overlapping cacophony.
+    public static int NotificationSoundThrottle => 3000;
+
     // Profile config
     public static bool Profile_TagsMatchAny => true;
     public static bool Profile_ExpandProfileView => true;
@@ -146,6 +151,13 @@ public static class GlobalStaticConfiguration
     public static bool PingMonitor_ExpandHostView => false;
     public static int PingMonitor_ChartTime => 120;
     public static ExportFileType PingMonitor_ExportFileType => ExportFileType.Csv;
+
+    // Application: Ping Monitor (notifications)
+    public static bool PingMonitor_ShowNotificationPopup => true;
+    public static bool PingMonitor_NotificationSound => true;
+    public static int PingMonitor_NotificationSuccessThreshold => 1;
+    public static int PingMonitor_NotificationFailureThreshold => 3;
+    public static int PingMonitor_NotificationCloseTime => 10;
 
     // Application: Traceroute
     public static int Traceroute_MaximumHops => 30;

--- a/Source/NETworkManager.Settings/SettingsInfo.cs
+++ b/Source/NETworkManager.Settings/SettingsInfo.cs
@@ -1537,6 +1537,71 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     } = GlobalStaticConfiguration.PingMonitor_ChartTime;
 
+    public bool PingMonitor_ShowNotificationPopup
+    {
+        get;
+        set
+        {
+            if (value == field)
+                return;
+
+            field = value;
+            OnPropertyChanged();
+        }
+    } = GlobalStaticConfiguration.PingMonitor_ShowNotificationPopup;
+
+    public bool PingMonitor_NotificationSound
+    {
+        get;
+        set
+        {
+            if (value == field)
+                return;
+
+            field = value;
+            OnPropertyChanged();
+        }
+    } = GlobalStaticConfiguration.PingMonitor_NotificationSound;
+
+    public int PingMonitor_NotificationSuccessThreshold
+    {
+        get;
+        set
+        {
+            if (value == field)
+                return;
+
+            field = value;
+            OnPropertyChanged();
+        }
+    } = GlobalStaticConfiguration.PingMonitor_NotificationSuccessThreshold;
+
+    public int PingMonitor_NotificationFailureThreshold
+    {
+        get;
+        set
+        {
+            if (value == field)
+                return;
+
+            field = value;
+            OnPropertyChanged();
+        }
+    } = GlobalStaticConfiguration.PingMonitor_NotificationFailureThreshold;
+
+    public int PingMonitor_NotificationCloseTime
+    {
+        get;
+        set
+        {
+            if (value == field)
+                return;
+
+            field = value;
+            OnPropertyChanged();
+        }
+    } = GlobalStaticConfiguration.PingMonitor_NotificationCloseTime;
+
     public string PingMonitor_ExportFilePath
     {
         get;

--- a/Source/NETworkManager/NotificationManager.cs
+++ b/Source/NETworkManager/NotificationManager.cs
@@ -38,6 +38,10 @@ public static class NotificationManager
     /// <param name="closeTimeSeconds">Seconds before the popup closes automatically.</param>
     public static void Show(PackIconMaterialKind iconKind, string iconColor, string title, string message, int closeTimeSeconds)
     {
+        // A late ping callback during application shutdown may find no Application instance.
+        if (Application.Current is null)
+            return;
+
         Application.Current.Dispatcher.BeginInvoke(() =>
         {
             var window = new NotificationWindow(iconKind, iconColor, title, message, closeTimeSeconds);
@@ -83,7 +87,8 @@ public static class NotificationManager
     }
 
     /// <summary>
-    /// Repositions all active windows after a sibling closes and stack indices shift.
+    /// Repositions all active windows, e.g. after one closes or its height changes so the stack
+    /// stays bottom-anchored without gaps or overlap.
     /// </summary>
     internal static void RepositionAll()
     {

--- a/Source/NETworkManager/NotificationManager.cs
+++ b/Source/NETworkManager/NotificationManager.cs
@@ -1,0 +1,93 @@
+using MahApps.Metro.IconPacks;
+using NETworkManager.Settings;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Media;
+using System.Threading;
+using System.Windows;
+
+namespace NETworkManager;
+
+/// <summary>
+/// Shows and manages stackable notification popups. Follows the same pattern as
+/// <see cref="DialogHelper"/> — callers pass display parameters; internals are hidden.
+/// </summary>
+public static class NotificationManager
+{
+    private static readonly List<NotificationWindow> ActiveWindows = [];
+
+    /// <summary>
+    /// Margin (in DIP) between the screen edges and between stacked notification windows.
+    /// </summary>
+    internal const double WindowMargin = 10.0;
+
+    // Throttles the notification sound (see GlobalStaticConfiguration.NotificationSoundThrottle)
+    // so a burst of near-simultaneous status changes collapses into a single sound.
+    private static readonly Lock SoundLock = new();
+    private static DateTime _lastSoundPlayed = DateTime.MinValue;
+
+    /// <summary>
+    /// Shows a notification popup in the bottom-right corner of the primary screen.
+    /// Safe to call from any thread.
+    /// </summary>
+    /// <param name="iconKind">The Material icon shown on the left of the popup.</param>
+    /// <param name="iconColor">The icon fill color (e.g. "Red" or "#badc58").</param>
+    /// <param name="title">The bold header text (e.g. the host title).</param>
+    /// <param name="message">The gray subtext below the header (e.g. "Host is up").</param>
+    /// <param name="closeTimeSeconds">Seconds before the popup closes automatically.</param>
+    public static void Show(PackIconMaterialKind iconKind, string iconColor, string title, string message, int closeTimeSeconds)
+    {
+        Application.Current.Dispatcher.BeginInvoke(() =>
+        {
+            var window = new NotificationWindow(iconKind, iconColor, title, message, closeTimeSeconds);
+
+            window.Closed += (_, _) =>
+            {
+                ActiveWindows.Remove(window);
+                RepositionAll();
+            };
+
+            ActiveWindows.Add(window);
+            window.Show(); // triggers OnSourceInitialized → window positions itself
+        });
+    }
+
+    /// <summary>
+    /// Returns the combined height (including margins) of all windows stacked below the given
+    /// window, i.e. the vertical offset from the bottom edge at which it should be placed.
+    /// </summary>
+    internal static double GetStackOffset(NotificationWindow window)
+    {
+        return ActiveWindows.TakeWhile(w => !ReferenceEquals(w, window)).Sum(w => w.ActualHeight + WindowMargin);
+    }
+
+    /// <summary>
+    /// Plays a notification sound, throttled so that a burst of near-simultaneous status changes
+    /// (e.g. many hosts going down at once) results in a single sound. Safe to call from any thread.
+    /// </summary>
+    /// <param name="sound">The system sound to play.</param>
+    public static void PlaySound(SystemSound sound)
+    {
+        lock (SoundLock)
+        {
+            var now = DateTime.UtcNow;
+
+            if ((now - _lastSoundPlayed).TotalMilliseconds < GlobalStaticConfiguration.NotificationSoundThrottle)
+                return;
+
+            _lastSoundPlayed = now;
+        }
+
+        sound.Play();
+    }
+
+    /// <summary>
+    /// Repositions all active windows after a sibling closes and stack indices shift.
+    /// </summary>
+    internal static void RepositionAll()
+    {
+        foreach (var window in ActiveWindows)
+            window.Reposition();
+    }
+}

--- a/Source/NETworkManager/NotificationWindow.xaml
+++ b/Source/NETworkManager/NotificationWindow.xaml
@@ -1,0 +1,119 @@
+<mah:MetroWindow x:Class="NETworkManager.NotificationWindow"
+                 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                 xmlns:mah="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+                 xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
+                 xmlns:localization="clr-namespace:NETworkManager.Localization.Resources;assembly=NETworkManager.Localization"
+                 xmlns:networkManager="clr-namespace:NETworkManager"
+                 mc:Ignorable="d"
+                 d:DataContext="{d:DesignInstance networkManager:NotificationWindow}"
+                 Style="{DynamicResource DefaultWindow}"
+                 Topmost="True"
+                 ShowInTaskbar="False"
+                 Width="360"
+                 MinHeight="80"
+                 SizeToContent="Height"
+                 ResizeMode="NoResize"
+                 IsWindowDraggable="False"
+                 ShowTitleBar="False"
+                 ShowMinButton="False"
+                 ShowMaxRestoreButton="False"
+                 ShowCloseButton="False"
+                 Closing="MetroWindow_Closing">
+    <!-- Clicking anywhere on the popup (except the close button) opens the main window.
+         Background="Transparent" makes the empty areas hit-test visible. -->
+    <Grid Background="Transparent" Cursor="Hand"
+          ToolTip="{x:Static localization:Strings.Show}"
+          MouseLeftButtonUp="Root_MouseLeftButtonUp">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="3" />
+        </Grid.RowDefinitions>
+
+        <!-- Main content -->
+        <Grid Grid.Row="0" Margin="10" Background="Transparent">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="10" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="10" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <!-- Status icon: kind and color bound from constructor parameters -->
+            <Rectangle Grid.Column="0" Grid.Row="0"
+                       Width="32" Height="32"
+                       Fill="{Binding IconColor}">
+                <Rectangle.OpacityMask>
+                    <VisualBrush Stretch="Uniform">
+                        <VisualBrush.Visual>
+                            <iconPacks:PackIconMaterial Kind="{Binding IconKind}" />
+                        </VisualBrush.Visual>
+                    </VisualBrush>
+                </Rectangle.OpacityMask>
+            </Rectangle>
+
+            <!-- Title + timestamp (header row) + Message (gray subtext) — fully generic -->
+            <Grid Grid.Column="2" Grid.Row="0" VerticalAlignment="Top">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Row="0" Grid.Column="0"
+                           Text="{Binding NotificationTitle}"
+                           Style="{StaticResource DefaultTextBlock}"
+                           TextTrimming="CharacterEllipsis" />
+                <TextBlock Grid.Row="0" Grid.Column="1"
+                           Text="{Binding Time}"
+                           Margin="10,0,0,0"
+                           VerticalAlignment="Center"
+                           Style="{StaticResource DefaultTextBlock}"
+                           Foreground="{DynamicResource MahApps.Brushes.Gray5}" />
+                <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                           Text="{Binding Message}"
+                           Margin="0,5,0,0"
+                           Style="{StaticResource DefaultTextBlock}"
+                           Foreground="{DynamicResource MahApps.Brushes.Gray5}"
+                           TextWrapping="Wrap" />
+            </Grid>
+
+            <!-- Close [×] — gray, Gray5 on hover, NOT red -->
+            <Button Grid.Column="4"
+                    Command="{Binding CloseCommand}"
+                    ToolTip="{x:Static localization:Strings.Close}"
+                    Style="{StaticResource CleanButton}"
+                    VerticalAlignment="Top"
+                    Margin="0,2,0,0">
+                <Rectangle Width="16" Height="16">
+                    <Rectangle.OpacityMask>
+                        <VisualBrush Stretch="Fill" Visual="{iconPacks:Material Kind=WindowClose}" />
+                    </Rectangle.OpacityMask>
+                    <Rectangle.Style>
+                        <Style TargetType="{x:Type Rectangle}">
+                            <Setter Property="Fill" Value="{DynamicResource MahApps.Brushes.Gray3}" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Button}}, Path=IsMouseOver}" Value="True">
+                                    <Setter Property="Fill" Value="{DynamicResource MahApps.Brushes.Gray5}" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Rectangle.Style>
+                </Rectangle>
+            </Button>
+        </Grid>
+
+        <!-- Countdown ProgressBar — 3 px, depletes left-to-right -->
+        <ProgressBar Grid.Row="1"
+                     Minimum="0"
+                     Maximum="{Binding TimeMax, Mode=OneWay}"
+                     Value="{Binding TimeRemaining, Mode=OneWay}"
+                     BorderThickness="0"
+                     Padding="0" />
+    </Grid>
+</mah:MetroWindow>

--- a/Source/NETworkManager/NotificationWindow.xaml.cs
+++ b/Source/NETworkManager/NotificationWindow.xaml.cs
@@ -1,0 +1,195 @@
+using MahApps.Metro.IconPacks;
+using NETworkManager.Utilities;
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Forms;
+using System.Windows.Input;
+using System.Windows.Threading;
+
+namespace NETworkManager;
+
+/// <summary>
+/// A generic, stackable notification popup shown in the bottom-right corner of the primary
+/// screen. Contains no feature-specific knowledge — icon, color, title and message are all
+/// supplied by the caller (via <see cref="NotificationManager"/>).
+/// </summary>
+public partial class NotificationWindow : INotifyPropertyChanged
+{
+    #region PropertyChangedEventHandler
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    #endregion
+
+    #region Variables
+
+    private readonly DispatcherTimer _timer = new(DispatcherPriority.Render);
+    private readonly Stopwatch _stopwatch = new();
+
+    // Bound properties — all set once in the constructor, no change notifications needed.
+    // Note: the header property is named NotificationTitle (not Title) to avoid clashing with
+    // the inherited Window.Title property, which a "{Binding Title}" would otherwise resolve to.
+    public PackIconMaterialKind IconKind { get; }
+    public string IconColor { get; }
+    public string NotificationTitle { get; }
+    public string Message { get; }
+
+    // Timestamp shown in the header — captured when the notification is created, which is the
+    // moment the status change occurred.
+    public string Time { get; }
+
+    public double TimeMax { get; }
+
+    public double TimeRemaining
+    {
+        get;
+        private set
+        {
+            if (Math.Abs(value - field) < 0.001)
+                return;
+
+            field = value;
+            OnPropertyChanged();
+        }
+    }
+
+    // Command — initialized once in the constructor, not recreated on every binding access
+    public ICommand CloseCommand { get; }
+
+    #endregion
+
+    #region Constructor
+
+    public NotificationWindow(PackIconMaterialKind iconKind, string iconColor, string title, string message, int closeTimeSeconds)
+    {
+        InitializeComponent();
+        DataContext = this;
+
+        IconKind = iconKind;
+        IconColor = iconColor;
+        NotificationTitle = title;
+        Message = message;
+        Time = DateTime.Now.ToString("HH:mm:ss");
+        TimeMax = closeTimeSeconds;
+        TimeRemaining = closeTimeSeconds;
+
+        CloseCommand = new RelayCommand(_ => CloseWindow());
+
+        // The window auto-sizes its height to the content (SizeToContent=Height), so when the
+        // message wraps to more lines the whole stack must re-anchor to the bottom edge.
+        SizeChanged += (_, _) => NotificationManager.RepositionAll();
+
+        _timer.Interval = TimeSpan.FromMilliseconds(16);
+        _timer.Tick += Timer_Tick;
+    }
+
+    #endregion
+
+    #region ICommands & Actions
+
+    private void ShowMainWindow()
+    {
+        CloseWindow();
+
+        if (System.Windows.Application.Current.MainWindow is MainWindow mainWindow &&
+            mainWindow.ShowWindowCommand.CanExecute(null))
+            mainWindow.ShowWindowCommand.Execute(null);
+    }
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Called by <see cref="NotificationManager"/> when the stack changes (a sibling closes or
+    /// resizes) and this window may need to move.
+    /// </summary>
+    internal void Reposition()
+    {
+        ApplyPosition();
+    }
+
+    private void ApplyPosition()
+    {
+        if (Screen.PrimaryScreen == null)
+            return;
+
+        var scale = System.Windows.Media.VisualTreeHelper.GetDpi(this).DpiScaleX;
+        var area = Screen.PrimaryScreen.WorkingArea;
+
+        // Offset = total height (incl. margins) of all windows stacked below this one. Using the
+        // actual heights keeps variable-height popups (wrapped messages) bottom-anchored.
+        var offset = NotificationManager.GetStackOffset(this);
+
+        Left = area.Right / scale - Width - NotificationManager.WindowMargin;
+        Top = area.Bottom / scale - ActualHeight - NotificationManager.WindowMargin - offset;
+    }
+
+    private void CloseWindow()
+    {
+        _timer.Stop();
+        _stopwatch.Stop();
+
+        Closing -= MetroWindow_Closing;
+        Close(); // fires Window.Closed → NotificationManager removes from stack and repositions
+    }
+
+    #endregion
+
+    #region Events
+
+    // Lifecycle — the HWND exists here, so DPI is safe to read for positioning
+    protected override void OnSourceInitialized(EventArgs e)
+    {
+        base.OnSourceInitialized(e);
+
+        ApplyPosition();
+
+        _stopwatch.Restart();
+        _timer.Start();
+    }
+
+    // Clicking anywhere on the popup opens the main window. The close button handles its own
+    // mouse events, so clicking [×] does not bubble up here.
+    private void Root_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        ShowMainWindow();
+    }
+
+    // Intercept Alt+F4 / OS close so the stack cleanup always runs through CloseWindow()
+    private void MetroWindow_Closing(object sender, CancelEventArgs e)
+    {
+        e.Cancel = true;
+        CloseWindow();
+    }
+
+    private async void Timer_Tick(object sender, EventArgs e)
+    {
+        // Use a local for the close decision — the TimeRemaining setter ignores sub-0.001 changes
+        // (to throttle the progress bar), so reading the property back could stay stuck at a tiny
+        // positive value and the window would never close.
+        var remaining = Math.Max(0.0, TimeMax - _stopwatch.Elapsed.TotalSeconds);
+        TimeRemaining = remaining;
+
+        if (remaining > 0)
+            return;
+
+        _timer.Stop();
+        _stopwatch.Stop();
+
+        await Task.Delay(250); // let the bar visually reach zero before closing
+
+        CloseWindow();
+    }
+
+    #endregion
+}

--- a/Source/NETworkManager/StatusWindow.xaml.cs
+++ b/Source/NETworkManager/StatusWindow.xaml.cs
@@ -144,8 +144,6 @@ public partial class StatusWindow : INotifyPropertyChanged
         // Check the network connection
         Check();
 
-        enableCloseTimer = true;
-
         // Close the window after a certain time
         if (enableCloseTimer)
         {

--- a/Source/NETworkManager/ViewModels/PingMonitorSettingsViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PingMonitorSettingsViewModel.cs
@@ -144,6 +144,101 @@ public class PingMonitorSettingsViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether a notification popup is shown on status change.
+    /// </summary>
+    public bool ShowNotificationPopup
+    {
+        get;
+        set
+        {
+            if (value == field)
+                return;
+
+            if (!_isLoading)
+                SettingsManager.Current.PingMonitor_ShowNotificationPopup = value;
+
+            field = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a sound is played on status change.
+    /// </summary>
+    public bool NotificationSound
+    {
+        get;
+        set
+        {
+            if (value == field)
+                return;
+
+            if (!_isLoading)
+                SettingsManager.Current.PingMonitor_NotificationSound = value;
+
+            field = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the number of consecutive successful pings required before an UP notification fires.
+    /// </summary>
+    public int NotificationSuccessThreshold
+    {
+        get;
+        set
+        {
+            if (value == field)
+                return;
+
+            if (!_isLoading)
+                SettingsManager.Current.PingMonitor_NotificationSuccessThreshold = value;
+
+            field = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the number of consecutive failed pings required before a DOWN notification fires.
+    /// </summary>
+    public int NotificationFailureThreshold
+    {
+        get;
+        set
+        {
+            if (value == field)
+                return;
+
+            if (!_isLoading)
+                SettingsManager.Current.PingMonitor_NotificationFailureThreshold = value;
+
+            field = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the time in seconds the notification popup is shown before it closes automatically.
+    /// </summary>
+    public int NotificationCloseTime
+    {
+        get;
+        set
+        {
+            if (value == field)
+                return;
+
+            if (!_isLoading)
+                SettingsManager.Current.PingMonitor_NotificationCloseTime = value;
+
+            field = value;
+            OnPropertyChanged();
+        }
+    }
+
     #endregion
 
     #region Contructor, load settings
@@ -169,6 +264,11 @@ public class PingMonitorSettingsViewModel : ViewModelBase
         WaitTime = SettingsManager.Current.PingMonitor_WaitTime;
         ExpandHostView = SettingsManager.Current.PingMonitor_ExpandHostView;
         ChartTime = SettingsManager.Current.PingMonitor_ChartTime;
+        ShowNotificationPopup = SettingsManager.Current.PingMonitor_ShowNotificationPopup;
+        NotificationSound = SettingsManager.Current.PingMonitor_NotificationSound;
+        NotificationSuccessThreshold = SettingsManager.Current.PingMonitor_NotificationSuccessThreshold;
+        NotificationFailureThreshold = SettingsManager.Current.PingMonitor_NotificationFailureThreshold;
+        NotificationCloseTime = SettingsManager.Current.PingMonitor_NotificationCloseTime;
     }
 
     #endregion

--- a/Source/NETworkManager/ViewModels/PingMonitorViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PingMonitorViewModel.cs
@@ -544,10 +544,13 @@ public class PingMonitorViewModel : ViewModelBase
         Lost = 0;
         PacketLoss = 0;
 
-        // Reset notification threshold tracking so the initial state is re-established silently
+        // Reset notification threshold tracking so the initial state is re-established silently.
+        // IsReachable is cleared too, so a prior run's state can't linger and show a stale (e.g.
+        // green "up") icon during the first few pings before the new initial state is established.
         _consecutiveSuccesses = 0;
         _consecutiveFailures = 0;
         _initialStateEstablished = false;
+        IsReachable = false;
 
         // Reset chart
         _sessionStartTime = DateTime.Now;

--- a/Source/NETworkManager/ViewModels/PingMonitorViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PingMonitorViewModel.cs
@@ -5,6 +5,7 @@ using LiveChartsCore.SkiaSharpView;
 using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.SkiaSharpView.Painting.Effects;
 using log4net;
+using MahApps.Metro.IconPacks;
 using MahApps.Metro.SimpleChildWindow;
 using NETworkManager.Localization.Resources;
 using NETworkManager.Models.Export;
@@ -76,6 +77,13 @@ public class PingMonitorViewModel : ViewModelBase
 
     private List<PingInfo> _pingInfoList = [];
 
+    // Notification threshold tracking. The status transition (and notification) only fires once
+    // the configured number of consecutive successes/failures is reached, to avoid noise from
+    // flapping hosts. The initial state is established silently (no notification).
+    private int _consecutiveSuccesses;
+    private int _consecutiveFailures;
+    private bool _initialStateEstablished;
+
     /// <summary>
     /// Gets the title of the monitor, typically "Hostname # IP".
     /// </summary>
@@ -91,6 +99,13 @@ public class PingMonitorViewModel : ViewModelBase
             OnPropertyChanged();
         }
     }
+
+    /// <summary>
+    /// Gets the host display name used as the notification header: the hostname if available,
+    /// otherwise the IP address as a fallback.
+    /// </summary>
+    private string NotificationHostDisplay =>
+        string.IsNullOrEmpty(Hostname) ? IPAddress.ToString() : Hostname.TrimEnd('.');
 
     /// <summary>
     /// Gets the hostname of the monitored host.
@@ -529,6 +544,11 @@ public class PingMonitorViewModel : ViewModelBase
         Lost = 0;
         PacketLoss = 0;
 
+        // Reset notification threshold tracking so the initial state is re-established silently
+        _consecutiveSuccesses = 0;
+        _consecutiveFailures = 0;
+        _initialStateEstablished = false;
+
         // Reset chart
         _sessionStartTime = DateTime.Now;
         ResetTimeChart();
@@ -653,12 +673,37 @@ public class PingMonitorViewModel : ViewModelBase
 
         LvlChartsDefaultInfo timeInfo;
 
+        var successThreshold = SettingsManager.Current.PingMonitor_NotificationSuccessThreshold;
+        var failureThreshold = SettingsManager.Current.PingMonitor_NotificationFailureThreshold;
+
         if (e.Args.Status == IPStatus.Success)
         {
-            if (!IsReachable)
+            _consecutiveSuccesses++;
+            _consecutiveFailures = 0;
+
+            if (!_initialStateEstablished)
+            {
+                if (_consecutiveSuccesses >= successThreshold)
+                {
+                    _initialStateEstablished = true;
+                    StatusTime = DateTime.Now;
+                    IsReachable = true;
+                    // No notification — this is the initial state being established.
+                }
+            }
+            else if (!IsReachable && _consecutiveSuccesses >= successThreshold)
             {
                 StatusTime = DateTime.Now;
                 IsReachable = true;
+
+                if (SettingsManager.Current.PingMonitor_NotificationSound)
+                    NotificationManager.PlaySound(System.Media.SystemSounds.Asterisk); // gentle info sound for UP
+
+                if (SettingsManager.Current.PingMonitor_ShowNotificationPopup)
+                    NotificationManager.Show(
+                        PackIconMaterialKind.LanConnect, "#badc58",
+                        NotificationHostDisplay, Strings.HostIsUp,
+                        SettingsManager.Current.PingMonitor_NotificationCloseTime);
             }
 
             Received++;
@@ -667,10 +712,32 @@ public class PingMonitorViewModel : ViewModelBase
         }
         else
         {
-            if (IsReachable)
+            _consecutiveFailures++;
+            _consecutiveSuccesses = 0;
+
+            if (!_initialStateEstablished)
+            {
+                if (_consecutiveFailures >= failureThreshold)
+                {
+                    _initialStateEstablished = true;
+                    StatusTime = DateTime.Now;
+                    IsReachable = false;
+                    // No notification or sound — initial state.
+                }
+            }
+            else if (IsReachable && _consecutiveFailures >= failureThreshold)
             {
                 StatusTime = DateTime.Now;
                 IsReachable = false;
+
+                if (SettingsManager.Current.PingMonitor_NotificationSound)
+                    NotificationManager.PlaySound(System.Media.SystemSounds.Exclamation); // warning sound for DOWN
+
+                if (SettingsManager.Current.PingMonitor_ShowNotificationPopup)
+                    NotificationManager.Show(
+                        PackIconMaterialKind.LanDisconnect, "Red",
+                        NotificationHostDisplay, Strings.HostIsDown,
+                        SettingsManager.Current.PingMonitor_NotificationCloseTime);
             }
 
             Lost++;

--- a/Source/NETworkManager/Views/PingMonitorSettingsView.xaml
+++ b/Source/NETworkManager/Views/PingMonitorSettingsView.xaml
@@ -27,6 +27,45 @@
         <TextBlock Text="{x:Static localization:Strings.ChartTimeInSeconds}" Style="{StaticResource CenterTextBlock}"
                    Margin="0,0,0,10" />
         <mah:NumericUpDown Value="{Binding ChartTime}" Minimum="30" Maximum="3600" Interval="30" Margin="0,0,0,10" />
-        <mah:ToggleSwitch IsOn="{Binding ExpandHostView}" Header="{x:Static localization:Strings.ExpandHostView}" />
+        <mah:ToggleSwitch IsOn="{Binding ExpandHostView}" Header="{x:Static localization:Strings.ExpandHostView}"
+                          Margin="0,0,0,20" />
+        <TextBlock Text="{x:Static localization:Strings.PingMonitorNotification}"
+                   Style="{StaticResource HeaderTextBlock}" />
+        <mah:ToggleSwitch IsOn="{Binding ShowNotificationPopup}"
+                          Header="{x:Static localization:Strings.ShowNotificationPopupOnStatusChange}"
+                          Margin="0,0,0,10" />
+        <mah:ToggleSwitch IsOn="{Binding NotificationSound}"
+                          Header="{x:Static localization:Strings.PlaySoundOnStatusChange}"
+                          Margin="0,0,0,10" />
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+            <TextBlock Text="{x:Static localization:Strings.NotificationSuccessThreshold}"
+                       Style="{DynamicResource DefaultTextBlock}" />
+            <Rectangle Width="24" Height="24"
+                       ToolTip="{x:Static localization:Strings.HelpMessage_NotificationSuccessThreshold}"
+                       Style="{StaticResource HelpImageRectangle}" Margin="10,0,0,0">
+                <Rectangle.Resources>
+                    <Style TargetType="{x:Type ToolTip}" BasedOn="{StaticResource HelpToolTip}" />
+                </Rectangle.Resources>
+            </Rectangle>
+        </StackPanel>
+        <mah:NumericUpDown Value="{Binding NotificationSuccessThreshold}"
+                           Minimum="1" Maximum="10" Interval="1" Margin="0,0,0,10" />
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+            <TextBlock Text="{x:Static localization:Strings.NotificationFailureThreshold}"
+                       Style="{DynamicResource DefaultTextBlock}" />
+            <Rectangle Width="24" Height="24"
+                       ToolTip="{x:Static localization:Strings.HelpMessage_NotificationFailureThreshold}"
+                       Style="{StaticResource HelpImageRectangle}" Margin="10,0,0,0">
+                <Rectangle.Resources>
+                    <Style TargetType="{x:Type ToolTip}" BasedOn="{StaticResource HelpToolTip}" />
+                </Rectangle.Resources>
+            </Rectangle>
+        </StackPanel>
+        <mah:NumericUpDown Value="{Binding NotificationFailureThreshold}"
+                           Minimum="1" Maximum="10" Interval="1" Margin="0,0,0,10" />
+        <TextBlock Text="{x:Static localization:Strings.NotificationDurationInSeconds}"
+                   Style="{StaticResource CenterTextBlock}" Margin="0,0,0,10" />
+        <mah:NumericUpDown Value="{Binding NotificationCloseTime}"
+                           Minimum="3" Maximum="60" Interval="1" />
     </StackPanel>
 </UserControl>

--- a/Source/NETworkManager/Views/PingMonitorView.xaml
+++ b/Source/NETworkManager/Views/PingMonitorView.xaml
@@ -223,7 +223,7 @@
                 <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static localization:Strings.IPAddress}" />
                 <TextBox Grid.Column="2" Grid.Row="2" Text="{Binding IPAddress, Mode=OneWay}" />
                 <TextBlock Grid.Column="0" Grid.Row="4" Text="{x:Static localization:Strings.StatusChange}" />
-                <TextBox Grid.Column="2" Grid.Row="4" Text="{Binding StatusTime, Mode=OneWay, StringFormat={}{0:hh}h {0:mm}m {0:ss}s}" />
+                <TextBox Grid.Column="2" Grid.Row="4" Text="{Binding StatusTime, Mode=OneWay, StringFormat={}{0:HH:mm:ss}}" />
                 <TextBlock Grid.Column="4" Grid.Row="0" Text="{x:Static localization:Strings.Received}" />
                 <TextBox Grid.Column="6" Grid.Row="0" Text="{Binding Received, Mode=OneWay}" />
                 <TextBlock Grid.Column="4" Grid.Row="2" Text="{x:Static localization:Strings.Lost}" />

--- a/Website/docs/application/ping-monitor.md
+++ b/Website/docs/application/ping-monitor.md
@@ -61,6 +61,23 @@ Right-click a monitored host (anywhere except the chart) to open the context men
 
 Right-clicking an individual field (hostname, IP address, ...) instead lets you **Copy** its value to the clipboard.
 
+### Notifications
+
+When a monitored host changes its reachability state (up → down or down → up), a small notification popup can appear in the bottom-right corner of the primary screen, optionally accompanied by a system sound.
+
+- The popup shows a status icon (green when the host is up, red when it is down), the hostname (or the IP address as a fallback) and the current status (**Host is up** / **Host is down**).
+- Multiple notifications **stack** upwards, so several hosts changing state at once are all visible.
+- **Click anywhere** on a notification to bring the main window to the front. Use the **×** button to dismiss a single notification without opening the main window.
+- Each notification closes automatically after a configurable [duration](#display-duration-seconds); a thin progress bar at the bottom shows the remaining time.
+- To avoid noise from flapping hosts, a state change is only reported after a configurable number of consecutive successes ([Success threshold](#success-threshold)) or failures ([Failure threshold](#failure-threshold)).
+- The **initial** state of a host (established when monitoring starts) never triggers a notification or sound — only later transitions do.
+
+:::note
+
+When many hosts change state at almost the same time (for example, when an uplink goes down and all hosts time out together), every host still shows its own popup, but the sound is played only once within a short interval to avoid an overlapping cacophony.
+
+:::
+
 ## Profile
 
 ### Inherit host from general
@@ -147,3 +164,43 @@ Expand the host view to show more information when the host is added.
 **Type:** `Boolean`
 
 **Default:** `Disabled`
+
+### Show notification popup on status change
+
+Show a notification popup in the bottom-right corner of the primary screen when a monitored host changes its reachability state. See [Notifications](#notifications) for details.
+
+**Type:** `Boolean`
+
+**Default:** `Enabled`
+
+### Play sound on status change
+
+Play a system sound when a monitored host changes its reachability state. This is independent of the [popup](#show-notification-popup-on-status-change) — you can enable the sound without the popup, or vice versa.
+
+**Type:** `Boolean`
+
+**Default:** `Enabled`
+
+### Success threshold
+
+Number of consecutive successful pings required before an **Host is up** notification is shown. Higher values reduce noise from flapping hosts.
+
+**Type:** `Integer` [Min `1`, Max `10`]
+
+**Default:** `1`
+
+### Failure threshold
+
+Number of consecutive failed pings (timeouts) required before an **Host is down** notification is shown. Higher values reduce noise from flapping hosts.
+
+**Type:** `Integer` [Min `1`, Max `10`]
+
+**Default:** `3`
+
+### Display duration (seconds)
+
+Time in seconds the notification popup is shown before it closes automatically.
+
+**Type:** `Integer` [Min `3`, Max `60`]
+
+**Default:** `10`

--- a/Website/docs/application/ping-monitor.md
+++ b/Website/docs/application/ping-monitor.md
@@ -191,7 +191,7 @@ Number of consecutive successful pings required before a **Host is up** notifica
 
 ### Failure threshold
 
-Number of consecutive failed pings (timeouts) required before an **Host is down** notification is shown. Higher values reduce noise from flapping hosts.
+Number of consecutive failed pings (timeouts) required before a **Host is down** notification is shown. Higher values reduce noise from flapping hosts.
 
 **Type:** `Integer` [Min `1`, Max `10`]
 

--- a/Website/docs/application/ping-monitor.md
+++ b/Website/docs/application/ping-monitor.md
@@ -183,7 +183,7 @@ Play a system sound when a monitored host changes its reachability state. This i
 
 ### Success threshold
 
-Number of consecutive successful pings required before an **Host is up** notification is shown. Higher values reduce noise from flapping hosts.
+Number of consecutive successful pings required before a **Host is up** notification is shown. Higher values reduce noise from flapping hosts.
 
 **Type:** `Integer` [Min `1`, Max `10`]
 

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -66,7 +66,7 @@ Release date: **xx.xx.2025**
 
 **Ping Monitor**
 
-- New **status change notifications**: when a monitored host goes up or down, a stackable popup appears in the bottom-right corner of the primary screen and/or an optional system sound is played. Configurable **success** and **failure thresholds** suppress noise from flapping hosts, the initial state is established silently, and clicking a popup brings the main window to the front. When many hosts change state at once, every host still shows its own popup but the sound is played only once. (See the [documentation](https://borntoberoot.net/NETworkManager/docs/application/ping-monitor#notifications) for more details) [#XXXX](https://github.com/BornToBeRoot/NETworkManager/pull/XXXX)
+- New **status change notifications**: when a monitored host goes up or down, a stackable popup appears in the bottom-right corner of the primary screen and/or an optional system sound is played. Configurable **success** and **failure thresholds** suppress noise from flapping hosts, the initial state is established silently, and clicking a popup brings the main window to the front. When many hosts change state at once, every host still shows its own popup but the sound is played only once. (See the [documentation](https://borntoberoot.net/NETworkManager/docs/application/ping-monitor#notifications) for more details) [#3471](https://github.com/BornToBeRoot/NETworkManager/pull/3471)
 
 ## Improvements
 
@@ -133,11 +133,11 @@ Release date: **xx.xx.2025**
 
 **Dashboard**
 
-- Fixed the Status Window auto-close timer firing even when the window was opened manually. The `enableCloseTimer` parameter is now respected, so a manually opened Status Window stays open while the one shown automatically on a network change still closes after the configured time. [#XXXX](https://github.com/BornToBeRoot/NETworkManager/pull/XXXX)
+- Fixed the Status Window auto-close timer firing even when the window was opened manually. The `enableCloseTimer` parameter is now respected, so a manually opened Status Window stays open while the one shown automatically on a network change still closes after the configured time. [#3471](https://github.com/BornToBeRoot/NETworkManager/pull/3471)
 
 **Ping Monitor**
 
-- Fixed the **Status change** field showing the time of day formatted as if it were a duration (e.g. `02h 30m 25s` for 14:30:25). It now correctly shows the time of the last status change as `HH:mm:ss`. [#XXXX](https://github.com/BornToBeRoot/NETworkManager/pull/XXXX)
+- Fixed the **Status change** field showing the time of day formatted as if it were a duration (e.g. `02h 30m 25s` for 14:30:25). It now correctly shows the time of the last status change as `HH:mm:ss`. [#3471](https://github.com/BornToBeRoot/NETworkManager/pull/3471)
 
 **Network Interface**
 

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -64,6 +64,10 @@ Release date: **xx.xx.2025**
 
 - Profiles can now be imported from **Active Directory**. Search for computers by name using an AD query, select the results, assign a group, and apply connection settings (RDP, SSH, etc.) before importing. [#3368](https://github.com/BornToBeRoot/NETworkManager/pull/3368)
 
+**Ping Monitor**
+
+- New **status change notifications**: when a monitored host goes up or down, a stackable popup appears in the bottom-right corner of the primary screen and/or an optional system sound is played. Configurable **success** and **failure thresholds** suppress noise from flapping hosts, the initial state is established silently, and clicking a popup brings the main window to the front. When many hosts change state at once, every host still shows its own popup but the sound is played only once. (See the [documentation](https://borntoberoot.net/NETworkManager/docs/application/ping-monitor#notifications) for more details) [#XXXX](https://github.com/BornToBeRoot/NETworkManager/pull/XXXX)
+
 ## Improvements
 
 **WiFi**
@@ -126,6 +130,14 @@ Release date: **xx.xx.2025**
 **PuTTY**
 
 - Fixed incorrect initial embedded window size on high-DPI monitors. The `WindowsFormsHost` panel now sets its initial dimensions in physical pixels using the current DPI scale factor, ensuring the PuTTY window fills the panel correctly at startup. [#3352](https://github.com/BornToBeRoot/NETworkManager/pull/3352)
+
+**Dashboard**
+
+- Fixed the Status Window auto-close timer firing even when the window was opened manually. The `enableCloseTimer` parameter is now respected, so a manually opened Status Window stays open while the one shown automatically on a network change still closes after the configured time. [#XXXX](https://github.com/BornToBeRoot/NETworkManager/pull/XXXX)
+
+**Ping Monitor**
+
+- Fixed the **Status change** field showing the time of day formatted as if it were a duration (e.g. `02h 30m 25s` for 14:30:25). It now correctly shows the time of the last status change as `HH:mm:ss`. [#XXXX](https://github.com/BornToBeRoot/NETworkManager/pull/XXXX)
 
 **Network Interface**
 


### PR DESCRIPTION
## Changes proposed in this pull request

- Notifications Manager added
- Ping host up/down notification added

## Related issue(s)

- Fix #194
- Fix #3351 

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request introduces a new, reusable notification popup system for the application, allowing for stackable, customizable notifications (such as status change alerts) in the bottom-right corner of the screen. It adds both the UI and logic for these notifications, provides new settings for notification behavior, and localizes the relevant strings. The most important changes are:

**Notification Popup System:**

* Added a new `NotificationManager` class that manages the display and stacking of notification popups, including sound throttling to prevent audio spam from bursts of status changes. (`Source/NETworkManager/NotificationManager.cs`)
* Introduced a new `NotificationWindow` WPF window, with customizable icon, color, title, message, and auto-close timer, including logic for positioning, stacking, and user interaction (click to open main window, close button, etc.). (`Source/NETworkManager/NotificationWindow.xaml`, `Source/NETworkManager/NotificationWindow.xaml.cs`) [[1]](diffhunk://#diff-665c8fb9ba4ce6da872ec8ec5879c9f96ecc080bcb6519abda91ed76d2ff6da8R1-R119) [[2]](diffhunk://#diff-82fb34cc415da3207d31bd73e7e546aad41cb27968c63bdb70ea61912ef1fdf7R1-R195)

**Settings and Configuration:**

* Added new global static configuration options for notification behavior, such as default thresholds, popup visibility, sound, and close time. (`Source/NETworkManager.Settings/GlobalStaticConfiguration.cs`) [[1]](diffhunk://#diff-89a71de984f1ae498641e2e11101c9f4a97c8e1f07939aa41da341126932fe06R33-R37) [[2]](diffhunk://#diff-89a71de984f1ae498641e2e11101c9f4a97c8e1f07939aa41da341126932fe06R155-R161)
* Extended the `SettingsInfo` class with properties for user-configurable notification settings, supporting property change notifications for UI binding. (`Source/NETworkManager.Settings/SettingsInfo.cs`)

**Localization:**

* Added localized string resources and accessors for all notification-related UI and settings, ensuring proper internationalization. (`Source/NETworkManager.Localization/Resources/Strings.resx`, `Source/NETworkManager.Localization/Resources/Strings.Designer.cs`) [[1]](diffhunk://#diff-aa5828c7aa59a68d20ce70a1088e4bd1038a53bac7f9eac6398a7b6e466f9df8R2370-R2399) [[2]](diffhunk://#diff-fd26c2c2130e727ae40f1060c182242ce89c894d95f0168fa6443e230da8e4e0R11122-R11211)

</details>

## To-Do

- [x] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs) to reflect this changes
- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
