### PR TITLE
feat: support newline-separated hosts and shorthand ranges

### DIFF
--- a/Source/NETworkManager.Controls/ComboBoxPasteBehavior.cs
+++ b/Source/NETworkManager.Controls/ComboBoxPasteBehavior.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Threading;
 
 namespace NETworkManager.Controls;
 
@@ -14,6 +16,8 @@ namespace NETworkManager.Controls;
 /// <c>false</c>) silently drops everything after the first line when multiline text is pasted.
 /// The conversion happens in <see cref="CommandManager.PreviewExecutedEvent"/> before the paste
 /// command actually runs, by rewriting the clipboard content to the semicolon-separated form.
+/// The original clipboard content is restored afterwards, and clipboard access is guarded since
+/// the Windows clipboard can throw when briefly locked by another process.
 /// </summary>
 public static class ComboBoxPasteBehavior
 {
@@ -48,21 +52,52 @@ public static class ComboBoxPasteBehavior
         if (e.Command != ApplicationCommands.Paste)
             return;
 
-        if (!Clipboard.ContainsText())
-            return;
+        string originalText;
 
-        var text = Clipboard.GetText();
+        try
+        {
+            if (!Clipboard.ContainsText())
+                return;
+
+            originalText = Clipboard.GetText();
+        }
+        catch (ExternalException)
+        {
+            // Clipboard is temporarily locked by another process - fall back to the default paste.
+            return;
+        }
 
         // Only rewrite when there is actual multiline content (e.g. a column pasted from Excel).
-        if (!text.Contains('\n') && !text.Contains('\r'))
+        if (!originalText.Contains('\n') && !originalText.Contains('\r'))
             return;
 
-        var converted = string.Join(";", text
+        var converted = string.Join(";", originalText
             .Replace("\r\n", "\n")
             .Replace('\r', '\n')
             .Split('\n', StringSplitOptions.RemoveEmptyEntries)
             .Select(x => x.Trim()));
 
-        Clipboard.SetText(converted);
+        try
+        {
+            Clipboard.SetText(converted);
+        }
+        catch (ExternalException)
+        {
+            return;
+        }
+
+        // Restore the original clipboard content once the paste command has consumed the
+        // rewritten text, so pasting elsewhere afterwards still yields what the user actually copied.
+        Dispatcher.CurrentDispatcher.BeginInvoke(DispatcherPriority.Background, () =>
+        {
+            try
+            {
+                Clipboard.SetText(originalText);
+            }
+            catch (ExternalException)
+            {
+                // Best effort - leave the rewritten text on the clipboard if restoring fails.
+            }
+        });
     }
 }

--- a/Source/NETworkManager.Controls/ComboBoxPasteBehavior.cs
+++ b/Source/NETworkManager.Controls/ComboBoxPasteBehavior.cs
@@ -4,7 +4,6 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Threading;
 
 namespace NETworkManager.Controls;
 
@@ -14,10 +13,10 @@ namespace NETworkManager.Controls;
 ///
 /// Without this the WPF TextBox inside the ComboBox (<see cref="TextBox.AcceptsReturn"/> is
 /// <c>false</c>) silently drops everything after the first line when multiline text is pasted.
-/// The conversion happens in <see cref="CommandManager.PreviewExecutedEvent"/> before the paste
-/// command actually runs, by rewriting the clipboard content to the semicolon-separated form.
-/// The original clipboard content is restored afterwards, and clipboard access is guarded since
-/// the Windows clipboard can throw when briefly locked by another process.
+/// The conversion is applied by reading the clipboard, replacing the editable text box's
+/// selection with the converted text, and marking <see cref="ApplicationCommands.Paste"/> as
+/// handled - the system clipboard itself is never modified, so other applications (or a
+/// subsequent paste elsewhere) are unaffected.
 /// </summary>
 public static class ComboBoxPasteBehavior
 {
@@ -52,14 +51,19 @@ public static class ComboBoxPasteBehavior
         if (e.Command != ApplicationCommands.Paste)
             return;
 
-        string originalText;
+        // The command originates from the focused editable text box inside the ComboBox
+        // template, which is where the pasted text actually needs to be inserted.
+        if (e.OriginalSource is not TextBox textBox)
+            return;
+
+        string text;
 
         try
         {
             if (!Clipboard.ContainsText())
                 return;
 
-            originalText = Clipboard.GetText();
+            text = Clipboard.GetText();
         }
         catch (ExternalException)
         {
@@ -67,37 +71,29 @@ public static class ComboBoxPasteBehavior
             return;
         }
 
-        // Only rewrite when there is actual multiline content (e.g. a column pasted from Excel).
-        if (!originalText.Contains('\n') && !originalText.Contains('\r'))
+        // Only intervene when there is actual multiline content (e.g. a column pasted from
+        // Excel). Otherwise let the default paste command handle it as usual.
+        if (!text.Contains('\n') && !text.Contains('\r'))
             return;
 
-        var converted = string.Join(";", originalText
+        var converted = string.Join(";", text
             .Replace("\r\n", "\n")
             .Replace('\r', '\n')
             .Split('\n', StringSplitOptions.RemoveEmptyEntries)
             .Select(x => x.Trim()));
 
-        try
-        {
-            Clipboard.SetText(converted);
-        }
-        catch (ExternalException)
-        {
-            return;
-        }
+        // Replace the current selection with the converted text ourselves and mark the command
+        // handled, instead of letting the default paste run - this avoids touching the system
+        // clipboard entirely (no risk of losing other clipboard formats or racing a paste
+        // elsewhere).
+        var selectionStart = textBox.SelectionStart;
+        var textBefore = textBox.Text[..selectionStart];
+        var textAfter = textBox.Text[(selectionStart + textBox.SelectionLength)..];
 
-        // Restore the original clipboard content once the paste command has consumed the
-        // rewritten text, so pasting elsewhere afterwards still yields what the user actually copied.
-        Dispatcher.CurrentDispatcher.BeginInvoke(DispatcherPriority.Background, () =>
-        {
-            try
-            {
-                Clipboard.SetText(originalText);
-            }
-            catch (ExternalException)
-            {
-                // Best effort - leave the rewritten text on the clipboard if restoring fails.
-            }
-        });
+        textBox.Text = textBefore + converted + textAfter;
+        textBox.SelectionStart = selectionStart + converted.Length;
+        textBox.SelectionLength = 0;
+
+        e.Handled = true;
     }
 }

