### PR TITLE
Feature: Remote desktop additional shortcuts

### DIFF
--- a/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
+++ b/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
@@ -2465,7 +2465,52 @@ namespace NETworkManager.Localization.Resources {
                 return ResourceManager.GetString("CtrlAltDel", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Task Manager (Ctrl+Shift+Esc).
+        /// </summary>
+        public static string TaskManager {
+            get {
+                return ResourceManager.GetString("TaskManager", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Lock (Win+L).
+        /// </summary>
+        public static string Lock {
+            get {
+                return ResourceManager.GetString("Lock", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Show Desktop (Win+D).
+        /// </summary>
+        public static string ShowDesktop {
+            get {
+                return ResourceManager.GetString("ShowDesktop", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Explorer (Win+E).
+        /// </summary>
+        public static string Explorer {
+            get {
+                return ResourceManager.GetString("Explorer", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Run dialog (Win+R).
+        /// </summary>
+        public static string RunDialog {
+            get {
+                return ResourceManager.GetString("RunDialog", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Currency.
         /// </summary>

--- a/Source/NETworkManager.Localization/Resources/Strings.resx
+++ b/Source/NETworkManager.Localization/Resources/Strings.resx
@@ -2250,6 +2250,21 @@ $$hostname$$	--&gt;	Hostname</value>
   <data name="CtrlAltDel" xml:space="preserve">
     <value>Ctrl+Alt+Del</value>
   </data>
+  <data name="TaskManager" xml:space="preserve">
+    <value>Task Manager (Ctrl+Shift+Esc)</value>
+  </data>
+  <data name="Lock" xml:space="preserve">
+    <value>Lock (Win+L)</value>
+  </data>
+  <data name="ShowDesktop" xml:space="preserve">
+    <value>Show Desktop (Win+D)</value>
+  </data>
+  <data name="Explorer" xml:space="preserve">
+    <value>Explorer (Win+E)</value>
+  </data>
+  <data name="RunDialog" xml:space="preserve">
+    <value>Run dialog (Win+R)</value>
+  </data>
   <data name="KeyboardShortcuts" xml:space="preserve">
     <value>Keyboard shortcuts</value>
   </data>

--- a/Source/NETworkManager.Models/RemoteDesktop/Keystroke.cs
+++ b/Source/NETworkManager.Models/RemoteDesktop/Keystroke.cs
@@ -8,5 +8,30 @@ public enum Keystroke
     /// <summary>
     ///     Ctrl + Alt + Del keystroke.
     /// </summary>
-    CtrlAltDel
+    CtrlAltDel,
+
+    /// <summary>
+    ///     Ctrl + Shift + Esc keystroke (opens Task Manager).
+    /// </summary>
+    TaskManager,
+
+    /// <summary>
+    ///     Win + L keystroke (locks the session).
+    /// </summary>
+    Lock,
+
+    /// <summary>
+    ///     Win + D keystroke (shows the desktop / minimizes all windows).
+    /// </summary>
+    ShowDesktop,
+
+    /// <summary>
+    ///     Win + E keystroke (opens File Explorer).
+    /// </summary>
+    Explorer,
+
+    /// <summary>
+    ///     Win + R keystroke (opens the Run dialog).
+    /// </summary>
+    RunDialog
 }

--- a/Source/NETworkManager.Models/RemoteDesktop/RemoteDesktop.cs
+++ b/Source/NETworkManager.Models/RemoteDesktop/RemoteDesktop.cs
@@ -38,6 +38,26 @@ public static class RemoteDesktop
                 info.ArrayKeyUp = [false, false, false, true, true, true];
                 info.KeyData = [0x1d, 0x38, 0x53, 0x53, 0x38, 0x1d];
                 break;
+            case Keystroke.TaskManager: // Ctrl + Shift + Esc
+                info.ArrayKeyUp = [false, false, false, true, true, true];
+                info.KeyData = [0x1d, 0x2a, 0x01, 0x01, 0x2a, 0x1d];
+                break;
+            case Keystroke.Lock: // Win + L
+                info.ArrayKeyUp = [false, false, true, true];
+                info.KeyData = [0x15b, 0x26, 0x26, 0x15b];
+                break;
+            case Keystroke.ShowDesktop: // Win + D
+                info.ArrayKeyUp = [false, false, true, true];
+                info.KeyData = [0x15b, 0x20, 0x20, 0x15b];
+                break;
+            case Keystroke.Explorer: // Win + E
+                info.ArrayKeyUp = [false, false, true, true];
+                info.KeyData = [0x15b, 0x12, 0x12, 0x15b];
+                break;
+            case Keystroke.RunDialog: // Win + R
+                info.ArrayKeyUp = [false, false, true, true];
+                info.KeyData = [0x15b, 0x13, 0x13, 0x15b];
+                break;
         }
 
         return info;

--- a/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml
+++ b/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml
@@ -160,6 +160,26 @@
                                                                     Header="{x:Static localization:Strings.CtrlAltDel}"
                                                                     Command="{Binding Data.RemoteDesktop_SendCtrlAltDelCommand, Source={StaticResource BindingProxy}}"
                                                                     CommandParameter="{Binding View}" />
+                                                                <MenuItem
+                                                                    Header="{x:Static localization:Strings.TaskManager}"
+                                                                    Command="{Binding Data.RemoteDesktop_SendTaskManagerCommand, Source={StaticResource BindingProxy}}"
+                                                                    CommandParameter="{Binding View}" />
+                                                                <MenuItem
+                                                                    Header="{x:Static localization:Strings.Lock}"
+                                                                    Command="{Binding Data.RemoteDesktop_SendLockCommand, Source={StaticResource BindingProxy}}"
+                                                                    CommandParameter="{Binding View}" />
+                                                                <MenuItem
+                                                                    Header="{x:Static localization:Strings.ShowDesktop}"
+                                                                    Command="{Binding Data.RemoteDesktop_SendShowDesktopCommand, Source={StaticResource BindingProxy}}"
+                                                                    CommandParameter="{Binding View}" />
+                                                                <MenuItem
+                                                                    Header="{x:Static localization:Strings.Explorer}"
+                                                                    Command="{Binding Data.RemoteDesktop_SendExplorerCommand, Source={StaticResource BindingProxy}}"
+                                                                    CommandParameter="{Binding View}" />
+                                                                <MenuItem
+                                                                    Header="{x:Static localization:Strings.RunDialog}"
+                                                                    Command="{Binding Data.RemoteDesktop_SendRunDialogCommand, Source={StaticResource BindingProxy}}"
+                                                                    CommandParameter="{Binding View}" />
                                                             </MenuItem>
                                                         </ContextMenu>
                                                     </Grid.ContextMenu>

--- a/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
+++ b/Source/NETworkManager/Controls/DragablzTabHostWindow.xaml.cs
@@ -222,16 +222,31 @@ public sealed partial class DragablzTabHostWindow : INotifyPropertyChanged
     }
 
     public ICommand RemoteDesktop_SendCtrlAltDelCommand =>
-        new RelayCommand(RemoteDesktop_SendCtrlAltDelAction, RemoteDesktop_IsConnectedAndNotViewOnly_CanExecute);
+        new RelayCommand(view => RemoteDesktop_SendKeyAction(view, Keystroke.CtrlAltDel), RemoteDesktop_IsConnectedAndNotViewOnly_CanExecute);
 
-    private async void RemoteDesktop_SendCtrlAltDelAction(object view)
+    public ICommand RemoteDesktop_SendTaskManagerCommand =>
+        new RelayCommand(view => RemoteDesktop_SendKeyAction(view, Keystroke.TaskManager), RemoteDesktop_IsConnectedAndNotViewOnly_CanExecute);
+
+    public ICommand RemoteDesktop_SendLockCommand =>
+        new RelayCommand(view => RemoteDesktop_SendKeyAction(view, Keystroke.Lock), RemoteDesktop_IsConnectedAndNotViewOnly_CanExecute);
+
+    public ICommand RemoteDesktop_SendShowDesktopCommand =>
+        new RelayCommand(view => RemoteDesktop_SendKeyAction(view, Keystroke.ShowDesktop), RemoteDesktop_IsConnectedAndNotViewOnly_CanExecute);
+
+    public ICommand RemoteDesktop_SendExplorerCommand =>
+        new RelayCommand(view => RemoteDesktop_SendKeyAction(view, Keystroke.Explorer), RemoteDesktop_IsConnectedAndNotViewOnly_CanExecute);
+
+    public ICommand RemoteDesktop_SendRunDialogCommand =>
+        new RelayCommand(view => RemoteDesktop_SendKeyAction(view, Keystroke.RunDialog), RemoteDesktop_IsConnectedAndNotViewOnly_CanExecute);
+
+    private void RemoteDesktop_SendKeyAction(object view, Keystroke keystroke)
     {
         if (view is not RemoteDesktopControl control)
             return;
 
         try
         {
-            control.SendKey(Keystroke.CtrlAltDel);
+            control.SendKey(keystroke);
         }
         catch (Exception ex)
         {

--- a/Source/NETworkManager/Controls/RemoteDesktopControl.xaml.cs
+++ b/Source/NETworkManager/Controls/RemoteDesktopControl.xaml.cs
@@ -508,7 +508,7 @@ public partial class RemoteDesktopControl : UserControlBase, IDragablzTabItem
 
         RdpClient.Focus();
 
-        ocx.SendKeys(info.KeyData.Length, info.ArrayKeyUp, info.KeyData);
+        ocx?.SendKeys(info.KeyData.Length, info.ArrayKeyUp, info.KeyData);
     }
 
     /// <summary>

--- a/Source/NETworkManager/ViewModels/RemoteDesktopHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/RemoteDesktopHostViewModel.cs
@@ -351,16 +351,31 @@ public class RemoteDesktopHostViewModel : ViewModelBase, IProfileManager
     }
 
     public ICommand SendCtrlAltDelCommand =>
-        new RelayCommand(SendCtrlAltDelAction, IsConnectedAndNotViewOnly_CanExecute);
+        new RelayCommand(view => SendKeyAction(view, Keystroke.CtrlAltDel), IsConnectedAndNotViewOnly_CanExecute);
 
-    private async void SendCtrlAltDelAction(object view)
+    public ICommand SendTaskManagerCommand =>
+        new RelayCommand(view => SendKeyAction(view, Keystroke.TaskManager), IsConnectedAndNotViewOnly_CanExecute);
+
+    public ICommand SendLockCommand =>
+        new RelayCommand(view => SendKeyAction(view, Keystroke.Lock), IsConnectedAndNotViewOnly_CanExecute);
+
+    public ICommand SendShowDesktopCommand =>
+        new RelayCommand(view => SendKeyAction(view, Keystroke.ShowDesktop), IsConnectedAndNotViewOnly_CanExecute);
+
+    public ICommand SendExplorerCommand =>
+        new RelayCommand(view => SendKeyAction(view, Keystroke.Explorer), IsConnectedAndNotViewOnly_CanExecute);
+
+    public ICommand SendRunDialogCommand =>
+        new RelayCommand(view => SendKeyAction(view, Keystroke.RunDialog), IsConnectedAndNotViewOnly_CanExecute);
+
+    private async void SendKeyAction(object view, Keystroke keystroke)
     {
         if (view is not RemoteDesktopControl control)
             return;
 
         try
         {
-            control.SendKey(Keystroke.CtrlAltDel);
+            control.SendKey(keystroke);
         }
         catch (Exception ex)
         {

--- a/Source/NETworkManager/Views/RemoteDesktopHostView.xaml
+++ b/Source/NETworkManager/Views/RemoteDesktopHostView.xaml
@@ -142,6 +142,21 @@
                                         <MenuItem Header="{x:Static localization:Strings.CtrlAltDel}"
                                                   Command="{Binding Data.SendCtrlAltDelCommand, Source={StaticResource BindingProxy}}"
                                                   CommandParameter="{Binding View}" />
+                                        <MenuItem Header="{x:Static localization:Strings.TaskManager}"
+                                                  Command="{Binding Data.SendTaskManagerCommand, Source={StaticResource BindingProxy}}"
+                                                  CommandParameter="{Binding View}" />
+                                        <MenuItem Header="{x:Static localization:Strings.Lock}"
+                                                  Command="{Binding Data.SendLockCommand, Source={StaticResource BindingProxy}}"
+                                                  CommandParameter="{Binding View}" />
+                                        <MenuItem Header="{x:Static localization:Strings.ShowDesktop}"
+                                                  Command="{Binding Data.SendShowDesktopCommand, Source={StaticResource BindingProxy}}"
+                                                  CommandParameter="{Binding View}" />
+                                        <MenuItem Header="{x:Static localization:Strings.Explorer}"
+                                                  Command="{Binding Data.SendExplorerCommand, Source={StaticResource BindingProxy}}"
+                                                  CommandParameter="{Binding View}" />
+                                        <MenuItem Header="{x:Static localization:Strings.RunDialog}"
+                                                  Command="{Binding Data.SendRunDialogCommand, Source={StaticResource BindingProxy}}"
+                                                  CommandParameter="{Binding View}" />
                                     </MenuItem>
                                 </ContextMenu>
                             </Grid.ContextMenu>

--- a/Website/docs/application/remote-desktop.md
+++ b/Website/docs/application/remote-desktop.md
@@ -37,6 +37,11 @@ Right-clicking a session tab opens a context menu:
 | **Adjust screen**                     | Adjusts the screen size to the current view size; only available if [Display](#display) is set to `Adjust screen automatically` or `Use the current view size as screen size` (only if connected) |
 | **View only**                         | Toggles [view only](#view-only) mode, which blocks keyboard and mouse input to the remote session while the screen keeps updating (only if connected)                                             |
 | **Keyboard shortcuts > Ctrl+Alt+Del** | Sends Ctrl+Alt+Del to the remote computer (only if connected and not in view only mode)                                                                                                           |
+| **Keyboard shortcuts > Task Manager** | Sends Ctrl+Shift+Esc to the remote computer, opening Task Manager directly (only if connected and not in view only mode)                                                                           |
+| **Keyboard shortcuts > Lock**         | Sends Win+L to the remote computer, locking the session (only if connected and not in view only mode)                                                                                             |
+| **Keyboard shortcuts > Show Desktop** | Sends Win+D to the remote computer, minimizing all windows (only if connected and not in view only mode)                                                                                          |
+| **Keyboard shortcuts > Explorer**     | Sends Win+E to the remote computer, opening File Explorer (only if connected and not in view only mode)                                                                                           |
+| **Keyboard shortcuts > Run dialog**   | Sends Win+R to the remote computer, opening the Run dialog (only if connected and not in view only mode)                                                                                          |
 
 ## Connect
 
@@ -127,7 +132,7 @@ Connect to the admin (console) session of the remote computer.
 
 ### View only
 
-Connect in view only mode. Keyboard and mouse input to the remote session is blocked while the screen keeps updating, so the session can be monitored without interacting with it. View only mode can also be toggled on the fly via the [tab context menu](#tab-context-menu). While it is active, an eye icon is shown on the tab and the **Fullscreen** and **Ctrl+Alt+Del** actions are disabled to prevent bypassing it.
+Connect in view only mode. Keyboard and mouse input to the remote session is blocked while the screen keeps updating, so the session can be monitored without interacting with it. View only mode can also be toggled on the fly via the [tab context menu](#tab-context-menu). While it is active, an eye icon is shown on the tab and the **Fullscreen** action and all **Keyboard shortcuts** are disabled to prevent bypassing it.
 
 **Type:** `Boolean`
 

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -70,7 +70,8 @@ Release date: **xx.xx.2025**
 
 **Remote Desktop**
 
-- New **View only** mode to monitor a session without sending input: keyboard and mouse are blocked while the screen keeps updating. It can be enabled in the connect dialog, per profile/group, and globally (inherited Global → Group → Profile), or toggled on the fly via the tab's right-click menu. An eye icon on the tab indicates when a session is view-only, and the **Fullscreen** and **Ctrl+Alt+Del** actions are disabled while it is active to prevent bypassing it. [#3482](https://github.com/BornToBeRoot/NETworkManager/pull/3482)
+- New **View only** mode to monitor a session without sending input: keyboard and mouse are blocked while the screen keeps updating. It can be enabled in the connect dialog, per profile/group, and globally (inherited Global → Group → Profile), or toggled on the fly via the tab's right-click menu. An eye icon on the tab indicates when a session is view-only, and the **Fullscreen** action and all **Keyboard shortcuts** are disabled while it is active to prevent bypassing it. [#3482](https://github.com/BornToBeRoot/NETworkManager/pull/3482)
+- The tab context menu's **Keyboard shortcuts** submenu now also includes **Task Manager** (`Ctrl+Shift+Esc`), **Lock** (`Win+L`), **Show Desktop** (`Win+D`), **Explorer** (`Win+E`) and **Run dialog** (`Win+R`), in addition to the existing **Ctrl+Alt+Del**. Like Ctrl+Alt+Del, these are sent directly via scan codes into the remote session, bypassing local key interception. [#3500](https://github.com/BornToBeRoot/NETworkManager/pull/3500)
 
 **Language**
 


### PR DESCRIPTION
## Changes proposed in this pull request
- Add additional shortscuts to remote desktop
-

## Related issue(s)

- Fixes #2967 

## Copilot generated summary

Provide a Copilot generated summary of the changes in this pull request.

<details>
<summary>Copilot summary</summary>

This pull request adds support for sending additional common Windows keyboard shortcuts to remote desktop sessions, making it easier for users to perform actions like opening Task Manager, locking the session, and more. The changes introduce new keystroke options, update the UI to include these shortcuts in context menus, and enhance documentation to describe the new features.

**Remote Desktop Keyboard Shortcut Enhancements:**

* Added new keystrokes to the `Keystroke` enum: Task Manager (Ctrl+Shift+Esc), Lock (Win+L), Show Desktop (Win+D), Explorer (Win+E), and Run Dialog (Win+R). (`Keystroke.cs`)
* Implemented logic for sending these new keystrokes in `RemoteDesktop.GetKeystroke` and updated the `SendKey` method to support them. (`RemoteDesktop.cs`, `RemoteDesktopControl.xaml.cs`) [[1]](diffhunk://#diff-9fc123f6c3bb96b914878431511b89dd41c93b19653b93528cf669bb6ff3639dR41-R60) [[2]](diffhunk://#diff-12cd39721d86b0dfa0e88a33ab58efdb58f74b01b9b722ddcf7901c7cdd82e32L511-R511)

**UI and Command Updates:**

* Updated context menus in both `DragablzTabHostWindow.xaml` and `RemoteDesktopHostView.xaml` to provide menu items for the new keyboard shortcuts, each bound to a corresponding command. [[1]](diffhunk://#diff-43a4e1b6e3a8ee87958ee39afe746d0b95912514492963251a0f272d132e9184R163-R182) [[2]](diffhunk://#diff-ab83d22236ff941d93a725a2d337a6cce27d1e27f9f843fba8272676f936a4ffR145-R159)
* Added new `ICommand` properties and refactored command handling in the code-behind and view models to support the new shortcuts, using a unified method for sending keystrokes. (`DragablzTabHostWindow.xaml.cs`, `RemoteDesktopHostViewModel.cs`) [[1]](diffhunk://#diff-1df06ffe3e7e8d00cff91456190920240b86ffc6413a9c47441e467c01397d09L225-R249) [[2]](diffhunk://#diff-8a50666e850b4c9082aff517feb48fc5331901f588b7ece6a7771d22e914e8f9L354-R378)

**Localization and Documentation:**

* Added localized strings for the new shortcuts in `Strings.resx` and exposed them in `Strings.Designer.cs`. [[1]](diffhunk://#diff-aa5828c7aa59a68d20ce70a1088e4bd1038a53bac7f9eac6398a7b6e466f9df8R2253-R2267) [[2]](diffhunk://#diff-fd26c2c2130e727ae40f1060c182242ce89c894d95f0168fa6443e230da8e4e0R2469-R2513)
* Updated documentation to describe the new keyboard shortcuts in the context menu and clarified that all keyboard shortcuts are disabled in view-only mode. (`remote-desktop.md`) [[1]](diffhunk://#diff-88d19ded94f89abf6285a87134baa884ae6ec69162a3fe4df96dcea2426692fcR40-R44) [[2]](diffhunk://#diff-88d19ded94f89abf6285a87134baa884ae6ec69162a3fe4df96dcea2426692fcL130-R135)

</details>

## To-Do

- [x] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs) to reflect this changes
- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
