### PR TITLE
Feature: Remove ThreadPool workaround and make scanner async

### DIFF
--- a/Source/GlobalAssemblyInfo.cs
+++ b/Source/GlobalAssemblyInfo.cs
@@ -6,5 +6,5 @@ using System.Reflection;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("2026.7.12.0")]
-[assembly: AssemblyFileVersion("2026.7.12.0")]
+[assembly: AssemblyVersion("2026.8.5.0")]
+[assembly: AssemblyFileVersion("2026.8.5.0")]

--- a/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
+++ b/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
@@ -5284,21 +5284,6 @@ namespace NETworkManager.Localization.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This setting specifies the minimum number of threads that will be created from the application&apos;s ThreadPool on demand. This can improve the performance for example of the IP scanner or port scanner.
-        ///	
-        ///The value is added to the default min. threads (number of CPU threads). The value 0 leaves the default settings. If the value is higher than the default max. threads of the ThreadPool, this value is used.
-        ///
-        ///If the value is too high, performance problems may occur.
-        ///
-        ///Changes to this value will take effect a [rest of string was truncated]&quot;;.
-        /// </summary>
-        public static string HelpMessage_ThreadPoolAdditionalMinThreads {
-            get {
-                return ResourceManager.GetString("HelpMessage_ThreadPoolAdditionalMinThreads", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Use custom themes to personalize the appearance of the application. You can edit or add theme in the &quot;Program Folder &gt; Themes&quot; directory. For more details, refer to the documentation..
         /// </summary>
         public static string HelpMessage_UseCustomThemes {
@@ -6891,16 +6876,6 @@ namespace NETworkManager.Localization.Resources {
                 return ResourceManager.GetString("MaxPortThreads", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to These settings only change the maximum number of concurrently executed threads per host/port scan. Go to Settings &gt; General &gt; General to adjust the (min) threads of the application..
-        /// </summary>
-        public static string MaxThreadsOnlyGoToSettingsGeneralGeneral {
-            get {
-                return ResourceManager.GetString("MaxThreadsOnlyGoToSettingsGeneralGeneral", resourceCulture);
-            }
-        }
-        
         /// <summary>
         ///   Looks up a localized string similar to Measured time.
         /// </summary>
@@ -11941,15 +11916,6 @@ namespace NETworkManager.Localization.Resources {
         public static string ThisWillResetAllSettings {
             get {
                 return ResourceManager.GetString("ThisWillResetAllSettings", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to ThreadPool additional min. threads.
-        /// </summary>
-        public static string ThreadPoolAdditionalMinThreads {
-            get {
-                return ResourceManager.GetString("ThreadPoolAdditionalMinThreads", resourceCulture);
             }
         }
         

--- a/Source/NETworkManager.Localization/Resources/Strings.resx
+++ b/Source/NETworkManager.Localization/Resources/Strings.resx
@@ -3353,21 +3353,6 @@ If the option is disabled again, the values are no longer modified. However, the
   <data name="PingStatus" xml:space="preserve">
     <value>Ping status</value>
   </data>
-  <data name="ThreadPoolAdditionalMinThreads" xml:space="preserve">
-    <value>ThreadPool additional min. threads</value>
-  </data>
-  <data name="HelpMessage_ThreadPoolAdditionalMinThreads" xml:space="preserve">
-    <value>This setting specifies the minimum number of threads that will be created from the application's ThreadPool on demand. This can improve the performance for example of the IP scanner or port scanner.
-	
-The value is added to the default min. threads (number of CPU threads). The value 0 leaves the default settings. If the value is higher than the default max. threads of the ThreadPool, this value is used.
-
-If the value is too high, performance problems may occur.
-
-Changes to this value will take effect after the application is restarted. Whether the value was set successfully can be seen in the log file under %LocalAppData%\NETworkManager\NETworkManager.log</value>
-  </data>
-  <data name="MaxThreadsOnlyGoToSettingsGeneralGeneral" xml:space="preserve">
-    <value>These settings only change the maximum number of concurrently executed threads per host/port scan. Go to Settings &gt; General &gt; General to adjust the (min) threads of the application.</value>
-  </data>
   <data name="PortStatus" xml:space="preserve">
     <value>Port status</value>
   </data>

--- a/Source/NETworkManager.Models/Network/HostRangeHelper.cs
+++ b/Source/NETworkManager.Models/Network/HostRangeHelper.cs
@@ -144,7 +144,7 @@ public static class HostRangeHelper
                 // example.com
                 case var _ when RegexHelper.HostnameOrDomainRegex().IsMatch(host):
                     var dnsResult = await DNSClientHelper.ResolveAorAaaaAsync(host, dnsResolveHostnamePreferIPv4)
-                        .ConfigureAwait(false);
+                        .WaitAsync(ct).ConfigureAwait(false);
 
                     if (!dnsResult.HasError)
                         hostsBag.Add((IPAddress.Parse($"{dnsResult.Value}"), host));
@@ -160,7 +160,7 @@ public static class HostRangeHelper
 
                     // Only support IPv4
                     var dnsResultWithSubnet = await DNSClientHelper.ResolveAorAaaaAsync(hostAndSubnet[0], true)
-                        .ConfigureAwait(false);
+                        .WaitAsync(ct).ConfigureAwait(false);
 
                     if (!dnsResultWithSubnet.HasError)
                     {

--- a/Source/NETworkManager.Models/Network/HostRangeHelper.cs
+++ b/Source/NETworkManager.Models/Network/HostRangeHelper.cs
@@ -29,19 +29,14 @@ public static class HostRangeHelper
             .ToArray();
     }
 
-    public static Task<(List<(IPAddress ipAddress, string hostname)> hosts, List<string> hostnamesNotResolved)>
+    public static async Task<(List<(IPAddress ipAddress, string hostname)> hosts, List<string> hostnamesNotResolved)>
         ResolveAsync(IEnumerable<string> hosts, bool dnsResolveHostnamePreferIPv4, CancellationToken cancellationToken)
-    {
-        return Task.Run(() => Resolve(hosts, dnsResolveHostnamePreferIPv4, cancellationToken), cancellationToken);
-    }
-
-    private static (List<(IPAddress ipAddress, string hostname)> hosts, List<string> hostnamesNotResolved) Resolve(
-        IEnumerable<string> hosts, bool dnsResolveHostnamePreferIPv4, CancellationToken cancellationToken)
     {
         var hostsBag = new ConcurrentBag<(IPAddress ipAddress, string hostname)>();
         var hostnamesNotResovledBag = new ConcurrentBag<string>();
 
-        Parallel.ForEach(hosts, new ParallelOptions { CancellationToken = cancellationToken }, host =>
+        await Parallel.ForEachAsync(hosts, new ParallelOptions { CancellationToken = cancellationToken },
+            async (host, ct) =>
         {
             switch (host)
             {
@@ -62,7 +57,7 @@ public static class HostRangeHelper
                     Parallel.For(IPv4Address.ToInt32(network.Network), IPv4Address.ToInt32(network.Broadcast) + 1,
                         (i, state) =>
                         {
-                            if (cancellationToken.IsCancellationRequested)
+                            if (ct.IsCancellationRequested)
                                 state.Break();
 
                             hostsBag.Add((IPv4Address.FromInt32(i), string.Empty));
@@ -77,7 +72,7 @@ public static class HostRangeHelper
                     Parallel.For(IPv4Address.ToInt32(IPAddress.Parse(range[0])),
                         IPv4Address.ToInt32(IPAddress.Parse(range[1])) + 1, (i, state) =>
                         {
-                            if (cancellationToken.IsCancellationRequested)
+                            if (ct.IsCancellationRequested)
                                 state.Break();
 
                             hostsBag.Add((IPv4Address.FromInt32(i), string.Empty));
@@ -107,7 +102,7 @@ public static class HostRangeHelper
                                     Parallel.For(int.Parse(rangeNumbers[0]), int.Parse(rangeNumbers[1]) + 1,
                                         (i, state) =>
                                         {
-                                            if (cancellationToken.IsCancellationRequested)
+                                            if (ct.IsCancellationRequested)
                                                 state.Break();
 
                                             innerList.Add(i);
@@ -124,18 +119,18 @@ public static class HostRangeHelper
                     }
 
                     // Build the new ipv4
-                    Parallel.ForEach(list[0], new ParallelOptions { CancellationToken = cancellationToken },
+                    Parallel.ForEach(list[0], new ParallelOptions { CancellationToken = ct },
                         i =>
                         {
-                            Parallel.ForEach(list[1], new ParallelOptions { CancellationToken = cancellationToken },
+                            Parallel.ForEach(list[1], new ParallelOptions { CancellationToken = ct },
                                 j =>
                                 {
                                     Parallel.ForEach(list[2],
-                                        new ParallelOptions { CancellationToken = cancellationToken },
+                                        new ParallelOptions { CancellationToken = ct },
                                         k =>
                                         {
                                             Parallel.ForEach(list[3],
-                                                new ParallelOptions { CancellationToken = cancellationToken },
+                                                new ParallelOptions { CancellationToken = ct },
                                                 h =>
                                                 {
                                                     hostsBag.Add((IPAddress.Parse($"{i}.{j}.{k}.{h}"), string.Empty));
@@ -148,17 +143,13 @@ public static class HostRangeHelper
 
                 // example.com
                 case var _ when RegexHelper.HostnameOrDomainRegex().IsMatch(host):
-                    using (var dnsResolverTask =
-                           DNSClientHelper.ResolveAorAaaaAsync(host, dnsResolveHostnamePreferIPv4))
-                    {
-                        // Wait for task inside a Parallel.Foreach
-                        dnsResolverTask.Wait(cancellationToken);
+                    var dnsResult = await DNSClientHelper.ResolveAorAaaaAsync(host, dnsResolveHostnamePreferIPv4)
+                        .ConfigureAwait(false);
 
-                        if (!dnsResolverTask.Result.HasError)
-                            hostsBag.Add((IPAddress.Parse($"{dnsResolverTask.Result.Value}"), host));
-                        else
-                            hostnamesNotResovledBag.Add(host);
-                    }
+                    if (!dnsResult.HasError)
+                        hostsBag.Add((IPAddress.Parse($"{dnsResult.Value}"), host));
+                    else
+                        hostnamesNotResovledBag.Add(host);
 
                     break;
 
@@ -168,42 +159,39 @@ public static class HostRangeHelper
                     var hostAndSubnet = host.Split('/');
 
                     // Only support IPv4
-                    using (var dnsResolverTask = DNSClientHelper.ResolveAorAaaaAsync(hostAndSubnet[0], true))
+                    var dnsResultWithSubnet = await DNSClientHelper.ResolveAorAaaaAsync(hostAndSubnet[0], true)
+                        .ConfigureAwait(false);
+
+                    if (!dnsResultWithSubnet.HasError)
                     {
-                        // Wait for task inside a Parallel.Foreach
-                        dnsResolverTask.Wait(cancellationToken);
-
-                        if (!dnsResolverTask.Result.HasError)
+                        // Only support IPv4 for ranges for now
+                        if (dnsResultWithSubnet.Value.AddressFamily == AddressFamily.InterNetwork)
                         {
-                            // Only support IPv4 for ranges for now
-                            if (dnsResolverTask.Result.Value.AddressFamily == AddressFamily.InterNetwork)
-                            {
-                                network = IPNetwork2.Parse(
-                                    $"{dnsResolverTask.Result.Value}/{hostAndSubnet[1]}");
+                            network = IPNetwork2.Parse(
+                                $"{dnsResultWithSubnet.Value}/{hostAndSubnet[1]}");
 
-                                Parallel.For(IPv4Address.ToInt32(network.Network),
-                                    IPv4Address.ToInt32(network.Broadcast) + 1, (i, state) =>
-                                    {
-                                        if (cancellationToken.IsCancellationRequested)
-                                            state.Break();
+                            Parallel.For(IPv4Address.ToInt32(network.Network),
+                                IPv4Address.ToInt32(network.Broadcast) + 1, (i, state) =>
+                                {
+                                    if (ct.IsCancellationRequested)
+                                        state.Break();
 
-                                        hostsBag.Add((IPv4Address.FromInt32(i), string.Empty));
-                                    });
-                            }
-                            else
-                            {
-                                hostnamesNotResovledBag.Add(hostAndSubnet[0]);
-                            }
+                                    hostsBag.Add((IPv4Address.FromInt32(i), string.Empty));
+                                });
                         }
                         else
                         {
                             hostnamesNotResovledBag.Add(hostAndSubnet[0]);
                         }
                     }
+                    else
+                    {
+                        hostnamesNotResovledBag.Add(hostAndSubnet[0]);
+                    }
 
                     break;
             }
-        });
+        }).ConfigureAwait(false);
 
         // Sort list and return
         IPAddressComparer comparer = new();

--- a/Source/NETworkManager.Models/Network/IPScanner.cs
+++ b/Source/NETworkManager.Models/Network/IPScanner.cs
@@ -79,7 +79,7 @@ public sealed class IPScanner(IPScannerOptions options)
         CancellationToken cancellationToken)
     {
         // Start the scan in a separate task
-        Task.Run(() =>
+        Task.Run(async () =>
         {
             _progressValue = 0;
 
@@ -101,40 +101,32 @@ public sealed class IPScanner(IPScannerOptions options)
                 };
 
                 // Start scan
-                Parallel.ForEach(hosts, hostParallelOptions, host =>
+                await Parallel.ForEachAsync(hosts, hostParallelOptions, async (host, ct) =>
                 {
-                    // Start ping async
-                    var pingTask = PingAsync(host.ipAddress, cancellationToken);
+                    // Start ping, port scan and netbios lookup concurrently - none of these block a thread anymore
+                    var pingTask = PingAsync(host.ipAddress, ct);
 
-                    // Start port scan async (if enabled)
                     var portScanTask = options.PortScanEnabled
-                        ? PortScanAsync(host.ipAddress, portScanParallelOptions, cancellationToken)
-                        : Task.FromResult(Enumerable.Empty<PortInfo>());
+                        ? PortScanAsync(host.ipAddress, portScanParallelOptions, ct)
+                        : Task.FromResult(new List<PortInfo>());
 
-                    // Start netbios lookup async (if enabled)
                     var netbiosTask = options.NetBIOSEnabled
-                        ? NetBIOSResolver.ResolveAsync(host.ipAddress, options.NetBIOSTimeout, cancellationToken)
+                        ? NetBIOSResolver.ResolveAsync(host.ipAddress, options.NetBIOSTimeout, ct)
                         : Task.FromResult(new NetBIOSInfo(host.ipAddress));
 
-                    // Get ping result
-                    pingTask.Wait(cancellationToken);
+                    await Task.WhenAll(pingTask, portScanTask, netbiosTask).ConfigureAwait(false);
+
                     var pingInfo = pingTask.Result;
-
-                    // Get port scan result
-                    portScanTask.Wait(cancellationToken);
-                    var portScanResults = portScanTask.Result.ToList();
-
-                    // Get netbios result
-                    netbiosTask.Wait(cancellationToken);
+                    var portScanResults = portScanTask.Result;
                     var netBIOSInfo = netbiosTask.Result;
 
                     // Cancel if the user has canceled
-                    cancellationToken.ThrowIfCancellationRequested();
+                    ct.ThrowIfCancellationRequested();
 
                     // Check if host is up
                     var isAnyPortOpen = portScanResults.Any(x => x.State == PortState.Open);
                     var isReachable = pingInfo.Status == IPStatus.Success || // ICMP response
-                                      isAnyPortOpen || // Any port is open   
+                                      isAnyPortOpen || // Any port is open
                                       netBIOSInfo.IsReachable; // NetBIOS response
 
                     // DNS & ARP
@@ -145,14 +137,11 @@ public sealed class IPScanner(IPScannerOptions options)
 
                         if (options.ResolveHostname)
                         {
-                            // Don't use await in Parallel.ForEach, this will break
-                            var dnsResolverTask = DNSClient.GetInstance().ResolvePtrAsync(host.ipAddress);
+                            var dnsResult = await DNSClient.GetInstance().ResolvePtrAsync(host.ipAddress)
+                                .ConfigureAwait(false);
 
-                            // Wait for task inside a Parallel.Foreach
-                            dnsResolverTask.Wait(cancellationToken);
-
-                            if (!dnsResolverTask.Result.HasError)
-                                dnsHostname = dnsResolverTask.Result.Value;
+                            if (!dnsResult.HasError)
+                                dnsHostname = dnsResult.Value;
                         }
 
                         // ARP
@@ -212,7 +201,7 @@ public sealed class IPScanner(IPScannerOptions options)
                     }
 
                     IncreaseProgress();
-                });
+                }).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -225,101 +214,79 @@ public sealed class IPScanner(IPScannerOptions options)
         }, cancellationToken);
     }
 
-    private Task<PingInfo> PingAsync(IPAddress ipAddress, CancellationToken cancellationToken)
+    private async Task<PingInfo> PingAsync(IPAddress ipAddress, CancellationToken cancellationToken)
     {
-        return Task.Run(() =>
+        using var ping = new System.Net.NetworkInformation.Ping();
+
+        for (var i = 0; i < options.ICMPAttempts; i++)
         {
-            using var ping = new System.Net.NetworkInformation.Ping();
+            // Get timestamp
+            var timestamp = DateTime.Now;
 
-            for (var i = 0; i < options.ICMPAttempts; i++)
+            try
             {
-                // Get timestamp 
-                var timestamp = DateTime.Now;
+                // Note: the CancellationToken-accepting overload requires a TimeSpan timeout,
+                // unlike the legacy int-based overloads used elsewhere in .NET's Ping API.
+                var pingReply = await ping.SendPingAsync(ipAddress, TimeSpan.FromMilliseconds(options.ICMPTimeout),
+                    options.ICMPBuffer, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-                try
+                // Success
+                if (pingReply is { Status: IPStatus.Success })
                 {
-                    var pingReply = ping.Send(ipAddress, options.ICMPTimeout, options.ICMPBuffer);
-
-                    // Success
-                    if (pingReply is { Status: IPStatus.Success })
+                    switch (ipAddress.AddressFamily)
                     {
-                        switch (ipAddress.AddressFamily)
-                        {
-                            case AddressFamily.InterNetwork:
-                                return new PingInfo(
-                                                             timestamp,
-                                                             pingReply.Address,
-                                                             pingReply.Buffer.Length,
-                                                             pingReply.RoundtripTime,
-                                                             pingReply.Options!.Ttl,
-                                                             pingReply.Status);
-                            case AddressFamily.InterNetworkV6:
-                                return new PingInfo(
+                        case AddressFamily.InterNetwork:
+                            return new PingInfo(
                                                          timestamp,
                                                          pingReply.Address,
                                                          pingReply.Buffer.Length,
                                                          pingReply.RoundtripTime,
+                                                         pingReply.Options!.Ttl,
                                                          pingReply.Status);
-                        }
+                        case AddressFamily.InterNetworkV6:
+                            return new PingInfo(
+                                                     timestamp,
+                                                     pingReply.Address,
+                                                     pingReply.Buffer.Length,
+                                                     pingReply.RoundtripTime,
+                                                     pingReply.Status);
                     }
-
-                    // Failed
-                    if (pingReply != null)
-                        return new PingInfo(timestamp, ipAddress, pingReply.Status);
-                }
-                catch (PingException)
-                {
-                    // Ping failed with unknown status
-                    return new PingInfo(timestamp, ipAddress, IPStatus.Unknown);
                 }
 
-                // Don't scan again, if the user has canceled (when more than 1 attempt)
-                if (cancellationToken.IsCancellationRequested)
-                    break;
+                // Failed
+                if (pingReply != null)
+                    return new PingInfo(timestamp, ipAddress, pingReply.Status);
+            }
+            catch (PingException)
+            {
+                // Ping failed with unknown status
+                return new PingInfo(timestamp, ipAddress, IPStatus.Unknown);
             }
 
-            // Fall back to unknown status
-            return new PingInfo(DateTime.Now, ipAddress, IPStatus.Unknown);
-        }, cancellationToken);
+            // Don't scan again, if the user has canceled (when more than 1 attempt)
+            if (cancellationToken.IsCancellationRequested)
+                break;
+        }
+
+        // Fall back to unknown status
+        return new PingInfo(DateTime.Now, ipAddress, IPStatus.Unknown);
     }
 
-    private Task<IEnumerable<PortInfo>> PortScanAsync(IPAddress ipAddress, ParallelOptions parallelOptions,
+    private async Task<List<PortInfo>> PortScanAsync(IPAddress ipAddress, ParallelOptions parallelOptions,
         CancellationToken cancellationToken)
     {
         ConcurrentBag<PortInfo> results = [];
 
-        Parallel.ForEach(options.PortScanPorts, parallelOptions, port =>
+        await Parallel.ForEachAsync(options.PortScanPorts, parallelOptions, async (port, ct) =>
         {
-            // Test if port is open
-            using var tcpClient = new TcpClient(ipAddress.AddressFamily);
+            var portState = await PortProbe.ProbeAsync(ipAddress, port, options.PortScanTimeout, ct)
+                .ConfigureAwait(false);
 
-            var portState = PortState.None;
+            if (portState == PortState.Open || options.ShowAllResults)
+                results.Add(new PortInfo(port, PortLookup.LookupByPortAndProtocol(port), portState));
+        }).ConfigureAwait(false);
 
-            try
-            {
-                // ReSharper disable once MethodSupportsCancellation - Wait for timeout
-                var task = tcpClient.ConnectAsync(ipAddress, port);
-
-                if (task.Wait(options.PortScanTimeout, cancellationToken))
-                    portState = tcpClient.Connected ? PortState.Open : PortState.Closed;
-                else
-                    portState = PortState.TimedOut;
-            }
-            catch
-            {
-                portState = PortState.Closed;
-            }
-            finally
-            {
-                tcpClient.Close();
-
-                if (portState == PortState.Open || options.ShowAllResults)
-                    results.Add(
-                        new PortInfo(port, PortLookup.LookupByPortAndProtocol(port), portState));
-            }
-        });
-
-        return Task.FromResult(results.AsEnumerable());
+        return results.ToList();
     }
 
     private void IncreaseProgress()

--- a/Source/NETworkManager.Models/Network/IPScanner.cs
+++ b/Source/NETworkManager.Models/Network/IPScanner.cs
@@ -138,7 +138,7 @@ public sealed class IPScanner(IPScannerOptions options)
                         if (options.ResolveHostname)
                         {
                             var dnsResult = await DNSClient.GetInstance().ResolvePtrAsync(host.ipAddress)
-                                .ConfigureAwait(false);
+                                .WaitAsync(ct).ConfigureAwait(false);
 
                             if (!dnsResult.HasError)
                                 dnsHostname = dnsResult.Value;

--- a/Source/NETworkManager.Models/Network/NetBIOSResolver.cs
+++ b/Source/NETworkManager.Models/Network/NetBIOSResolver.cs
@@ -50,23 +50,17 @@ public static class NetBIOSResolver
 
         var remoteEndPoint = new IPEndPoint(ipAddress, NetBIOSUdpPort);
 
+        // Linked so the receive is genuinely canceled (not just abandoned) on either timeout or
+        // caller cancellation - avoids leaving a pending receive that later faults, unobserved,
+        // once the socket is closed in the finally block below.
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
         try
         {
             await udpClient.SendAsync(RequestData, RequestData.Length, remoteEndPoint);
 
-            // ReSharper disable once MethodSupportsCancellation - cancellation is handled below by Task.WhenAny
-            var receiveTask = udpClient.ReceiveAsync();
-            var timeoutTask = Task.Delay(timeout, cancellationToken);
-
-            var completedTask = await Task.WhenAny(receiveTask, timeoutTask).ConfigureAwait(false);
-
-            if (completedTask == timeoutTask)
-                return new NetBIOSInfo(ipAddress);
-
-            // Note: if the receive task were still pending here, it would fault once the socket
-            // is closed in the finally block below. Since we only reach this point when it has
-            // already completed, that's not a concern.
-            var response = await receiveTask.ConfigureAwait(false);
+            var response = await udpClient.ReceiveAsync(linkedCts.Token).ConfigureAwait(false);
 
             if (response.Buffer.Length < ResponseBaseLen || response.Buffer[ResponseTypePos] != ResponseTypeNbstat)
                 return new NetBIOSInfo(ipAddress); // response was too short

--- a/Source/NETworkManager.Models/Network/NetBIOSResolver.cs
+++ b/Source/NETworkManager.Models/Network/NetBIOSResolver.cs
@@ -47,7 +47,6 @@ public static class NetBIOSResolver
         CancellationToken cancellationToken)
     {
         var udpClient = new UdpClient();
-        udpClient.Client.ReceiveTimeout = timeout;
 
         var remoteEndPoint = new IPEndPoint(ipAddress, NetBIOSUdpPort);
 
@@ -57,11 +56,17 @@ public static class NetBIOSResolver
 
             // ReSharper disable once MethodSupportsCancellation - cancellation is handled below by Task.WhenAny
             var receiveTask = udpClient.ReceiveAsync();
+            var timeoutTask = Task.Delay(timeout, cancellationToken);
 
-            if (!receiveTask.Wait(timeout, cancellationToken))
+            var completedTask = await Task.WhenAny(receiveTask, timeoutTask).ConfigureAwait(false);
+
+            if (completedTask == timeoutTask)
                 return new NetBIOSInfo(ipAddress);
 
-            var response = receiveTask.Result;
+            // Note: if the receive task were still pending here, it would fault once the socket
+            // is closed in the finally block below. Since we only reach this point when it has
+            // already completed, that's not a concern.
+            var response = await receiveTask.ConfigureAwait(false);
 
             if (response.Buffer.Length < ResponseBaseLen || response.Buffer[ResponseTypePos] != ResponseTypeNbstat)
                 return new NetBIOSInfo(ipAddress); // response was too short

--- a/Source/NETworkManager.Models/Network/PortProbe.cs
+++ b/Source/NETworkManager.Models/Network/PortProbe.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NETworkManager.Models.Network;
+
+/// <summary>
+///     Provides a shared, fully asynchronous TCP connect probe used by <see cref="IPScanner" /> and
+///     <see cref="PortScanner" />.
+/// </summary>
+internal static class PortProbe
+{
+    /// <summary>
+    ///     Attempts a TCP connect to the given <paramref name="ipAddress" /> and <paramref name="port" /> and
+    ///     classifies the result. Never throws for expected connect failures.
+    /// </summary>
+    /// <param name="ipAddress">IP address to connect to.</param>
+    /// <param name="port">Port to connect to.</param>
+    /// <param name="timeoutMs">Timeout in milliseconds after which the port is considered timed out.</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+    /// <returns>The <see cref="PortState" /> of the probed port.</returns>
+    public static async Task<PortState> ProbeAsync(IPAddress ipAddress, int port, int timeoutMs,
+        CancellationToken cancellationToken)
+    {
+        using var tcpClient = new TcpClient(ipAddress.AddressFamily);
+        using var timeoutCts = new CancellationTokenSource(timeoutMs);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        try
+        {
+            await tcpClient.ConnectAsync(ipAddress, port, linkedCts.Token).ConfigureAwait(false);
+
+            return tcpClient.Connected ? PortState.Open : PortState.Closed;
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested &&
+                                                   !cancellationToken.IsCancellationRequested)
+        {
+            // Only our own timeout fired, not the caller's cancellation -> timed out
+            return PortState.TimedOut;
+        }
+        catch (Exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Connection refused, host unreachable, etc.
+            return PortState.Closed;
+        }
+        finally
+        {
+            tcpClient.Close();
+        }
+    }
+}

--- a/Source/NETworkManager.Models/Network/PortProbe.cs
+++ b/Source/NETworkManager.Models/Network/PortProbe.cs
@@ -34,15 +34,21 @@ internal static class PortProbe
 
             return tcpClient.Connected ? PortState.Open : PortState.Closed;
         }
-        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested &&
-                                                   !cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
-            // Only our own timeout fired, not the caller's cancellation -> timed out
+            // linkedCts was canceled, but not by the caller -> our own timeout fired
             return PortState.TimedOut;
         }
-        catch (Exception) when (!cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
-            // Connection refused, host unreachable, etc.
+            // Caller's token is why this was canceled -> propagate as a real cancellation
+            throw;
+        }
+        catch (Exception)
+        {
+            // Any other connect failure (refused, unreachable, etc.) -> always Closed, regardless
+            // of whether cancellation also happens to be in flight concurrently for an unrelated
+            // reason (that used to race against this classification via a token-state check here).
             return PortState.Closed;
         }
         finally

--- a/Source/NETworkManager.Models/Network/PortProfile.cs
+++ b/Source/NETworkManager.Models/Network/PortProfile.cs
@@ -18,7 +18,8 @@ public static class PortProfile
             new("Database", "1433-1434; 1521; 1830; 3306; 5432"),
             new("SMB", "139; 445"),
             new("LDAP", "389; 636"),
-            new("HTTP proxy", "3128")
+            new("HTTP proxy", "3128"),
+            new("Well-known ports", "1-1024")
         };
     }
 }

--- a/Source/NETworkManager.Models/Network/PortScanner.cs
+++ b/Source/NETworkManager.Models/Network/PortScanner.cs
@@ -90,7 +90,7 @@ public sealed class PortScanner
                     if (_options.ResolveHostname)
                     {
                         var dnsResult = await DNSClient.GetInstance().ResolvePtrAsync(host.ipAddress)
-                            .ConfigureAwait(false);
+                            .WaitAsync(hostCt).ConfigureAwait(false);
 
                         if (!dnsResult.HasError)
                             hostname = dnsResult.Value;

--- a/Source/NETworkManager.Models/Network/PortScanner.cs
+++ b/Source/NETworkManager.Models/Network/PortScanner.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
-using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using NETworkManager.Models.Lookup;
@@ -67,7 +66,7 @@ public sealed class PortScanner
     {
         _progressValue = 0;
 
-        Task.Run(() =>
+        Task.Run(async () =>
         {
             try
             {
@@ -83,58 +82,34 @@ public sealed class PortScanner
                     MaxDegreeOfParallelism = _options.MaxPortThreads
                 };
 
-                Parallel.ForEach(hosts, hostParallelOptions, host =>
+                await Parallel.ForEachAsync(hosts, hostParallelOptions, async (host, hostCt) =>
                 {
                     // Resolve Hostname (PTR)
                     var hostname = string.Empty;
 
                     if (_options.ResolveHostname)
                     {
-                        // Don't use await in Parallel.ForEach, this will break
-                        var dnsResolverTask = DNSClient.GetInstance().ResolvePtrAsync(host.ipAddress);
+                        var dnsResult = await DNSClient.GetInstance().ResolvePtrAsync(host.ipAddress)
+                            .ConfigureAwait(false);
 
-                        // Wait for task inside a Parallel.Foreach
-                        dnsResolverTask.Wait(cancellationToken);
-
-                        if (!dnsResolverTask.Result.HasError)
-                            hostname = dnsResolverTask.Result.Value;
+                        if (!dnsResult.HasError)
+                            hostname = dnsResult.Value;
                     }
 
                     // Check each port
-                    Parallel.ForEach(ports, portParallelOptions, port =>
+                    await Parallel.ForEachAsync(ports, portParallelOptions, async (port, portCt) =>
                     {
-                        // Test if port is open
-                        using (var tcpClient = new TcpClient(host.ipAddress.AddressFamily))
-                        {
-                            var portState = PortState.None;
+                        var portState = await PortProbe.ProbeAsync(host.ipAddress, port, _options.Timeout, portCt)
+                            .ConfigureAwait(false);
 
-                            try
-                            {
-                                var task = tcpClient.ConnectAsync(host.ipAddress, port);
-
-                                if (task.Wait(_options.Timeout))
-                                    portState = tcpClient.Connected ? PortState.Open : PortState.Closed;
-                                else
-                                    portState = PortState.TimedOut;
-                            }
-                            catch
-                            {
-                                portState = PortState.Closed;
-                            }
-                            finally
-                            {
-                                tcpClient.Close();
-
-                                if (_options.ShowAllResults || portState == PortState.Open)
-                                    OnPortScanned(new PortScannerPortScannedArgs(
-                                        new PortScannerPortInfo(host.ipAddress, hostname, port,
-                                            PortLookup.LookupByPortAndProtocol(port), portState)));
-                            }
-                        }
+                        if (_options.ShowAllResults || portState == PortState.Open)
+                            OnPortScanned(new PortScannerPortScannedArgs(
+                                new PortScannerPortInfo(host.ipAddress, hostname, port,
+                                    PortLookup.LookupByPortAndProtocol(port), portState)));
 
                         IncreaseProgress();
-                    });
-                });
+                    }).ConfigureAwait(false);
+                }).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/Source/NETworkManager.Settings/GlobalStaticConfiguration.cs
+++ b/Source/NETworkManager.Settings/GlobalStaticConfiguration.cs
@@ -133,7 +133,7 @@ public static class GlobalStaticConfiguration
     public static bool IPScanner_PortScanEnabled => true;
     public static string IPScanner_PortScanPorts => "22; 53; 80; 135; 139; 389; 636; 443; 445; 3389; 9100";
     public static int IPScanner_PortScanTimeout => 4000;
-    public static int IPScanner_MaxHostThreads => 256;
+    public static int IPScanner_MaxHostThreads => 64;
     public static int IPScanner_MaxPortThreads => 4;
     public static bool IPScanner_NetBIOSEnabled => true;
     public static int IPScanner_NetBIOSTimeout => 4000;
@@ -141,7 +141,7 @@ public static class GlobalStaticConfiguration
 
     // Application: Port Scanner 
     public static int PortScanner_MaxHostThreads => 4;
-    public static int PortScanner_MaxPortThreads => 256;
+    public static int PortScanner_MaxPortThreads => 64;
     public static int PortScanner_Timeout => 4000;
     public static ExportFileType PortScanner_ExportFileType => ExportFileType.Csv;
 

--- a/Source/NETworkManager.Settings/GlobalStaticConfiguration.cs
+++ b/Source/NETworkManager.Settings/GlobalStaticConfiguration.cs
@@ -61,7 +61,6 @@ public static class GlobalStaticConfiguration
 
     // Settings: General
     public static int General_BackgroundJobInterval => 5;
-    public static int General_ThreadPoolAdditionalMinThreads => 512;
     public static int General_HistoryListEntries => 10;
 
     // Settings: Window
@@ -132,16 +131,16 @@ public static class GlobalStaticConfiguration
     public static int IPScanner_ICMPBuffer => 32;
     public static bool IPScanner_ResolveHostname => true;
     public static bool IPScanner_PortScanEnabled => true;
-    public static string IPScanner_PortScanPorts => "22; 53; 80; 139; 389; 636; 443; 445; 3389";
+    public static string IPScanner_PortScanPorts => "22; 53; 80; 135; 139; 389; 636; 443; 445; 3389; 9100";
     public static int IPScanner_PortScanTimeout => 4000;
     public static int IPScanner_MaxHostThreads => 256;
-    public static int IPScanner_MaxPortThreads => 5;
+    public static int IPScanner_MaxPortThreads => 4;
     public static bool IPScanner_NetBIOSEnabled => true;
     public static int IPScanner_NetBIOSTimeout => 4000;
     public static ExportFileType IPScanner_ExportFileType => ExportFileType.Csv;
 
     // Application: Port Scanner 
-    public static int PortScanner_MaxHostThreads => 5;
+    public static int PortScanner_MaxHostThreads => 4;
     public static int PortScanner_MaxPortThreads => 256;
     public static int PortScanner_Timeout => 4000;
     public static ExportFileType PortScanner_ExportFileType => ExportFileType.Csv;

--- a/Source/NETworkManager.Settings/SettingsInfo.cs
+++ b/Source/NETworkManager.Settings/SettingsInfo.cs
@@ -152,20 +152,6 @@ public class SettingsInfo : INotifyPropertyChanged
         }
     } = GlobalStaticConfiguration.General_BackgroundJobInterval;
 
-
-    public int General_ThreadPoolAdditionalMinThreads
-    {
-        get;
-        set
-        {
-            if (value == field)
-                return;
-
-            field = value;
-            OnPropertyChanged();
-        }
-    } = GlobalStaticConfiguration.General_ThreadPoolAdditionalMinThreads;
-
     public int General_HistoryListEntries
     {
         get;

--- a/Source/NETworkManager.Settings/SettingsManager.cs
+++ b/Source/NETworkManager.Settings/SettingsManager.cs
@@ -770,6 +770,12 @@ public static class SettingsManager
             Current.PortScanner_MaxPortThreads = 64;
         }
 
+        if (Current.IPScanner_PortScanPorts == "22; 53; 80; 139; 389; 636; 443; 445; 3389")
+        {
+            Log.Info($"Update \"IPScanner_PortScanPorts\" to \"{GlobalStaticConfiguration.IPScanner_PortScanPorts}\"...");
+            Current.IPScanner_PortScanPorts = GlobalStaticConfiguration.IPScanner_PortScanPorts;
+        }
+
         // Add new Port Scanner port profiles
         foreach (var portProfile in PortProfile.GetDefaultList())
         {

--- a/Source/NETworkManager.Settings/SettingsManager.cs
+++ b/Source/NETworkManager.Settings/SettingsManager.cs
@@ -741,6 +741,47 @@ public static class SettingsManager
     private static void UpgradeToLatest(Version version)
     {
         Log.Info($"Apply upgrade to {version}...");
+
+        // IP Scanner / Port Scanner - lower the default concurrency (see changelog for why).
+        // Only applied if still at the old default, so a deliberately customized value is left alone.
+        Log.Info("Lower IP Scanner / Port Scanner default concurrency, if still unchanged from the old default...");
+
+        if (Current.IPScanner_MaxHostThreads == 256)
+        {
+            Log.Info("Update \"IPScanner_MaxHostThreads\" from 256 to 64...");
+            Current.IPScanner_MaxHostThreads = 64;
+        }
+
+        if (Current.IPScanner_MaxPortThreads == 5)
+        {
+            Log.Info("Update \"IPScanner_MaxPortThreads\" from 5 to 4...");
+            Current.IPScanner_MaxPortThreads = 4;
+        }
+
+        if (Current.PortScanner_MaxHostThreads == 5)
+        {
+            Log.Info("Update \"PortScanner_MaxHostThreads\" from 5 to 4...");
+            Current.PortScanner_MaxHostThreads = 4;
+        }
+
+        if (Current.PortScanner_MaxPortThreads == 256)
+        {
+            Log.Info("Update \"PortScanner_MaxPortThreads\" from 256 to 64...");
+            Current.PortScanner_MaxPortThreads = 64;
+        }
+
+        // Add new Port Scanner port profiles
+        foreach (var portProfile in PortProfile.GetDefaultList())
+        {
+            var portProfileFound =
+                Current.PortScanner_PortProfiles.FirstOrDefault(x => x.Name == portProfile.Name);
+
+            if (portProfileFound != null)
+                continue;
+
+            Log.Info($"Add \"{portProfile.Name}\" to \"PortScanner_PortProfiles\"...");
+            Current.PortScanner_PortProfiles.Add(portProfile);
+        }
     }
     #endregion
 }

--- a/Source/NETworkManager/App.xaml.cs
+++ b/Source/NETworkManager/App.xaml.cs
@@ -165,27 +165,6 @@ public partial class App
             Log.Info("Background job is disabled.");
         }
 
-        // Setup ThreadPool for the application
-        ThreadPool.GetMaxThreads(out var workerThreadsMax, out var completionPortThreadsMax);
-        ThreadPool.GetMinThreads(out var workerThreadsMin, out var completionPortThreadsMin);
-
-        var workerThreadsMinNew = workerThreadsMin + SettingsManager.Current.General_ThreadPoolAdditionalMinThreads;
-        var completionPortThreadsMinNew = completionPortThreadsMin +
-                                          SettingsManager.Current.General_ThreadPoolAdditionalMinThreads;
-
-        if (workerThreadsMinNew > workerThreadsMax)
-            workerThreadsMinNew = workerThreadsMax;
-
-        if (completionPortThreadsMinNew > completionPortThreadsMax)
-            completionPortThreadsMinNew = completionPortThreadsMax;
-
-        if (ThreadPool.SetMinThreads(workerThreadsMinNew, completionPortThreadsMinNew))
-            Log.Info(
-                $"ThreadPool min threads set to: workerThreads: {workerThreadsMinNew}, completionPortThreads: {completionPortThreadsMinNew}");
-        else
-            Log.Warn(
-                $"ThreadPool min threads could not be set to workerThreads: {workerThreadsMinNew}, completionPortThreads: {completionPortThreadsMinNew}");
-
         // Show splash screen
         if (SettingsManager.Current.SplashScreen_Enabled)
         {

--- a/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
@@ -43,6 +43,18 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
     private bool _firstLoad = true;
     private bool _closed;
 
+    // Background HostScanned events append here instead of hopping to the UI thread per item -
+    // a DispatcherTimer periodically flushes this into the Results collection instead, so a large
+    // scan doesn't flood the dispatcher queue with one BeginInvoke per host.
+    private readonly List<IPScannerHostInfo> _resultsBuffer = [];
+    private readonly Lock _resultsBufferLock = new();
+    private DispatcherTimer _resultsFlushTimer;
+
+    // Same reasoning as the results buffer above - ProgressChanged fires once per host
+    // (unconditionally, unlike HostScanned), so it's flushed to the bound property on the same
+    // timer instead of updating it directly from the background thread on every event.
+    private int _latestHostsScanned;
+
     /// <summary>
     /// Gets or sets the host or IP range to scan.
     /// </summary>
@@ -435,6 +447,13 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
         IsRunning = true;
         PreparingScan = true;
 
+        _resultsFlushTimer?.Stop();
+
+        lock (_resultsBufferLock)
+        {
+            _resultsBuffer.Clear();
+        }
+
         Results.Clear();
 
         DragablzTabItem.SetTabHeader(_tabId, Host);
@@ -466,6 +485,7 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
 
         HostsToScan = hosts.hosts.Count;
         HostsScanned = 0;
+        Volatile.Write(ref _latestHostsScanned, 0);
 
         PreparingScan = false;
 
@@ -492,6 +512,17 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
         ipScanner.ScanComplete += ScanComplete;
         ipScanner.ProgressChanged += ProgressChanged;
         ipScanner.UserHasCanceled += UserHasCanceled;
+
+        _resultsFlushTimer = new DispatcherTimer(DispatcherPriority.Background)
+        {
+            Interval = TimeSpan.FromMilliseconds(150)
+        };
+        _resultsFlushTimer.Tick += (_, _) =>
+        {
+            FlushResultsBuffer();
+            FlushProgress();
+        };
+        _resultsFlushTimer.Start();
 
         ipScanner.ScanAsync(hosts.hosts, _cancellationTokenSource.Token);
     }
@@ -704,21 +735,53 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
     /// <param name="e">The <see cref="IPScannerHostScannedArgs"/> instance containing the event data.</param>
     private void HostScanned(object sender, IPScannerHostScannedArgs e)
     {
-        Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal,
-            new Action(delegate
-            {
-                Results.Add(e.Args);
-            }));
+        lock (_resultsBufferLock)
+        {
+            _resultsBuffer.Add(e.Args);
+        }
     }
 
     /// <summary>
-    /// Handles the ProgressChanged event. Updates the progress.
+    /// Moves buffered scan results into <see cref="Results"/>. Always called on the UI thread -
+    /// either from the <see cref="_resultsFlushTimer"/> tick, or from within a Dispatcher.Invoke
+    /// call in <see cref="ScanComplete"/> / <see cref="UserHasCanceled"/>.
+    /// </summary>
+    private void FlushResultsBuffer()
+    {
+        List<IPScannerHostInfo> itemsToAdd;
+
+        lock (_resultsBufferLock)
+        {
+            if (_resultsBuffer.Count == 0)
+                return;
+
+            itemsToAdd = [.. _resultsBuffer];
+            _resultsBuffer.Clear();
+        }
+
+        foreach (var item in itemsToAdd)
+            Results.Add(item);
+    }
+
+    /// <summary>
+    /// Handles the ProgressChanged event. Stores the value for <see cref="FlushProgress"/> to
+    /// pick up on the next timer tick, instead of updating the bound property directly from a
+    /// background thread on every single host.
     /// </summary>
     /// <param name="sender">The source of the event.</param>
     /// <param name="e">The <see cref="ProgressChangedArgs"/> instance containing the event data.</param>
     private void ProgressChanged(object sender, ProgressChangedArgs e)
     {
-        HostsScanned = e.Value;
+        Volatile.Write(ref _latestHostsScanned, e.Value);
+    }
+
+    /// <summary>
+    /// Pushes the latest buffered progress value into <see cref="HostsScanned"/>. Always called
+    /// on the UI thread - same calling contexts as <see cref="FlushResultsBuffer"/>.
+    /// </summary>
+    private void FlushProgress()
+    {
+        HostsScanned = Volatile.Read(ref _latestHostsScanned);
     }
 
     /// <summary>
@@ -732,6 +795,10 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
         // to ensure all results are added first #3285
         Application.Current.Dispatcher.Invoke(() =>
         {
+            _resultsFlushTimer?.Stop();
+            FlushResultsBuffer();
+            FlushProgress();
+
             if (Results.Count == 0)
             {
                 StatusMessage = Strings.NoReachableHostsFound;
@@ -750,11 +817,18 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
     /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
     private void UserHasCanceled(object sender, EventArgs e)
     {
-        StatusMessage = Strings.CanceledByUserMessage;
-        IsStatusMessageDisplayed = true;
+        Application.Current.Dispatcher.Invoke(() =>
+        {
+            _resultsFlushTimer?.Stop();
+            FlushResultsBuffer();
+            FlushProgress();
 
-        IsCanceling = false;
-        IsRunning = false;
+            StatusMessage = Strings.CanceledByUserMessage;
+            IsStatusMessageDisplayed = true;
+
+            IsCanceling = false;
+            IsRunning = false;
+        });
     }
 
     #endregion

--- a/Source/NETworkManager/ViewModels/PortProfilesViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PortProfilesViewModel.cs
@@ -26,8 +26,17 @@ public class PortProfilesViewModel : ViewModelBase
     /// <param name="cancelHandler">The action to execute when the Cancel command is invoked.</param>
     public PortProfilesViewModel(Action<PortProfilesViewModel> okCommand, Action<PortProfilesViewModel> cancelHandler)
     {
-        OKCommand = new RelayCommand(_ => okCommand(this));
-        CancelCommand = new RelayCommand(_ => cancelHandler(this));
+        // Clear the filter on close so it doesn't leak into other views sharing this collection's default view.
+        OKCommand = new RelayCommand(_ =>
+        {
+            PortProfiles.Filter = null;
+            okCommand(this);
+        });
+        CancelCommand = new RelayCommand(_ =>
+        {
+            PortProfiles.Filter = null;
+            cancelHandler(this);
+        });
 
         PortProfiles = CollectionViewSource.GetDefaultView(SettingsManager.Current.PortScanner_PortProfiles);
         PortProfiles.SortDescriptions.Add(

--- a/Source/NETworkManager/ViewModels/PortScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PortScannerViewModel.cs
@@ -38,6 +38,18 @@ public class PortScannerViewModel : ViewModelBase
     private bool _firstLoad = true;
     private bool _closed;
 
+    // Background PortScanned events append here instead of hopping to the UI thread per item -
+    // a DispatcherTimer periodically flushes this into the Results collection instead, so a large
+    // scan doesn't flood the dispatcher queue with one BeginInvoke per port.
+    private readonly List<PortScannerPortInfo> _resultsBuffer = [];
+    private readonly Lock _resultsBufferLock = new();
+    private DispatcherTimer _resultsFlushTimer;
+
+    // Same reasoning as the results buffer above - ProgressChanged fires once per port
+    // (unconditionally, unlike PortScanned), so it's flushed to the bound property on the same
+    // timer instead of updating it directly from the background thread on every event.
+    private int _latestPortsScanned;
+
     /// <summary>
     /// Gets or sets the host to scan.
     /// </summary>
@@ -386,6 +398,13 @@ public class PortScannerViewModel : ViewModelBase
         IsRunning = true;
         PreparingScan = true;
 
+        _resultsFlushTimer?.Stop();
+
+        lock (_resultsBufferLock)
+        {
+            _resultsBuffer.Clear();
+        }
+
         Results.Clear();
 
         DragablzTabItem.SetTabHeader(_tabId, Host);
@@ -420,6 +439,7 @@ public class PortScannerViewModel : ViewModelBase
 
         PortsToScan = ports.Length * hosts.hosts.Count;
         PortsScanned = 0;
+        Volatile.Write(ref _latestPortsScanned, 0);
 
         PreparingScan = false;
 
@@ -439,6 +459,17 @@ public class PortScannerViewModel : ViewModelBase
         portScanner.ScanComplete += ScanComplete;
         portScanner.ProgressChanged += ProgressChanged;
         portScanner.UserHasCanceled += UserHasCanceled;
+
+        _resultsFlushTimer = new DispatcherTimer(DispatcherPriority.Background)
+        {
+            Interval = TimeSpan.FromMilliseconds(150)
+        };
+        _resultsFlushTimer.Tick += (_, _) =>
+        {
+            FlushResultsBuffer();
+            FlushProgress();
+        };
+        _resultsFlushTimer.Start();
 
         portScanner.ScanAsync(hosts.hosts, ports, _cancellationTokenSource.Token);
     }
@@ -531,13 +562,46 @@ public class PortScannerViewModel : ViewModelBase
 
     private void PortScanned(object sender, PortScannerPortScannedArgs e)
     {
-        Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal,
-            new Action(delegate { Results.Add(e.Args); }));
+        lock (_resultsBufferLock)
+        {
+            _resultsBuffer.Add(e.Args);
+        }
+    }
+
+    /// <summary>
+    /// Moves buffered scan results into <see cref="Results"/>. Always called on the UI thread -
+    /// either from the <see cref="_resultsFlushTimer"/> tick, or from within a Dispatcher.Invoke
+    /// call in <see cref="ScanComplete"/> / <see cref="UserHasCanceled"/>.
+    /// </summary>
+    private void FlushResultsBuffer()
+    {
+        List<PortScannerPortInfo> itemsToAdd;
+
+        lock (_resultsBufferLock)
+        {
+            if (_resultsBuffer.Count == 0)
+                return;
+
+            itemsToAdd = [.. _resultsBuffer];
+            _resultsBuffer.Clear();
+        }
+
+        foreach (var item in itemsToAdd)
+            Results.Add(item);
     }
 
     private void ProgressChanged(object sender, ProgressChangedArgs e)
     {
-        PortsScanned = e.Value;
+        Volatile.Write(ref _latestPortsScanned, e.Value);
+    }
+
+    /// <summary>
+    /// Pushes the latest buffered progress value into <see cref="PortsScanned"/>. Always called
+    /// on the UI thread - same calling contexts as <see cref="FlushResultsBuffer"/>.
+    /// </summary>
+    private void FlushProgress()
+    {
+        PortsScanned = Volatile.Read(ref _latestPortsScanned);
     }
 
     private void ScanComplete(object sender, EventArgs e)
@@ -546,6 +610,10 @@ public class PortScannerViewModel : ViewModelBase
         // to ensure all results are added first #3285
         Application.Current.Dispatcher.Invoke(() =>
         {
+            _resultsFlushTimer?.Stop();
+            FlushResultsBuffer();
+            FlushProgress();
+
             if (Results.Count == 0)
             {
                 StatusMessage = Strings.NoOpenPortsFound;
@@ -559,11 +627,18 @@ public class PortScannerViewModel : ViewModelBase
 
     private void UserHasCanceled(object sender, EventArgs e)
     {
-        StatusMessage = Strings.CanceledByUserMessage;
-        IsStatusMessageDisplayed = true;
+        Application.Current.Dispatcher.Invoke(() =>
+        {
+            _resultsFlushTimer?.Stop();
+            FlushResultsBuffer();
+            FlushProgress();
 
-        IsCanceling = false;
-        IsRunning = false;
+            StatusMessage = Strings.CanceledByUserMessage;
+            IsStatusMessageDisplayed = true;
+
+            IsCanceling = false;
+            IsRunning = false;
+        });
     }
 
     #endregion

--- a/Source/NETworkManager/ViewModels/SettingsGeneralViewModel.cs
+++ b/Source/NETworkManager/ViewModels/SettingsGeneralViewModel.cs
@@ -45,22 +45,6 @@ public class SettingsGeneralViewModel : ViewModelBase
         }
     }
 
-    public int ThreadPoolAdditionalMinThreads
-    {
-        get;
-        set
-        {
-            if (value == field)
-                return;
-
-            if (!_isLoading)
-                SettingsManager.Current.General_ThreadPoolAdditionalMinThreads = value;
-
-            field = value;
-            OnPropertyChanged();
-        }
-    }
-
     public int HistoryListEntries
     {
         get;
@@ -100,7 +84,6 @@ public class SettingsGeneralViewModel : ViewModelBase
         }.View;
 
         BackgroundJobInterval = SettingsManager.Current.General_BackgroundJobInterval;
-        ThreadPoolAdditionalMinThreads = SettingsManager.Current.General_ThreadPoolAdditionalMinThreads;
         HistoryListEntries = SettingsManager.Current.General_HistoryListEntries;
     }
 

--- a/Source/NETworkManager/Views/IPScannerSettingsView.xaml
+++ b/Source/NETworkManager/Views/IPScannerSettingsView.xaml
@@ -138,16 +138,5 @@
         <TextBlock Text="{x:Static localization:Strings.MaxPortThreads}" Style="{StaticResource DefaultTextBlock}"
                    Margin="0,0,0,10" />
         <mah:NumericUpDown Value="{Binding MaxPortThreads}" Maximum="10" Minimum="1" Interval="1" Margin="0,0,0,10" />
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="10" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Rectangle Grid.Column="0" Style="{StaticResource InfoImageRectangle}" Width="24" Height="24"
-                       HorizontalAlignment="Right" />
-            <TextBlock Grid.Column="2" Text="{x:Static localization:Strings.MaxThreadsOnlyGoToSettingsGeneralGeneral}"
-                       TextWrapping="Wrap" Style="{StaticResource InfoTextBlock}" />
-        </Grid>
     </StackPanel>
 </UserControl>

--- a/Source/NETworkManager/Views/PortScannerSettingsView.xaml
+++ b/Source/NETworkManager/Views/PortScannerSettingsView.xaml
@@ -103,16 +103,5 @@
         <TextBlock Text="{x:Static localization:Strings.MaxPortThreads}" Style="{StaticResource DefaultTextBlock}"
                    Margin="0,0,0,10" />
         <mah:NumericUpDown Value="{Binding MaxPortThreads}" Maximum="512" Minimum="1" Interval="1" Margin="0,0,0,10" />
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="10" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Rectangle Grid.Column="0" Style="{StaticResource InfoImageRectangle}" Width="24" Height="24"
-                       HorizontalAlignment="Right" />
-            <TextBlock Grid.Column="2" Text="{x:Static localization:Strings.MaxThreadsOnlyGoToSettingsGeneralGeneral}"
-                       TextWrapping="Wrap" Style="{StaticResource InfoTextBlock}" />
-        </Grid>
     </StackPanel>
 </UserControl>

--- a/Source/NETworkManager/Views/SettingsGeneralView.xaml
+++ b/Source/NETworkManager/Views/SettingsGeneralView.xaml
@@ -186,19 +186,6 @@
         <TextBlock Style="{StaticResource HeaderTextBlock}" Text="{x:Static localization:Strings.History}" />
         <TextBlock Text="{x:Static localization:Strings.NumberOfStoredEntries}"
                    Style="{DynamicResource DefaultTextBlock}" Margin="0,0,0,10" />
-        <mah:NumericUpDown Value="{Binding HistoryListEntries}" Maximum="25" Minimum="0" Interval="1" Margin="0,0,0,20" />
-        <TextBlock Text="{x:Static localization:Strings.Multithreading}" Style="{StaticResource HeaderTextBlock}" />
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-            <TextBlock Text="{x:Static localization:Strings.ThreadPoolAdditionalMinThreads}"
-                       Style="{StaticResource DefaultTextBlock}" />
-            <Rectangle Width="24" Height="24"
-                       ToolTip="{x:Static localization:Strings.HelpMessage_ThreadPoolAdditionalMinThreads}"
-                       Style="{StaticResource HelpImageRectangle}" Margin="10,0,0,0">
-                <Rectangle.Resources>
-                    <Style TargetType="{x:Type ToolTip}" BasedOn="{StaticResource HelpToolTip}" />
-                </Rectangle.Resources>
-            </Rectangle>
-        </StackPanel>
-        <mah:NumericUpDown Value="{Binding ThreadPoolAdditionalMinThreads}" Maximum="1024" Minimum="0" Interval="1" />
+        <mah:NumericUpDown Value="{Binding HistoryListEntries}" Maximum="25" Minimum="0" Interval="1" />
     </StackPanel>
 </UserControl>

--- a/Website/docs/application/ip-scanner.md
+++ b/Website/docs/application/ip-scanner.md
@@ -154,7 +154,7 @@ List of TCP ports to scan for each IP address.
 
 **Type:** `String`
 
-**Default:** `22; 53; 80; 139; 389; 636; 443; 445; 3389`
+**Default:** `22; 53; 80; 135; 139; 389; 636; 443; 445; 3389; 9100`
 
 :::note
 
@@ -245,30 +245,18 @@ Too many threads can also cause performance problems on the device.
 
 :::
 
-:::note
-
-This setting only changes the maximum number of concurrently executed threads per host scan. See also the [General](../settings/general#threadpool-additional-min-threads) settings to configure the application-wide thread pool.
-
-:::
-
 ### Max. concurrent port threads
 
 Maximum number of threads that are used to scan for open ports for each host (IP address).
 
 **Type:** `Integer` [Min `1`, Max `10`]
 
-**Default:** `5`
+**Default:** `4`
 
 :::warning
 
 Too many simultaneous requests may be blocked by a firewall. You can reduce the number of threads to avoid this, but this will increase the scan time.
 
 Too many threads can also cause performance problems on the device.
-
-:::
-
-:::note
-
-This setting only changes the maximum number of concurrently executed threads per port scan. See also the [General](../settings/general#threadpool-additional-min-threads) settings to configure the application-wide thread pool.
 
 :::

--- a/Website/docs/application/ip-scanner.md
+++ b/Website/docs/application/ip-scanner.md
@@ -235,7 +235,7 @@ Maximum number of threads used to scan for active hosts (1 thread = 1 host / IP 
 
 **Type:** `Integer` [Min `1`, Max `512`]
 
-**Default:** `256`
+**Default:** `64`
 
 :::warning
 

--- a/Website/docs/application/port-scanner.md
+++ b/Website/docs/application/port-scanner.md
@@ -142,6 +142,7 @@ List of common TCP ports to scan for.
 | SMB               | `139; 445`                          |
 | LDAP              | `389; 636`                          |
 | HTTP proxy        | `3128`                              |
+| Well-known ports  | `1-1024`                            |
 
 :::note
 
@@ -197,7 +198,7 @@ Maximum number of threads used to scan for ports for each host (1 thread = 1 por
 
 **Type:** `Integer` [Min `1`, Max `512`]
 
-**Default:** `256`
+**Default:** `64`
 
 :::warning
 

--- a/Website/docs/application/port-scanner.md
+++ b/Website/docs/application/port-scanner.md
@@ -181,19 +181,13 @@ Maximum number of threads used to scan hosts (1 thread = 1 host).
 
 **Type:** `Integer` [Min `1`, Max `10`]
 
-**Default:** `5`
+**Default:** `4`
 
 :::warning
 
 Too many simultaneous requests may be blocked by a firewall. You can reduce the number of threads to avoid this, but this will increase the scan time.
 
 Too many threads can also cause performance problems on the device.
-
-:::
-
-:::note
-
-This setting only changes the maximum number of concurrently executed threads per host scan. See also the [General](../settings/general#threadpool-additional-min-threads) settings to configure the application-wide thread pool.
 
 :::
 
@@ -210,11 +204,5 @@ Maximum number of threads used to scan for ports for each host (1 thread = 1 por
 Too many simultaneous requests may be blocked by a firewall. You can reduce the number of threads to avoid this, but this will increase the scan time.
 
 Too many threads can also cause performance problems on the device.
-
-:::
-
-:::note
-
-This setting only changes the maximum number of concurrently executed threads per port scan. See also the [General](../settings/general#threadpool-additional-min-threads) settings to configure the application-wide thread pool.
 
 :::

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -19,6 +19,8 @@ Release date: **xx.xx.2026**
 
 ## Breaking Changes
 
+- Removed the **ThreadPool additional min. threads** setting (Settings > General) and the application-wide `ThreadPool.SetMinThreads` workaround it configured for the IP Scanner and Port Scanner. It's no longer needed now that both scan engines use non-blocking async concurrency instead of blocking calls. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
+
 ## What's new?
 
 - ARM64 builds are now available. [#3538](https://github.com/BornToBeRoot/NETworkManager/issues/3538)
@@ -31,6 +33,15 @@ Release date: **xx.xx.2026**
 
 - The collapsed/expanded state of profile groups (e.g. **linux-server**) is now remembered per profile file and shared across all tools, instead of resetting every time you switch tools or restart the application. [#3539](https://github.com/BornToBeRoot/NETworkManager/pull/3539)
 
+**IP Scanner**
+
+- Added `135` (RPC) and `9100` (raw printing) to the default **Ports** list used to detect if a host is reachable. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
+- Reduced the default **Max. concurrent port threads** from `5` to `4`. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
+
+**Port Scanner**
+
+- Reduced the default **Max. concurrent host threads** from `5` to `4`. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
+
 ## Bug Fixes
 
 **Dashboard**
@@ -39,9 +50,14 @@ Release date: **xx.xx.2026**
 - Fixed the DNS status (Computer/Router/Internet) in the **Network Connection** widget showing as an error when no PTR record exists for the address, which is common and expected for private IP ranges. This is now shown as informational instead of critical. [#3553](https://github.com/BornToBeRoot/NETworkManager/pull/3553)
 - Fixed a race condition in the **Network Connection** widget where results from a superseded check could overwrite the results of a newer, still-running check after quickly reopening the widget. [#3553](https://github.com/BornToBeRoot/NETworkManager/pull/3553)
 
+**IP Scanner**
+
+- Fixed NetBIOS lookups (computer name, domain/workgroup, user name) not starting until a host's entire port scan had finished, since the port scan wasn't actually running asynchronously despite being awaited alongside it. Ping, port scan, and NetBIOS resolution now genuinely run concurrently for every host. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
+
 ## Dependencies, Refactoring & Documentation
 
 - Code cleanup & refactoring
+- Converted the **IP Scanner** and **Port Scanner** engines from `Parallel.ForEach` with blocking calls to genuinely asynchronous `Parallel.ForEachAsync`, removing the risk of exhausting the application's ThreadPool at high concurrency settings. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
 - Refactored the **Network Connection** widget's check logic to reduce duplicated code and share the local IP address detection between the Computer and Router checks instead of detecting it twice. [#3553](https://github.com/BornToBeRoot/NETworkManager/pull/3553)
 - Consolidated the duplicated **Profiles** side panel (search, tag filter, grouped list, context menu, add/edit/copy/delete) used across 15 tool views into a single shared control, reducing code duplication. As part of this, the profile panel's expanded/width state is now shared across all tools instead of being tracked per tool. [#3537](https://github.com/BornToBeRoot/NETworkManager/pull/3537)
 - Language files updated via [#transifex](https://github.com/BornToBeRoot/NETworkManager/pulls?q=author%3Aapp%2Ftransifex-integration)

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -37,10 +37,13 @@ Release date: **xx.xx.2026**
 
 - Added `135` (RPC) and `9100` (raw printing) to the default **Ports** list used to detect if a host is reachable. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
 - Reduced the default **Max. concurrent port threads** from `5` to `4`. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
+- Reduced the default **Max. concurrent host threads** from `256` to `64`, a more conservative default that puts less simultaneous load on the scanned network. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
 
 **Port Scanner**
 
 - Reduced the default **Max. concurrent host threads** from `5` to `4`. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
+- Reduced the default **Max. concurrent port threads** from `256` to `64`, a more conservative default that puts less simultaneous load on the scanned host. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
+- Added a new **Well-known ports** (`1-1024`) default port profile. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
 
 ## Bug Fixes
 
@@ -53,6 +56,7 @@ Release date: **xx.xx.2026**
 **IP Scanner**
 
 - Fixed NetBIOS lookups (computer name, domain/workgroup, user name) not starting until a host's entire port scan had finished, since the port scan wasn't actually running asynchronously despite being awaited alongside it. Ping, port scan, and NetBIOS resolution now genuinely run concurrently for every host. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
+- Fixed the application becoming unresponsive (including the window not reacting to input) during a large scan (e.g. a /24). Scan results and progress were both being pushed to the UI one item/update at a time via a dispatcher call per host/port, which could flood the UI thread's message queue on large scans. Both are now batched and flushed periodically (every 150ms) instead, for **IP Scanner** and **Port Scanner** alike. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
 
 ## Dependencies, Refactoring & Documentation
 

--- a/Website/docs/settings/general.md
+++ b/Website/docs/settings/general.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 0
-description: "Configure which applications appear in the NETworkManager sidebar and adjust general application behavior including thread pool settings."
-keywords: [NETworkManager, general settings, sidebar configuration, application settings, thread pool]
+description: "Configure which applications appear in the NETworkManager sidebar and adjust general application behavior."
+keywords: [NETworkManager, general settings, sidebar configuration, application settings]
 ---
 
 # General
@@ -47,17 +47,3 @@ Maximum number of entries stored in the history for several application inputs.
 Type: `Integer`
 
 Default: `5` [Min `0`, Max `25`]
-
-### ThreadPool additional min. threads
-
-Additional [minimum number of threads](https://learn.microsoft.com/en-us/dotnet/api/system.threading.threadpool.setminthreads?view=net-7.0) of the applications [ThreadPool](https://learn.microsoft.com/en-us/dotnet/standard/threading/the-managed-thread-pool) that are created on demand, as new requests are made, before switching to an algorithm for managing thread creation and destruction. This can improve e.g. the IP scanner or port scanner. The value is added to the default settings.
-
-Type: `Integer`
-
-Default: `512` [Min `0`, Max `1024`]
-
-:::note
-
-The value 0 leaves the default settings (number of CPU threads). If the value is to high, performance problems may occur. If the value is higher than the max. threads of the ThreadPool, the max. threads will be used. Changes to this value will take effect after restarting the application. Wheter the value was set successfully can be seen in the log file under `%LocalAppData%\NETworkManager\NETworkManager.log`.
-
-:::


### PR DESCRIPTION
## Changes proposed in this pull request

- Remove ThreadPool workaround
- Make scanner async

## To-Do

- [x] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs) to reflect this changes
- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