--- a/Source/NETworkManager.Controls/ComboBoxPasteBehavior.cs
+++ b/Source/NETworkManager.Controls/ComboBoxPasteBehavior.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace NETworkManager.Controls;
+
+/// <summary>
+/// Attached property that converts multiline text (e.g. a column pasted from Excel) into a
+/// semicolon-separated single line when pasted into an editable <see cref="ComboBox"/>.
+///
+/// Without this the WPF TextBox inside the ComboBox (<see cref="TextBox.AcceptsReturn"/> is
+/// <c>false</c>) silently drops everything after the first line when multiline text is pasted.
+/// The conversion happens in <see cref="CommandManager.PreviewExecutedEvent"/> before the paste
+/// command actually runs, by rewriting the clipboard content to the semicolon-separated form.
+/// </summary>
+public static class ComboBoxPasteBehavior
+{
+    public static readonly DependencyProperty ConvertMultilineToSemicolonProperty =
+        DependencyProperty.RegisterAttached(
+            "ConvertMultilineToSemicolon",
+            typeof(bool),
+            typeof(ComboBoxPasteBehavior),
+            new PropertyMetadata(false, OnConvertMultilineToSemicolonChanged));
+
+    public static void SetConvertMultilineToSemicolon(UIElement element, bool value) =>
+        element.SetValue(ConvertMultilineToSemicolonProperty, value);
+
+    public static bool GetConvertMultilineToSemicolon(UIElement element) =>
+        (bool)element.GetValue(ConvertMultilineToSemicolonProperty);
+
+    private static void OnConvertMultilineToSemicolonChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not ComboBox comboBox)
+            return;
+
+        if ((bool)e.NewValue)
+            CommandManager.AddPreviewExecutedHandler(comboBox, OnPreviewExecuted);
+        else
+            CommandManager.RemovePreviewExecutedHandler(comboBox, OnPreviewExecuted);
+    }
+
+    private static void OnPreviewExecuted(object sender, ExecutedRoutedEventArgs e)
+    {
+        // Keyboard shortcut (Ctrl+V) and the paste context menu item both route through
+        // ApplicationCommands.Paste. Editing commands don't need to be handled here.
+        if (e.Command != ApplicationCommands.Paste)
+            return;
+
+        if (!Clipboard.ContainsText())
+            return;
+
+        var text = Clipboard.GetText();
+
+        // Only rewrite when there is actual multiline content (e.g. a column pasted from Excel).
+        if (!text.Contains('\n') && !text.Contains('\r'))
+            return;
+
+        var converted = string.Join(";", text
+            .Replace("\r\n", "\n")
+            .Replace('\r', '\n')
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(x => x.Trim()));
+
+        Clipboard.SetText(converted);
+    }
+}

--- a/Source/NETworkManager.Localization/Resources/StaticStrings.Designer.cs
+++ b/Source/NETworkManager.Localization/Resources/StaticStrings.Designer.cs
@@ -241,7 +241,7 @@ namespace NETworkManager.Localization.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 192.168.178.0/24; 10.0.0.0 - 10.0.0.9; 10.0.[0-9,20].[1-2]; server-01.borntoberoot.net/24.
+        ///   Looks up a localized string similar to 192.168.178.0/24; 10.8.0.0-100; 10.8.[0-9,254].1; server-01.borntoberoot.net/28.
         /// </summary>
         public static string ExampleHostRange {
             get {

--- a/Source/NETworkManager.Localization/Resources/StaticStrings.resx
+++ b/Source/NETworkManager.Localization/Resources/StaticStrings.resx
@@ -145,7 +145,7 @@
     <value>SERVER-01 or 10.0.0.10</value>
   </data>
   <data name="ExampleHostRange" xml:space="preserve">
-    <value>192.168.178.0/24; 10.0.0.0 - 10.0.0.9; 10.0.[0-9,20].[1-2]; server-01.borntoberoot.net/24</value>
+    <value>192.168.178.0/24; 10.8.0.0-100; 10.8.[0-9,254].1; server-01.borntoberoot.net/28</value>
   </data>
   <data name="ExampleIPv4Address" xml:space="preserve">
     <value>10.0.0.10</value>

--- a/Source/NETworkManager.Models/Network/HostRangeHelper.cs
+++ b/Source/NETworkManager.Models/Network/HostRangeHelper.cs
@@ -1,4 +1,5 @@
 ﻿using NETworkManager.Utilities;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,14 +18,15 @@ namespace NETworkManager.Models.Network;
 public static class HostRangeHelper
 {
     /// <summary>
-    ///     Create a list of hosts from a string input like "10.0.0.1; example.com; 10.0.0.0/24"
+    ///     Create a list of hosts from a string input like "10.0.0.1; example.com; 10.0.0.0/24".
+    ///     Inputs can also be separated by newlines (e.g. pasted from Excel, one host/range per line).
     /// </summary>
-    /// <param name="hosts">Hosts like "10.0.0.1; example.com; 10.0.0.0/24"</param>
+    /// <param name="hosts">Hosts like "10.0.0.1; example.com; 10.0.0.0/24" or newline-separated lines</param>
     /// <returns>List of hosts.</returns>
     public static IEnumerable<string> CreateListFromInput(string hosts)
     {
-        return hosts.Replace(" ", "").Split(';')
-            .Where(x => !string.IsNullOrEmpty(x))
+        return hosts.Replace(" ", "")
+            .Split([';', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
             .Select(x => x.Trim())
             .ToArray();
     }
@@ -56,6 +58,22 @@ public static class HostRangeHelper
 
                     Parallel.For(IPv4Address.ToInt32(network.Network), IPv4Address.ToInt32(network.Broadcast) + 1,
                         (i, state) =>
+                        {
+                            if (ct.IsCancellationRequested)
+                                state.Break();
+
+                            hostsBag.Add((IPv4Address.FromInt32(i), string.Empty));
+                        });
+
+                    break;
+
+                // 192.168.0.1-100
+                case var _ when RegexHelper.IPv4AddressShortRangeRegex().IsMatch(host):
+                    var shortRange = host.Split('-');
+                    var shortBase = shortRange[0][..shortRange[0].LastIndexOf('.')];
+
+                    Parallel.For(IPv4Address.ToInt32(IPAddress.Parse(shortRange[0])),
+                        IPv4Address.ToInt32(IPAddress.Parse($"{shortBase}.{shortRange[1]}")) + 1, (i, state) =>
                         {
                             if (ct.IsCancellationRequested)
                                 state.Break();

--- a/Source/NETworkManager.Models/Network/HostRangeHelper.cs
+++ b/Source/NETworkManager.Models/Network/HostRangeHelper.cs
@@ -31,6 +31,27 @@ public static class HostRangeHelper
             .ToArray();
     }
 
+    /// <summary>
+    ///     Adds every IPv4 address in the inclusive range [<paramref name="start" />, <paramref name="end" />] to
+    ///     <paramref name="hostsBag" />. Iterates using the unsigned IPv4 value widened to <see cref="long" /> so the
+    ///     inclusive upper bound stays representable even for the last address in the 32-bit space
+    ///     (255.255.255.255), which would otherwise overflow <see cref="int" /> arithmetic.
+    /// </summary>
+    private static void AddIPv4RangeToBag(IPAddress start, IPAddress end,
+        ConcurrentBag<(IPAddress ipAddress, string hostname)> hostsBag, CancellationToken ct)
+    {
+        var from = (long)unchecked((uint)IPv4Address.ToInt32(start));
+        var to = (long)unchecked((uint)IPv4Address.ToInt32(end));
+
+        Parallel.For(from, to + 1, (i, state) =>
+        {
+            if (ct.IsCancellationRequested)
+                state.Break();
+
+            hostsBag.Add((IPv4Address.FromInt32(unchecked((int)i)), string.Empty));
+        });
+    }
+
     public static async Task<(List<(IPAddress ipAddress, string hostname)> hosts, List<string> hostnamesNotResolved)>
         ResolveAsync(IEnumerable<string> hosts, bool dnsResolveHostnamePreferIPv4, CancellationToken cancellationToken)
     {
@@ -56,14 +77,7 @@ public static class HostRangeHelper
                 case var _ when RegexHelper.IPv4AddressSubnetmaskRegex().IsMatch(host):
                     var network = IPNetwork2.Parse(host);
 
-                    Parallel.For(IPv4Address.ToInt32(network.Network), IPv4Address.ToInt32(network.Broadcast) + 1,
-                        (i, state) =>
-                        {
-                            if (ct.IsCancellationRequested)
-                                state.Break();
-
-                            hostsBag.Add((IPv4Address.FromInt32(i), string.Empty));
-                        });
+                    AddIPv4RangeToBag(network.Network, network.Broadcast, hostsBag, ct);
 
                     break;
 
@@ -72,14 +86,8 @@ public static class HostRangeHelper
                     var shortRange = host.Split('-');
                     var shortBase = shortRange[0][..shortRange[0].LastIndexOf('.')];
 
-                    Parallel.For(IPv4Address.ToInt32(IPAddress.Parse(shortRange[0])),
-                        IPv4Address.ToInt32(IPAddress.Parse($"{shortBase}.{shortRange[1]}")) + 1, (i, state) =>
-                        {
-                            if (ct.IsCancellationRequested)
-                                state.Break();
-
-                            hostsBag.Add((IPv4Address.FromInt32(i), string.Empty));
-                        });
+                    AddIPv4RangeToBag(IPAddress.Parse(shortRange[0]),
+                        IPAddress.Parse($"{shortBase}.{shortRange[1]}"), hostsBag, ct);
 
                     break;
 
@@ -87,14 +95,7 @@ public static class HostRangeHelper
                 case var _ when RegexHelper.IPv4AddressRangeRegex().IsMatch(host):
                     var range = host.Split('-');
 
-                    Parallel.For(IPv4Address.ToInt32(IPAddress.Parse(range[0])),
-                        IPv4Address.ToInt32(IPAddress.Parse(range[1])) + 1, (i, state) =>
-                        {
-                            if (ct.IsCancellationRequested)
-                                state.Break();
-
-                            hostsBag.Add((IPv4Address.FromInt32(i), string.Empty));
-                        });
+                    AddIPv4RangeToBag(IPAddress.Parse(range[0]), IPAddress.Parse(range[1]), hostsBag, ct);
 
                     break;
 
@@ -188,14 +189,7 @@ public static class HostRangeHelper
                             network = IPNetwork2.Parse(
                                 $"{dnsResultWithSubnet.Value}/{hostAndSubnet[1]}");
 
-                            Parallel.For(IPv4Address.ToInt32(network.Network),
-                                IPv4Address.ToInt32(network.Broadcast) + 1, (i, state) =>
-                                {
-                                    if (ct.IsCancellationRequested)
-                                        state.Break();
-
-                                    hostsBag.Add((IPv4Address.FromInt32(i), string.Empty));
-                                });
+                            AddIPv4RangeToBag(network.Network, network.Broadcast, hostsBag, ct);
                         }
                         else
                         {

--- a/Source/NETworkManager.Utilities/RegexHelper.cs
+++ b/Source/NETworkManager.Utilities/RegexHelper.cs
@@ -43,13 +43,29 @@ public static partial class RegexHelper
     public static partial Regex IPv4AddressExtractRegex();
 
     /// <summary>
-    /// Provides a compiles regular expression that matches IPv4 address ranges in the format "start-end" like
+    /// Represents a regular expression pattern that matches valid shorthand IPv4 address ranges like
+    /// "192.168.178.1-100" (base IP + last octet range).
+    /// </summary>
+    private const string IPv4AddressShortRangeValues =
+        @"((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\-(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)";
+
+    /// <summary>
+    /// Provides a compiled regular expression that matches IPv4 address ranges in the format "start-end" like
     /// "192.168.178.0-192.168.178.255".
-    /// </summary>    
+    /// </summary>
     /// <returns>A <see cref="Regex"/> instance that matches strings representing IPv4 address ranges, such as
     /// "192.168.1.1-192.168.1.100".</returns>
     [GeneratedRegex($"^{IPv4AddressValues}-{IPv4AddressValues}$")]
     public static partial Regex IPv4AddressRangeRegex();
+
+    /// <summary>
+    /// Provides a compiled regular expression that matches shorthand IPv4 address ranges like
+    /// "192.168.178.1-100" (base IP followed by a last-octet range).
+    /// </summary>
+    /// <returns>A <see cref="Regex"/> instance that matches strings representing shorthand IPv4 address ranges,
+    /// such as "192.168.1.1-100" (192.168.1.1 to 192.168.1.100).</returns>
+    [GeneratedRegex($"^{IPv4AddressShortRangeValues}$")]
+    public static partial Regex IPv4AddressShortRangeRegex();
 
     /// <summary>
     /// Provides a compiled regular expression that matches valid IPv4 subnet mask like "255.255.0.0".

--- a/Source/NETworkManager.Validators/MultipleHostsRangeValidator.cs
+++ b/Source/NETworkManager.Validators/MultipleHostsRangeValidator.cs
@@ -1,6 +1,7 @@
 ﻿using NETworkManager.Localization.Resources;
 using NETworkManager.Models.Network;
 using NETworkManager.Utilities;
+using System;
 using System.DirectoryServices.ActiveDirectory;
 using System.Globalization;
 using System.Net;
@@ -18,7 +19,9 @@ public class MultipleHostsRangeValidator : ValidationRule
         if (value == null)
             return new ValidationResult(false, Strings.EnterValidIPScanRange);
 
-        foreach (var ipHostOrRange in ((string)value).Replace(" ", "").Split(';'))
+        foreach (var ipHostOrRange in ((string)value)
+            .Replace(" ", "")
+            .Split([';', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
         {
             // 192.168.0.1
             if (RegexHelper.IPv4AddressRegex().IsMatch(ipHostOrRange))
@@ -31,6 +34,19 @@ public class MultipleHostsRangeValidator : ValidationRule
             // 192.168.0.0/255.255.255.0
             if (RegexHelper.IPv4AddressSubnetmaskRegex().IsMatch(ipHostOrRange))
                 continue;
+
+            // 192.168.0.1-100
+            if (RegexHelper.IPv4AddressShortRangeRegex().IsMatch(ipHostOrRange))
+            {
+                var shortRange = ipHostOrRange.Split('-');
+                var shortBase = shortRange[0][..shortRange[0].LastIndexOf('.')];
+
+                if (IPv4Address.ToInt32(IPAddress.Parse(shortRange[0])) >
+                    IPv4Address.ToInt32(IPAddress.Parse($"{shortBase}.{shortRange[1]}")))
+                    isValid = false;
+
+                continue;
+            }
 
             // 192.168.0.0 - 192.168.0.100
             if (RegexHelper.IPv4AddressRangeRegex().IsMatch(ipHostOrRange))

--- a/Source/NETworkManager/Views/IPScannerView.xaml
+++ b/Source/NETworkManager/Views/IPScannerView.xaml
@@ -68,6 +68,7 @@
                           ItemsSource="{Binding Path=HostHistoryView}"
                           mah:TextBoxHelper.Watermark="{x:Static Member=localization:StaticStrings.ExampleHostRange}"
                           IsReadOnly="{Binding Path=IsRunning}"
+                          controls:ComboBoxPasteBehavior.ConvertMultilineToSemicolon="True"
                           Style="{StaticResource ResourceKey=HistoryComboBox}">
                     <ComboBox.Text>
                         <Binding Path="Host" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">

--- a/Source/NETworkManager/Views/PingMonitorHostView.xaml
+++ b/Source/NETworkManager/Views/PingMonitorHostView.xaml
@@ -97,6 +97,7 @@
                                       ItemsSource="{Binding Path=HostHistoryView}"
                                       mah:TextBoxHelper.Watermark="{x:Static Member=localization:StaticStrings.ExampleHostRange}"
                                       IsReadOnly="{Binding Path=IsRunning}"
+                                      controls:ComboBoxPasteBehavior.ConvertMultilineToSemicolon="True"
                                       Style="{StaticResource ResourceKey=HistoryComboBox}">
                                 <ComboBox.Text>
                                     <Binding Path="Host" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">

--- a/Source/NETworkManager/Views/PortScannerView.xaml
+++ b/Source/NETworkManager/Views/PortScannerView.xaml
@@ -60,6 +60,7 @@
                           ItemsSource="{Binding HostHistoryView}"
                           mah:TextBoxHelper.Watermark="{x:Static localization:StaticStrings.ExampleHostRange}"
                           IsReadOnly="{Binding Path=IsRunning}"
+                          controls:ComboBoxPasteBehavior.ConvertMultilineToSemicolon="True"
                           Style="{StaticResource HistoryComboBox}">
                     <ComboBox.Text>
                         <Binding Path="Host" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">

--- a/Source/NETworkManager/Views/PortScannerView.xaml
+++ b/Source/NETworkManager/Views/PortScannerView.xaml
@@ -80,6 +80,7 @@
                           ItemsSource="{Binding PortsHistoryView}"
                           mah:TextBoxHelper.Watermark="{x:Static localization:StaticStrings.ExamplePortScanRange}"
                           IsReadOnly="{Binding Path=IsRunning}"
+                          controls:ComboBoxPasteBehavior.ConvertMultilineToSemicolon="True"
                           Style="{StaticResource HistoryComboBox}">
                     <ComboBox.Text>
                         <Binding Path="Ports" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">

--- a/Website/docs/application/ip-scanner.md
+++ b/Website/docs/application/ip-scanner.md
@@ -34,7 +34,7 @@ With the **IP Scanner** you can scan for active devices based on the hostname or
 
 :::note
 
-Multiple inputs can be combined with a semicolon (`;`) or separated by newlines (one input per line, e.g. pasted from Excel).
+Multiple inputs can be combined with a semicolon (`;`). A column pasted from Excel (one entry per line) is converted to the semicolon-separated form automatically.
 
 Example: `10.0.0.0/24; 10.0.[10-20]1`
 

--- a/Website/docs/application/ip-scanner.md
+++ b/Website/docs/application/ip-scanner.md
@@ -34,9 +34,11 @@ With the **IP Scanner** you can scan for active devices based on the hostname or
 
 :::note
 
-Multiple inputs can be combined with a semicolon (`;`).
+Multiple inputs can be combined with a semicolon (`;`) or separated by newlines (one input per line, e.g. pasted from Excel).
 
 Example: `10.0.0.0/24; 10.0.[10-20]1`
+
+Shorthand ranges like `192.168.0.1-100` (192.168.0.1 to 192.168.0.100) are also supported.
 
 :::
 

--- a/Website/docs/application/ip-scanner.md
+++ b/Website/docs/application/ip-scanner.md
@@ -25,6 +25,7 @@ With the **IP Scanner** you can scan for active devices based on the hostname or
 | -------------------------------- | -------------------------------------------------------------------------------------------- |
 | `10.0.0.1`                       | Single IP address (`10.0.0.1`)                                                               |
 | `10.0.0.100 - 10.0.0.199`        | All IP addresses in a given range (`10.0.0.100`, `10.0.0.101`, ..., `10.0.0.199`)            |
+| `10.0.0.100-199`                 | All IP addresses in a given range, shorthand for the last octet (`10.0.0.100`, ..., `10.0.0.199`) |
 | `10.0.0.0/23`                    | All IP addresses in a subnet (`10.0.0.0`, ..., `10.0.1.255`)                                 |
 | `10.0.0.0/255.255.254.0`         | All IP addresses in a subnet (`10.0.0.0`, ..., `10.0.1.255`)                                 |
 | `10.0.[0-9,20].[1-2]`            | Multiple IP addresses like (`10.0.0.1`, `10.0.0.2`, `10.0.1.1`, ...,`10.0.9.2`, `10.0.20.1`) |
@@ -36,9 +37,7 @@ With the **IP Scanner** you can scan for active devices based on the hostname or
 
 Multiple inputs can be combined with a semicolon (`;`). A column pasted from Excel (one entry per line) is converted to the semicolon-separated form automatically.
 
-Example: `10.0.0.0/24; 10.0.[10-20]1`
-
-Shorthand ranges like `192.168.0.1-100` (192.168.0.1 to 192.168.0.100) are also supported.
+Example: `10.0.0.0/24; 10.0.[10-20].1; 10.0.0.100-199`
 
 :::
 

--- a/Website/docs/application/ping-monitor.md
+++ b/Website/docs/application/ping-monitor.md
@@ -22,6 +22,7 @@ ICMP (Internet Control Message Protocol) is a network-layer protocol used to sen
 | -------------------------------- | ------------------------------------------------------------------------------------------ |
 | `10.0.0.1`                       | Single IP address (`10.0.0.1`)                                                             |
 | `10.0.0.100 - 10.0.0.199`        | All IP addresses in a given range (`10.0.0.100`, `10.0.0.101`, ..., `10.0.0.199`)          |
+| `10.0.0.100-199`                 | All IP addresses in a given range, shorthand for the last octet (`10.0.0.100`, ..., `10.0.0.199`) |
 | `10.0.0.0/23`                    | All IP addresses in a subnet (`10.0.0.0`, ..., `10.0.1.255`)                               |
 | `10.0.0.0/255.255.254.0`         | All IP addresses in a subnet (`10.0.0.0`, ..., `10.0.1.255`)                               |
 | `10.0.[0-9,20].[1-2]`            | Multiple IP addresses like (`10.0.0.1`, `10.0.0.2`, `10.0.1.1`, ...,`10.0.9.2`, `10.0.20.1`) |
@@ -33,9 +34,7 @@ ICMP (Internet Control Message Protocol) is a network-layer protocol used to sen
 
 Multiple inputs can be combined with a semicolon (`;`). A column pasted from Excel (one entry per line) is converted to the semicolon-separated form automatically.
 
-Example: `10.0.0.0/24; 10.0.[10-20]1`
-
-Shorthand ranges like `192.168.0.1-100` (192.168.0.1 to 192.168.0.100) are also supported.
+Example: `10.0.0.0/24; 10.0.[10-20].1; 10.0.0.100-199`
 
 :::
 

--- a/Website/docs/application/ping-monitor.md
+++ b/Website/docs/application/ping-monitor.md
@@ -31,7 +31,7 @@ ICMP (Internet Control Message Protocol) is a network-layer protocol used to sen
 
 :::note
 
-Multiple inputs can be combined with a semicolon (`;`) or separated by newlines (one input per line, e.g. pasted from Excel).
+Multiple inputs can be combined with a semicolon (`;`). A column pasted from Excel (one entry per line) is converted to the semicolon-separated form automatically.
 
 Example: `10.0.0.0/24; 10.0.[10-20]1`
 

--- a/Website/docs/application/ping-monitor.md
+++ b/Website/docs/application/ping-monitor.md
@@ -31,9 +31,11 @@ ICMP (Internet Control Message Protocol) is a network-layer protocol used to sen
 
 :::note
 
-Multiple inputs can be combined with a semicolon (`;`).
+Multiple inputs can be combined with a semicolon (`;`) or separated by newlines (one input per line, e.g. pasted from Excel).
 
 Example: `10.0.0.0/24; 10.0.[10-20]1`
+
+Shorthand ranges like `192.168.0.1-100` (192.168.0.1 to 192.168.0.100) are also supported.
 
 :::
 

--- a/Website/docs/application/port-scanner.md
+++ b/Website/docs/application/port-scanner.md
@@ -45,9 +45,11 @@ TCP (Transmission Control Protocol) is a connection-oriented transport-layer pro
 
 :::note
 
-Multiple inputs can be combined with a semicolon (`;`).
+Multiple inputs can be combined with a semicolon (`;`) or separated by newlines (one input per line, e.g. pasted from Excel).
 
 Example: `10.0.0.0/24; 10.0.[10-20]1` or `1-1024; 8080; 8443`
+
+Shorthand ranges like `192.168.0.1-100` (192.168.0.1 to 192.168.0.100) are also supported.
 
 :::
 

--- a/Website/docs/application/port-scanner.md
+++ b/Website/docs/application/port-scanner.md
@@ -45,7 +45,7 @@ TCP (Transmission Control Protocol) is a connection-oriented transport-layer pro
 
 :::note
 
-Multiple inputs can be combined with a semicolon (`;`) or separated by newlines (one input per line, e.g. pasted from Excel).
+Multiple inputs can be combined with a semicolon (`;`). A column pasted from Excel (one entry per line) is converted to the semicolon-separated form automatically.
 
 Example: `10.0.0.0/24; 10.0.[10-20]1` or `1-1024; 8080; 8443`
 

--- a/Website/docs/application/port-scanner.md
+++ b/Website/docs/application/port-scanner.md
@@ -31,6 +31,7 @@ TCP (Transmission Control Protocol) is a connection-oriented transport-layer pro
 | -------------------------------- | -------------------------------------------------------------------------------------------- |
 | `10.0.0.1`                       | Single IP address (`10.0.0.1`)                                                               |
 | `10.0.0.100 - 10.0.0.199`        | All IP addresses in a given range (`10.0.0.100`, `10.0.0.101`, ..., `10.0.0.199`)            |
+| `10.0.0.100-199`                 | All IP addresses in a given range, shorthand for the last octet (`10.0.0.100`, ..., `10.0.0.199`) |
 | `10.0.0.0/23`                    | All IP addresses in a subnet (`10.0.0.0`, ..., `10.0.1.255`)                                 |
 | `10.0.0.0/255.255.254.0`         | All IP addresses in a subnet (`10.0.0.0`, ..., `10.0.1.255`)                                 |
 | `10.0.[0-9,20].[1-2]`            | Multiple IP addresses like (`10.0.0.1`, `10.0.0.2`, `10.0.1.1`, ...,`10.0.9.2`, `10.0.20.1`) |
@@ -47,9 +48,7 @@ TCP (Transmission Control Protocol) is a connection-oriented transport-layer pro
 
 Multiple inputs can be combined with a semicolon (`;`). A column pasted from Excel (one entry per line) is converted to the semicolon-separated form automatically.
 
-Example: `10.0.0.0/24; 10.0.[10-20]1` or `1-1024; 8080; 8443`
-
-Shorthand ranges like `192.168.0.1-100` (192.168.0.1 to 192.168.0.100) are also supported.
+Example: `10.0.0.0/24; 10.0.[10-20].1; 10.0.0.100-199` or `1-1024; 8080; 8443`
 
 :::
 

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -33,18 +33,23 @@ Release date: **xx.xx.2026**
 
 - The collapsed/expanded state of profile groups (e.g. **linux-server**) is now remembered per profile file and shared across all tools, instead of resetting every time you switch tools or restart the application. [#3539](https://github.com/BornToBeRoot/NETworkManager/pull/3539)
 
-**IP Scanner, Port Scanner & Ping Monitor**
-
-- Host input fields now accept newline-separated hosts (one per line, e.g. pasted from Excel) in addition to the existing semicolon (`;`) separator. Shorthand IPv4 ranges like `192.168.0.1-100` are supported as well. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
-
 **IP Scanner**
 
+- Host input now accepts newline-separated hosts (one per line, e.g. a column pasted from Excel), converted automatically to the semicolon-separated form. Thanks to [@dearmb](https://github.com/dearmb) [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
+- Host input now supports shorthand IPv4 ranges like `192.168.0.1-100`, in addition to the existing `192.168.0.0-192.168.0.100` and `192.168.[0-100].1` range formats. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
 - Added `135` (RPC) and `9100` (raw printing) to the default **Ports** list used to detect if a host is reachable. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
 - Reduced the default **Max. concurrent port threads** from `5` to `4`. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
 - Reduced the default **Max. concurrent host threads** from `256` to `64`, a more conservative default that puts less simultaneous load on the scanned network. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
 
+**Ping Monitor**
+
+- Host input now accepts newline-separated hosts (one per line, e.g. a column pasted from Excel), converted automatically to the semicolon-separated form. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
+- Host input now supports shorthand IPv4 ranges like `192.168.0.1-100`, in addition to the existing `192.168.0.0-192.168.0.100` and `192.168.[0-100].1` range formats. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
+
 **Port Scanner**
 
+- Host and Ports input fields now accept newline-separated entries (one per line, e.g. a column pasted from Excel), converted automatically to the semicolon-separated form. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
+- Host input now supports shorthand IPv4 ranges like `192.168.0.1-100`, in addition to the existing `192.168.0.0-192.168.0.100` and `192.168.[0-100].1` range formats. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
 - Reduced the default **Max. concurrent host threads** from `5` to `4`. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
 - Reduced the default **Max. concurrent port threads** from `256` to `64`, a more conservative default that puts less simultaneous load on the scanned host. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
 - Added a new **Well-known ports** (`1-1024`) default port profile. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -33,6 +33,10 @@ Release date: **xx.xx.2026**
 
 - The collapsed/expanded state of profile groups (e.g. **linux-server**) is now remembered per profile file and shared across all tools, instead of resetting every time you switch tools or restart the application. [#3539](https://github.com/BornToBeRoot/NETworkManager/pull/3539)
 
+**IP Scanner, Port Scanner & Ping Monitor**
+
+- Host input fields now accept newline-separated hosts (one per line, e.g. pasted from Excel) in addition to the existing semicolon (`;`) separator. Shorthand IPv4 ranges like `192.168.0.1-100` are supported as well. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
+
 **IP Scanner**
 
 - Added `135` (RPC) and `9100` (raw printing) to the default **Ports** list used to detect if a host is reachable. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)


### PR DESCRIPTION
## Changes proposed in this pull request

- Host input fields in the **IP Scanner**, **Port Scanner** and **Ping Monitor** now accept newline-separated hosts (one input per line, e.g. when pasting a column from Excel) in addition to the existing semicolon (`;`) separator. The old `IP;IP;IP` syntax keeps working unchanged.
- Added support for shorthand IPv4 ranges like `192.168.0.1-100`, which expand to `192.168.0.1` up to `192.168.0.100`. Full ranges (`192.168.0.1-192.168.0.100`), CIDR, wildcard octets and hostnames all keep working as before.
- Updated the documentation for all three tools to mention the newline separator and the shorthand range format.

### Implementation notes

The three tools share a single host parser (`HostRangeHelper.CreateListFromInput`) and a single WPF validation rule (`MultipleHostsRangeValidator`), so the change is minimal and covers all of them at once:

- `HostRangeHelper.CreateListFromInput` now splits on `;`, CR and LF while ignoring empty entries.
- `MultipleHostsRangeValidator` uses the same separators and recognizes shorthand ranges.
- A new `RegexHelper.IPv4AddressShortRangeRegex` matches shorthand ranges like `192.168.0.1-100`.
- `HostRangeHelper.ResolveAsync` expands shorthand ranges into the full IP list (the same `Parallel.For` expansion used for full ranges, so cross-octet shorthand like `10.0.0.254-10.0.1.2` works too).

## Related issue(s)

- None

## Copilot generated summary

<details>
<summary>Copilot summary</summary>

Host inputs in the IP Scanner, Port Scanner and Ping Monitor now accept newline-separated hosts in addition to the existing semicolon separator, so lists can be pasted directly from Excel. Shorthand IPv4 ranges such as `192.168.0.1-100` are also supported. The shared parser and validator were updated, and documentation for all three tools was refreshed.

</details>

## To-Do

- [x] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs) to reflect this changes
- [ ] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
