### PR TITLE
Feature: Add count up/down, open/closed and re-work ping monitor view

### DIFF
--- a/Source/NETworkManager.Converters/PingMonitorGroupSummaryConverter.cs
+++ b/Source/NETworkManager.Converters/PingMonitorGroupSummaryConverter.cs
@@ -3,9 +3,9 @@ using System.Globalization;
 using System.Linq;
 using System.Windows;
 using System.Windows.Data;
-using NETworkManager.Views;
+using NETworkManager.Models.Network;
 
-namespace NETworkManager.ViewModels;
+namespace NETworkManager.Converters;
 
 /// <summary>
 /// Formats the count of hosts up (reachable), down (unreachable) or paused (not running) within
@@ -15,9 +15,8 @@ namespace NETworkManager.ViewModels;
 /// </summary>
 /// <remarks>
 /// Bound as a <see cref="MultiBinding"/> with the <see cref="CollectionViewGroup"/> as the first
-/// value and <see cref="PingMonitorHostViewModel.HostsChangeVersion"/> as the second. The second
-/// value isn't used directly, it only forces re-evaluation whenever a host's
-/// <see cref="PingMonitorViewModel.IsReachable"/>/<see cref="PingMonitorViewModel.IsRunning"/>
+/// value and a per-group change-notification trigger as the second. The second value isn't used
+/// directly, it only forces re-evaluation whenever a host's <see cref="IPingMonitorHostStatus"/>
 /// changes, since <see cref="CollectionViewGroup"/> itself only raises change notifications for
 /// item add/remove, not for property changes on its items.
 /// </remarks>
@@ -28,21 +27,28 @@ public sealed class PingMonitorGroupSummaryConverter : IMultiValueConverter
         if (values.Length == 0 || values[0] is not CollectionViewGroup group)
             return parameter as string == "PausedVisibility" ? Visibility.Collapsed : string.Empty;
 
-        var hosts = group.Items.OfType<PingMonitorView>().Select(host => host.ViewModel).ToList();
+        var up = 0;
+        var down = 0;
+        var paused = 0;
 
-        switch (parameter as string)
+        foreach (var host in group.Items.OfType<IPingMonitorHostStatus>())
         {
-            case "Up":
-                return $"{hosts.Count(host => host.IsRunning && host.IsReachable)} {values[2]}";
-            case "Down":
-                return $"{hosts.Count(host => host.IsRunning && !host.IsReachable)} {values[2]}";
-            case "Paused":
-                return $"{hosts.Count(host => !host.IsRunning)} {values[2]}";
-            case "PausedVisibility":
-                return hosts.Any(host => !host.IsRunning) ? Visibility.Visible : Visibility.Collapsed;
-            default:
-                return string.Empty;
+            if (!host.IsRunning)
+                paused++;
+            else if (host.IsReachable)
+                up++;
+            else
+                down++;
         }
+
+        return parameter as string switch
+        {
+            "Up" => $"{up} {values[2]}",
+            "Down" => $"{down} {values[2]}",
+            "Paused" => $"{paused} {values[2]}",
+            "PausedVisibility" => paused > 0 ? Visibility.Visible : Visibility.Collapsed,
+            _ => string.Empty
+        };
     }
 
     public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)

--- a/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
+++ b/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
@@ -3432,7 +3432,16 @@ namespace NETworkManager.Localization.Resources {
                 return ResourceManager.GetString("DontFragment", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Down.
+        /// </summary>
+        public static string Down {
+            get {
+                return ResourceManager.GetString("Down", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Download.
         /// </summary>
@@ -8091,7 +8100,16 @@ namespace NETworkManager.Localization.Resources {
                 return ResourceManager.GetString("Pause", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Paused.
+        /// </summary>
+        public static string Paused {
+            get {
+                return ResourceManager.GetString("Paused", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Performance.
         /// </summary>
@@ -11497,7 +11515,7 @@ namespace NETworkManager.Localization.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Status change.
+        ///   Looks up a localized string similar to Last status change.
         /// </summary>
         public static string StatusChange {
             get {
@@ -12233,7 +12251,16 @@ namespace NETworkManager.Localization.Resources {
                 return ResourceManager.GetString("UntrayBringWindowToForeground", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Up.
+        /// </summary>
+        public static string Up {
+            get {
+                return ResourceManager.GetString("Up", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Update.
         /// </summary>

--- a/Source/NETworkManager.Localization/Resources/Strings.resx
+++ b/Source/NETworkManager.Localization/Resources/Strings.resx
@@ -228,6 +228,9 @@
   <data name="DontFragment" xml:space="preserve">
     <value>Don't fragment</value>
   </data>
+  <data name="Down" xml:space="preserve">
+    <value>Down</value>
+  </data>
   <data name="EditCredentials" xml:space="preserve">
     <value>Edit credentials</value>
   </data>
@@ -1251,6 +1254,9 @@ Profile files are not affected!</value>
   </data>
   <data name="UntrayBringWindowToForeground" xml:space="preserve">
     <value>Untray / Bring window to foreground</value>
+  </data>
+  <data name="Up" xml:space="preserve">
+    <value>Up</value>
   </data>
   <data name="URL" xml:space="preserve">
     <value>URL</value>
@@ -2442,6 +2448,9 @@ is disabled!</value>
   <data name="Pause" xml:space="preserve">
     <value>Pause</value>
   </data>
+  <data name="Paused" xml:space="preserve">
+    <value>Paused</value>
+  </data>
   <data name="Resume" xml:space="preserve">
     <value>Resume</value>
   </data>
@@ -2836,7 +2845,7 @@ is disabled!</value>
     <value>Received</value>
   </data>
   <data name="StatusChange" xml:space="preserve">
-    <value>Status change</value>
+    <value>Last status change</value>
   </data>
   <data name="UpdateAvailable" xml:space="preserve">
     <value>Update available!</value>

--- a/Source/NETworkManager.Models/Network/IPScanner.cs
+++ b/Source/NETworkManager.Models/Network/IPScanner.cs
@@ -21,6 +21,20 @@ public sealed class IPScanner(IPScannerOptions options)
     #region Variables
 
     private int _progressValue;
+    private int _hostsUp;
+    private int _hostsDown;
+
+    /// <summary>
+    ///     Gets the number of hosts found to be reachable so far. Thread-safe; may be read from
+    ///     any thread while the scan is running.
+    /// </summary>
+    public int HostsUp => Volatile.Read(ref _hostsUp);
+
+    /// <summary>
+    ///     Gets the number of hosts found to be unreachable so far. Thread-safe; may be read from
+    ///     any thread while the scan is running.
+    /// </summary>
+    public int HostsDown => Volatile.Read(ref _hostsDown);
 
     #endregion
 
@@ -128,6 +142,13 @@ public sealed class IPScanner(IPScannerOptions options)
                     var isReachable = pingInfo.Status == IPStatus.Success || // ICMP response
                                       isAnyPortOpen || // Any port is open
                                       netBIOSInfo.IsReachable; // NetBIOS response
+
+                    // Count reachable/unreachable hosts unconditionally, since ShowAllResults
+                    // (below) may prevent unreachable hosts from ever reaching HostScanned
+                    if (isReachable)
+                        Interlocked.Increment(ref _hostsUp);
+                    else
+                        Interlocked.Increment(ref _hostsDown);
 
                     // DNS & ARP
                     if (isReachable || options.ShowAllResults)

--- a/Source/NETworkManager.Models/Network/IPScanner.cs
+++ b/Source/NETworkManager.Models/Network/IPScanner.cs
@@ -21,20 +21,20 @@ public sealed class IPScanner(IPScannerOptions options)
     #region Variables
 
     private int _progressValue;
-    private int _hostsUp;
-    private int _hostsDown;
+    private readonly InterlockedCounter _hostsUp = new();
+    private readonly InterlockedCounter _hostsDown = new();
 
     /// <summary>
     ///     Gets the number of hosts found to be reachable so far. Thread-safe; may be read from
     ///     any thread while the scan is running.
     /// </summary>
-    public int HostsUp => Volatile.Read(ref _hostsUp);
+    public int HostsUp => _hostsUp.Value;
 
     /// <summary>
     ///     Gets the number of hosts found to be unreachable so far. Thread-safe; may be read from
     ///     any thread while the scan is running.
     /// </summary>
-    public int HostsDown => Volatile.Read(ref _hostsDown);
+    public int HostsDown => _hostsDown.Value;
 
     #endregion
 
@@ -146,9 +146,9 @@ public sealed class IPScanner(IPScannerOptions options)
                     // Count reachable/unreachable hosts unconditionally, since ShowAllResults
                     // (below) may prevent unreachable hosts from ever reaching HostScanned
                     if (isReachable)
-                        Interlocked.Increment(ref _hostsUp);
+                        _hostsUp.Increment();
                     else
-                        Interlocked.Increment(ref _hostsDown);
+                        _hostsDown.Increment();
 
                     // DNS & ARP
                     if (isReachable || options.ShowAllResults)

--- a/Source/NETworkManager.Models/Network/IPingMonitorHostStatus.cs
+++ b/Source/NETworkManager.Models/Network/IPingMonitorHostStatus.cs
@@ -1,0 +1,19 @@
+namespace NETworkManager.Models.Network;
+
+/// <summary>
+///     Minimal reachability/running status of a Ping Monitor host, exposed so lower-level
+///     projects (e.g. converters) can read a host's status without depending on the concrete
+///     View/ViewModel types that implement it.
+/// </summary>
+public interface IPingMonitorHostStatus
+{
+    /// <summary>
+    ///     Gets a value indicating whether the host is reachable (responds to ping).
+    /// </summary>
+    bool IsReachable { get; }
+
+    /// <summary>
+    ///     Gets a value indicating whether the ping monitoring is currently running.
+    /// </summary>
+    bool IsRunning { get; }
+}

--- a/Source/NETworkManager.Models/Network/PortScanner.cs
+++ b/Source/NETworkManager.Models/Network/PortScanner.cs
@@ -22,8 +22,22 @@ public sealed class PortScanner
     #region Variables
 
     private int _progressValue;
+    private int _portsOpen;
+    private int _portsClosed;
 
     private readonly PortScannerOptions _options;
+
+    /// <summary>
+    ///     Gets the number of ports found to be open so far. Thread-safe; may be read from any
+    ///     thread while the scan is running.
+    /// </summary>
+    public int PortsOpen => Volatile.Read(ref _portsOpen);
+
+    /// <summary>
+    ///     Gets the number of ports found to be closed (or timed out) so far. Thread-safe; may be
+    ///     read from any thread while the scan is running.
+    /// </summary>
+    public int PortsClosed => Volatile.Read(ref _portsClosed);
 
     #endregion
 
@@ -101,6 +115,13 @@ public sealed class PortScanner
                     {
                         var portState = await PortProbe.ProbeAsync(host.ipAddress, port, _options.Timeout, portCt)
                             .ConfigureAwait(false);
+
+                        // Count open/closed ports unconditionally, since ShowAllResults (below)
+                        // may prevent closed ports from ever reaching PortScanned
+                        if (portState == PortState.Open)
+                            Interlocked.Increment(ref _portsOpen);
+                        else
+                            Interlocked.Increment(ref _portsClosed);
 
                         if (_options.ShowAllResults || portState == PortState.Open)
                             OnPortScanned(new PortScannerPortScannedArgs(

--- a/Source/NETworkManager.Models/Network/PortScanner.cs
+++ b/Source/NETworkManager.Models/Network/PortScanner.cs
@@ -22,8 +22,8 @@ public sealed class PortScanner
     #region Variables
 
     private int _progressValue;
-    private int _portsOpen;
-    private int _portsClosed;
+    private readonly InterlockedCounter _portsOpen = new();
+    private readonly InterlockedCounter _portsClosed = new();
 
     private readonly PortScannerOptions _options;
 
@@ -31,13 +31,13 @@ public sealed class PortScanner
     ///     Gets the number of ports found to be open so far. Thread-safe; may be read from any
     ///     thread while the scan is running.
     /// </summary>
-    public int PortsOpen => Volatile.Read(ref _portsOpen);
+    public int PortsOpen => _portsOpen.Value;
 
     /// <summary>
     ///     Gets the number of ports found to be closed (or timed out) so far. Thread-safe; may be
     ///     read from any thread while the scan is running.
     /// </summary>
-    public int PortsClosed => Volatile.Read(ref _portsClosed);
+    public int PortsClosed => _portsClosed.Value;
 
     #endregion
 
@@ -119,9 +119,9 @@ public sealed class PortScanner
                         // Count open/closed ports unconditionally, since ShowAllResults (below)
                         // may prevent closed ports from ever reaching PortScanned
                         if (portState == PortState.Open)
-                            Interlocked.Increment(ref _portsOpen);
+                            _portsOpen.Increment();
                         else
-                            Interlocked.Increment(ref _portsClosed);
+                            _portsClosed.Increment();
 
                         if (_options.ShowAllResults || portState == PortState.Open)
                             OnPortScanned(new PortScannerPortScannedArgs(

--- a/Source/NETworkManager.Utilities/InterlockedCounter.cs
+++ b/Source/NETworkManager.Utilities/InterlockedCounter.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+
+namespace NETworkManager.Utilities;
+
+/// <summary>
+///     A simple counter that can be incremented from any thread and read from any other thread
+///     without locking.
+/// </summary>
+public sealed class InterlockedCounter
+{
+    private int _value;
+
+    /// <summary>
+    ///     Gets the current value.
+    /// </summary>
+    public int Value => Volatile.Read(ref _value);
+
+    /// <summary>
+    ///     Increments the value by one.
+    /// </summary>
+    public void Increment()
+    {
+        Interlocked.Increment(ref _value);
+    }
+}

--- a/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
@@ -490,6 +490,17 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
 
         Results.Clear();
 
+        // Reset before hostname resolution too (not just after), so a cancellation during
+        // resolution can't flush the previous scan's stale totals - HostsToScan = 0 also hides
+        // the up/down summary until the new scan's host count is known.
+        HostsToScan = 0;
+        HostsScanned = 0;
+        HostsUp = 0;
+        HostsDown = 0;
+        Volatile.Write(ref _latestHostsScanned, 0);
+        Volatile.Write(ref _latestHostsUp, 0);
+        Volatile.Write(ref _latestHostsDown, 0);
+
         DragablzTabItem.SetTabHeader(_tabId, Host);
 
         _cancellationTokenSource?.Dispose();
@@ -518,12 +529,6 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
         }
 
         HostsToScan = hosts.hosts.Count;
-        HostsScanned = 0;
-        HostsUp = 0;
-        HostsDown = 0;
-        Volatile.Write(ref _latestHostsScanned, 0);
-        Volatile.Write(ref _latestHostsUp, 0);
-        Volatile.Write(ref _latestHostsDown, 0);
 
         PreparingScan = false;
 

--- a/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/IPScannerViewModel.cs
@@ -54,6 +54,8 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
     // (unconditionally, unlike HostScanned), so it's flushed to the bound property on the same
     // timer instead of updating it directly from the background thread on every event.
     private int _latestHostsScanned;
+    private int _latestHostsUp;
+    private int _latestHostsDown;
 
     /// <summary>
     /// Gets or sets the host or IP range to scan.
@@ -197,6 +199,38 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
     /// Gets or sets the number of hosts already scanned.
     /// </summary>
     public int HostsScanned
+    {
+        get;
+        set
+        {
+            if (value == field)
+                return;
+
+            field = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the number of hosts found to be reachable so far.
+    /// </summary>
+    public int HostsUp
+    {
+        get;
+        set
+        {
+            if (value == field)
+                return;
+
+            field = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the number of hosts found to be unreachable so far.
+    /// </summary>
+    public int HostsDown
     {
         get;
         set
@@ -485,7 +519,11 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
 
         HostsToScan = hosts.hosts.Count;
         HostsScanned = 0;
+        HostsUp = 0;
+        HostsDown = 0;
         Volatile.Write(ref _latestHostsScanned, 0);
+        Volatile.Write(ref _latestHostsUp, 0);
+        Volatile.Write(ref _latestHostsDown, 0);
 
         PreparingScan = false;
 
@@ -768,20 +806,29 @@ public class IPScannerViewModel : ViewModelBase, IProfileManagerMinimal
     /// pick up on the next timer tick, instead of updating the bound property directly from a
     /// background thread on every single host.
     /// </summary>
-    /// <param name="sender">The source of the event.</param>
+    /// <param name="sender">The <see cref="IPScanner"/> instance raising the event.</param>
     /// <param name="e">The <see cref="ProgressChangedArgs"/> instance containing the event data.</param>
     private void ProgressChanged(object sender, ProgressChangedArgs e)
     {
         Volatile.Write(ref _latestHostsScanned, e.Value);
+
+        if (sender is IPScanner ipScanner)
+        {
+            Volatile.Write(ref _latestHostsUp, ipScanner.HostsUp);
+            Volatile.Write(ref _latestHostsDown, ipScanner.HostsDown);
+        }
     }
 
     /// <summary>
-    /// Pushes the latest buffered progress value into <see cref="HostsScanned"/>. Always called
-    /// on the UI thread - same calling contexts as <see cref="FlushResultsBuffer"/>.
+    /// Pushes the latest buffered progress value into <see cref="HostsScanned"/>,
+    /// <see cref="HostsUp"/> and <see cref="HostsDown"/>. Always called on the UI thread - same
+    /// calling contexts as <see cref="FlushResultsBuffer"/>.
     /// </summary>
     private void FlushProgress()
     {
         HostsScanned = Volatile.Read(ref _latestHostsScanned);
+        HostsUp = Volatile.Read(ref _latestHostsUp);
+        HostsDown = Volatile.Read(ref _latestHostsDown);
     }
 
     /// <summary>

--- a/Source/NETworkManager/ViewModels/PingMonitorGroupSummaryConverter.cs
+++ b/Source/NETworkManager/ViewModels/PingMonitorGroupSummaryConverter.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Windows;
+using System.Windows.Data;
+using NETworkManager.Views;
+
+namespace NETworkManager.ViewModels;
+
+/// <summary>
+/// Formats the count of hosts up (reachable), down (unreachable) or paused (not running) within
+/// a Ping Monitor group, selected via <c>ConverterParameter</c> ("Up", "Down", "Paused" - formats
+/// "{count} {label}" using the label bound as the third value - or "PausedVisibility", which
+/// instead returns a <see cref="Visibility"/> so the paused count can be hidden while zero).
+/// </summary>
+/// <remarks>
+/// Bound as a <see cref="MultiBinding"/> with the <see cref="CollectionViewGroup"/> as the first
+/// value and <see cref="PingMonitorHostViewModel.HostsChangeVersion"/> as the second. The second
+/// value isn't used directly, it only forces re-evaluation whenever a host's
+/// <see cref="PingMonitorViewModel.IsReachable"/>/<see cref="PingMonitorViewModel.IsRunning"/>
+/// changes, since <see cref="CollectionViewGroup"/> itself only raises change notifications for
+/// item add/remove, not for property changes on its items.
+/// </remarks>
+public sealed class PingMonitorGroupSummaryConverter : IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values.Length == 0 || values[0] is not CollectionViewGroup group)
+            return parameter as string == "PausedVisibility" ? Visibility.Collapsed : string.Empty;
+
+        var hosts = group.Items.OfType<PingMonitorView>().Select(host => host.ViewModel).ToList();
+
+        switch (parameter as string)
+        {
+            case "Up":
+                return $"{hosts.Count(host => host.IsRunning && host.IsReachable)} {values[2]}";
+            case "Down":
+                return $"{hosts.Count(host => host.IsRunning && !host.IsReachable)} {values[2]}";
+            case "Paused":
+                return $"{hosts.Count(host => !host.IsRunning)} {values[2]}";
+            case "PausedVisibility":
+                return hosts.Any(host => !host.IsRunning) ? Visibility.Visible : Visibility.Collapsed;
+            default:
+                return string.Empty;
+        }
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
@@ -18,6 +18,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Input;
+using System.Windows.Threading;
 
 namespace NETworkManager.ViewModels;
 
@@ -415,10 +416,19 @@ public class PingMonitorHostViewModel : ProfileHostViewModelBase
     ///     Bumps <see cref="HostsChangeVersion"/> whenever a host's reachability or running state
     ///     changes, so the per-group up/down summary re-evaluates.
     /// </summary>
+    /// <remarks>
+    ///     <see cref="PingMonitorViewModel.IsReachable"/>/<see cref="PingMonitorViewModel.IsRunning"/>
+    ///     are updated directly from each host's background ping loop (not marshaled to the UI
+    ///     thread), so this handler can be invoked concurrently for multiple hosts. The increment
+    ///     is marshaled to the UI thread so it's never lost - and never silently suppressed by the
+    ///     property setter's equality check - to a concurrent write from another host.
+    /// </remarks>
     private void HostViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName is nameof(PingMonitorViewModel.IsReachable) or nameof(PingMonitorViewModel.IsRunning))
-            HostsChangeVersion++;
+        if (e.PropertyName is not (nameof(PingMonitorViewModel.IsReachable) or nameof(PingMonitorViewModel.IsRunning)))
+            return;
+
+        Application.Current?.Dispatcher.BeginInvoke(DispatcherPriority.Normal, () => HostsChangeVersion++);
     }
 
     #endregion

--- a/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
@@ -1,4 +1,5 @@
 using MahApps.Metro.Controls;
+using NETworkManager.Converters;
 using NETworkManager.Localization.Resources;
 using NETworkManager.Models;
 using NETworkManager.Models.Network;

--- a/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
@@ -9,6 +9,7 @@ using NETworkManager.Views;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Net;
@@ -136,6 +137,25 @@ public class PingMonitorHostViewModel : ProfileHostViewModelBase
     /// </summary>
     public ICollectionView HostsView { get; }
 
+    /// <summary>
+    ///     Bumped whenever a host is added/removed, or a host's reachability/running state
+    ///     changes. Used only as a change-notification trigger for the per-group up/down summary
+    ///     (see <see cref="PingMonitorGroupSummaryConverter"/>) - the value itself carries no
+    ///     meaning.
+    /// </summary>
+    public int HostsChangeVersion
+    {
+        get;
+        private set
+        {
+            if (value == field)
+                return;
+
+            field = value;
+            OnPropertyChanged();
+        }
+    }
+
     #endregion
 
     #region Constructor, load settings
@@ -152,6 +172,7 @@ public class PingMonitorHostViewModel : ProfileHostViewModelBase
         HostsView = CollectionViewSource.GetDefaultView(Hosts);
         HostsView.GroupDescriptions.Add(new PropertyGroupDescription(nameof(PingMonitorView.Group)));
         HostsView.SortDescriptions.Add(new SortDescription(nameof(PingMonitorView.Group), ListSortDirection.Ascending));
+        Hosts.CollectionChanged += Hosts_CollectionChanged;
 
         InitializeProfileHost();
     }
@@ -370,6 +391,34 @@ public class PingMonitorHostViewModel : ProfileHostViewModelBase
 
         IsCanceling = false;
         IsRunning = false;
+    }
+
+    /// <summary>
+    ///     Keeps each host's <see cref="PingMonitorViewModel.PropertyChanged"/> subscription in
+    ///     sync with <see cref="Hosts"/>, and bumps <see cref="HostsChangeVersion"/> so the
+    ///     per-group up/down summary (<see cref="PingMonitorGroupSummaryConverter"/>) re-evaluates.
+    /// </summary>
+    private void Hosts_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.NewItems != null)
+            foreach (PingMonitorView host in e.NewItems)
+                host.ViewModel.PropertyChanged += HostViewModel_PropertyChanged;
+
+        if (e.OldItems != null)
+            foreach (PingMonitorView host in e.OldItems)
+                host.ViewModel.PropertyChanged -= HostViewModel_PropertyChanged;
+
+        HostsChangeVersion++;
+    }
+
+    /// <summary>
+    ///     Bumps <see cref="HostsChangeVersion"/> whenever a host's reachability or running state
+    ///     changes, so the per-group up/down summary re-evaluates.
+    /// </summary>
+    private void HostViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(PingMonitorViewModel.IsReachable) or nameof(PingMonitorViewModel.IsRunning))
+            HostsChangeVersion++;
     }
 
     #endregion

--- a/Source/NETworkManager/ViewModels/PingMonitorViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PingMonitorViewModel.cs
@@ -32,7 +32,7 @@ namespace NETworkManager.ViewModels;
 /// <summary>
 /// ViewModel for the Ping Monitor feature, representing a single monitored host.
 /// </summary>
-public class PingMonitorViewModel : ViewModelBase
+public class PingMonitorViewModel : ViewModelBase, IPingMonitorHostStatus
 {
     #region Contructor, load settings
 

--- a/Source/NETworkManager/ViewModels/PingMonitorViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PingMonitorViewModel.cs
@@ -200,8 +200,14 @@ public class PingMonitorViewModel : ViewModelBase
 
             field = value;
             OnPropertyChanged();
+            OnPropertyChanged(nameof(StatusTimeToolTip));
         }
     }
+
+    /// <summary>
+    /// Gets the tooltip text for the connectivity icon, e.g. "Last status change: 14:32:05".
+    /// </summary>
+    public string StatusTimeToolTip => $"{Strings.StatusChange}: {StatusTime:HH:mm:ss}";
 
     /// <summary>
     /// Gets or sets the total number of ping packets transmitted.

--- a/Source/NETworkManager/ViewModels/PortScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PortScannerViewModel.cs
@@ -441,6 +441,17 @@ public class PortScannerViewModel : ViewModelBase
 
         Results.Clear();
 
+        // Reset before hostname resolution too (not just after), so a cancellation during
+        // resolution can't flush the previous scan's stale totals - PortsToScan = 0 also hides
+        // the open/closed summary until the new scan's port count is known.
+        PortsToScan = 0;
+        PortsScanned = 0;
+        PortsOpen = 0;
+        PortsClosed = 0;
+        Volatile.Write(ref _latestPortsScanned, 0);
+        Volatile.Write(ref _latestPortsOpen, 0);
+        Volatile.Write(ref _latestPortsClosed, 0);
+
         DragablzTabItem.SetTabHeader(_tabId, Host);
 
         _cancellationTokenSource?.Dispose();
@@ -472,12 +483,6 @@ public class PortScannerViewModel : ViewModelBase
         var ports = await PortRangeHelper.ConvertPortRangeToIntArrayAsync(Ports);
 
         PortsToScan = ports.Length * hosts.hosts.Count;
-        PortsScanned = 0;
-        PortsOpen = 0;
-        PortsClosed = 0;
-        Volatile.Write(ref _latestPortsScanned, 0);
-        Volatile.Write(ref _latestPortsOpen, 0);
-        Volatile.Write(ref _latestPortsClosed, 0);
 
         PreparingScan = false;
 

--- a/Source/NETworkManager/ViewModels/PortScannerViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PortScannerViewModel.cs
@@ -49,6 +49,8 @@ public class PortScannerViewModel : ViewModelBase
     // (unconditionally, unlike PortScanned), so it's flushed to the bound property on the same
     // timer instead of updating it directly from the background thread on every event.
     private int _latestPortsScanned;
+    private int _latestPortsOpen;
+    private int _latestPortsClosed;
 
     /// <summary>
     /// Gets or sets the host to scan.
@@ -197,6 +199,38 @@ public class PortScannerViewModel : ViewModelBase
     /// Gets or sets the number of ports already scanned.
     /// </summary>
     public int PortsScanned
+    {
+        get;
+        set
+        {
+            if (value == field)
+                return;
+
+            field = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the number of ports found to be open so far.
+    /// </summary>
+    public int PortsOpen
+    {
+        get;
+        set
+        {
+            if (value == field)
+                return;
+
+            field = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the number of ports found to be closed so far.
+    /// </summary>
+    public int PortsClosed
     {
         get;
         set
@@ -439,7 +473,11 @@ public class PortScannerViewModel : ViewModelBase
 
         PortsToScan = ports.Length * hosts.hosts.Count;
         PortsScanned = 0;
+        PortsOpen = 0;
+        PortsClosed = 0;
         Volatile.Write(ref _latestPortsScanned, 0);
+        Volatile.Write(ref _latestPortsOpen, 0);
+        Volatile.Write(ref _latestPortsClosed, 0);
 
         PreparingScan = false;
 
@@ -593,15 +631,24 @@ public class PortScannerViewModel : ViewModelBase
     private void ProgressChanged(object sender, ProgressChangedArgs e)
     {
         Volatile.Write(ref _latestPortsScanned, e.Value);
+
+        if (sender is PortScanner portScanner)
+        {
+            Volatile.Write(ref _latestPortsOpen, portScanner.PortsOpen);
+            Volatile.Write(ref _latestPortsClosed, portScanner.PortsClosed);
+        }
     }
 
     /// <summary>
-    /// Pushes the latest buffered progress value into <see cref="PortsScanned"/>. Always called
-    /// on the UI thread - same calling contexts as <see cref="FlushResultsBuffer"/>.
+    /// Pushes the latest buffered progress value into <see cref="PortsScanned"/>,
+    /// <see cref="PortsOpen"/> and <see cref="PortsClosed"/>. Always called on the UI thread -
+    /// same calling contexts as <see cref="FlushResultsBuffer"/>.
     /// </summary>
     private void FlushProgress()
     {
         PortsScanned = Volatile.Read(ref _latestPortsScanned);
+        PortsOpen = Volatile.Read(ref _latestPortsOpen);
+        PortsClosed = Volatile.Read(ref _latestPortsClosed);
     }
 
     private void ScanComplete(object sender, EventArgs e)

--- a/Source/NETworkManager/Views/IPScannerView.xaml
+++ b/Source/NETworkManager/Views/IPScannerView.xaml
@@ -219,6 +219,34 @@
         <TextBlock Grid.Column="0" Grid.Row="2"
                    Style="{StaticResource HeaderTextBlock}"
                    Text="{x:Static localization:Strings.Result}" />
+        <StackPanel Grid.Column="0" Grid.Row="2"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Center"
+                    Visibility="{Binding Path=HostsToScan, Converter={StaticResource IntNotZeroToVisibilityCollapsedConverter}}">
+            <TextBlock Style="{StaticResource DefaultTextBlock}"
+                       Foreground="{DynamicResource MahApps.Brushes.Gray5}">
+                <TextBlock.Text>
+                    <MultiBinding StringFormat="{}{0} {1}">
+                        <Binding Path="HostsUp" />
+                        <Binding Source="{x:Static localization:Strings.Up}" />
+                    </MultiBinding>
+                </TextBlock.Text>
+            </TextBlock>
+            <TextBlock Text="·"
+                       Style="{StaticResource DefaultTextBlock}"
+                       Foreground="{DynamicResource MahApps.Brushes.Gray5}"
+                       Margin="6,0,6,0" />
+            <TextBlock Style="{StaticResource DefaultTextBlock}"
+                       Foreground="{DynamicResource MahApps.Brushes.Gray5}">
+                <TextBlock.Text>
+                    <MultiBinding StringFormat="{}{0} {1}">
+                        <Binding Path="HostsDown" />
+                        <Binding Source="{x:Static localization:Strings.Down}" />
+                    </MultiBinding>
+                </TextBlock.Text>
+            </TextBlock>
+        </StackPanel>
         <controls:MultiSelectDataGrid x:Name="DataGridResults"
                                       Grid.Column="0" Grid.Row="3"
                                       ItemsSource="{Binding Path=ResultsView}"

--- a/Source/NETworkManager/Views/PingMonitorHostView.xaml
+++ b/Source/NETworkManager/Views/PingMonitorHostView.xaml
@@ -25,7 +25,7 @@
         <converters:IntNotZeroToVisibilityCollapsedConverter x:Key="IntNotZeroToVisibilityCollapsedConverter" />
         <converters:IntZeroToVisibilityCollapsedConverter x:Key="IntZeroToVisibilityCollapsedConverter" />
         <converters:StringNullOrEmptyToBoolConverter x:Key="StringNullOrEmptyToBoolConverter" />
-        <viewModels:PingMonitorGroupSummaryConverter x:Key="PingMonitorGroupSummaryConverter" />
+        <converters:PingMonitorGroupSummaryConverter x:Key="PingMonitorGroupSummaryConverter" />
         <DataTemplate x:Key="PingMonitorProfileItemTemplate" DataType="{x:Type profiles:ProfileInfo}">
             <Grid Background="Transparent">
                 <Grid.ToolTip>
@@ -253,17 +253,10 @@
                                                                         <TextBlock Text="·"
                                                                                    Style="{StaticResource ResourceKey=DefaultTextBlock}"
                                                                                    Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}"
-                                                                                   Margin="6,0,6,0">
-                                                                            <TextBlock.Visibility>
-                                                                                <MultiBinding Converter="{StaticResource ResourceKey=PingMonitorGroupSummaryConverter}"
-                                                                                              ConverterParameter="PausedVisibility">
-                                                                                    <Binding />
-                                                                                    <Binding Path="DataContext.HostsChangeVersion"
-                                                                                             RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}" />
-                                                                                </MultiBinding>
-                                                                            </TextBlock.Visibility>
-                                                                        </TextBlock>
-                                                                        <TextBlock Style="{StaticResource ResourceKey=DefaultTextBlock}"
+                                                                                   Margin="6,0,6,0"
+                                                                                   Visibility="{Binding ElementName=PausedText, Path=Visibility}" />
+                                                                        <TextBlock x:Name="PausedText"
+                                                                                   Style="{StaticResource ResourceKey=DefaultTextBlock}"
                                                                                    Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}">
                                                                             <TextBlock.Text>
                                                                                 <MultiBinding Converter="{StaticResource ResourceKey=PingMonitorGroupSummaryConverter}"

--- a/Source/NETworkManager/Views/PingMonitorHostView.xaml
+++ b/Source/NETworkManager/Views/PingMonitorHostView.xaml
@@ -25,6 +25,7 @@
         <converters:IntNotZeroToVisibilityCollapsedConverter x:Key="IntNotZeroToVisibilityCollapsedConverter" />
         <converters:IntZeroToVisibilityCollapsedConverter x:Key="IntZeroToVisibilityCollapsedConverter" />
         <converters:StringNullOrEmptyToBoolConverter x:Key="StringNullOrEmptyToBoolConverter" />
+        <viewModels:PingMonitorGroupSummaryConverter x:Key="PingMonitorGroupSummaryConverter" />
         <DataTemplate x:Key="PingMonitorProfileItemTemplate" DataType="{x:Type profiles:ProfileInfo}">
             <Grid Background="Transparent">
                 <Grid.ToolTip>
@@ -212,11 +213,78 @@
                                                                         <ColumnDefinition Width="*" />
                                                                         <ColumnDefinition Width="10" />
                                                                         <ColumnDefinition Width="Auto" />
+                                                                        <ColumnDefinition Width="10" />
+                                                                        <ColumnDefinition Width="Auto" />
                                                                     </Grid.ColumnDefinitions>
                                                                     <TextBlock Grid.Column="0" Grid.Row="0"
                                                                                Text="{Binding Path=(CollectionViewGroup.Name)}"
                                                                                Style="{DynamicResource ResourceKey=HeaderTextBlock}" />
-                                                                    <Button Grid.Column="2" Grid.Row="0"
+                                                                    <StackPanel Grid.Column="2" Grid.Row="0"
+                                                                                Orientation="Horizontal"
+                                                                                VerticalAlignment="Center">
+                                                                        <TextBlock Style="{StaticResource ResourceKey=DefaultTextBlock}"
+                                                                                   Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}">
+                                                                            <TextBlock.Text>
+                                                                                <MultiBinding Converter="{StaticResource ResourceKey=PingMonitorGroupSummaryConverter}"
+                                                                                              ConverterParameter="Up">
+                                                                                    <Binding />
+                                                                                    <Binding Path="DataContext.HostsChangeVersion"
+                                                                                             RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}" />
+                                                                                    <Binding Source="{x:Static Member=localization:Strings.Up}" />
+                                                                                </MultiBinding>
+                                                                            </TextBlock.Text>
+                                                                        </TextBlock>
+                                                                        <TextBlock Text="·"
+                                                                                   Style="{StaticResource ResourceKey=DefaultTextBlock}"
+                                                                                   Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}"
+                                                                                   Margin="6,0,6,0" />
+                                                                        <TextBlock Style="{StaticResource ResourceKey=DefaultTextBlock}"
+                                                                                   Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}">
+                                                                            <TextBlock.Text>
+                                                                                <MultiBinding Converter="{StaticResource ResourceKey=PingMonitorGroupSummaryConverter}"
+                                                                                              ConverterParameter="Down">
+                                                                                    <Binding />
+                                                                                    <Binding Path="DataContext.HostsChangeVersion"
+                                                                                             RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}" />
+                                                                                    <Binding Source="{x:Static Member=localization:Strings.Down}" />
+                                                                                </MultiBinding>
+                                                                            </TextBlock.Text>
+                                                                        </TextBlock>
+                                                                        <TextBlock Text="·"
+                                                                                   Style="{StaticResource ResourceKey=DefaultTextBlock}"
+                                                                                   Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}"
+                                                                                   Margin="6,0,6,0">
+                                                                            <TextBlock.Visibility>
+                                                                                <MultiBinding Converter="{StaticResource ResourceKey=PingMonitorGroupSummaryConverter}"
+                                                                                              ConverterParameter="PausedVisibility">
+                                                                                    <Binding />
+                                                                                    <Binding Path="DataContext.HostsChangeVersion"
+                                                                                             RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}" />
+                                                                                </MultiBinding>
+                                                                            </TextBlock.Visibility>
+                                                                        </TextBlock>
+                                                                        <TextBlock Style="{StaticResource ResourceKey=DefaultTextBlock}"
+                                                                                   Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}">
+                                                                            <TextBlock.Text>
+                                                                                <MultiBinding Converter="{StaticResource ResourceKey=PingMonitorGroupSummaryConverter}"
+                                                                                              ConverterParameter="Paused">
+                                                                                    <Binding />
+                                                                                    <Binding Path="DataContext.HostsChangeVersion"
+                                                                                             RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}" />
+                                                                                    <Binding Source="{x:Static Member=localization:Strings.Paused}" />
+                                                                                </MultiBinding>
+                                                                            </TextBlock.Text>
+                                                                            <TextBlock.Visibility>
+                                                                                <MultiBinding Converter="{StaticResource ResourceKey=PingMonitorGroupSummaryConverter}"
+                                                                                              ConverterParameter="PausedVisibility">
+                                                                                    <Binding />
+                                                                                    <Binding Path="DataContext.HostsChangeVersion"
+                                                                                             RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}" />
+                                                                                </MultiBinding>
+                                                                            </TextBlock.Visibility>
+                                                                        </TextBlock>
+                                                                    </StackPanel>
+                                                                    <Button Grid.Column="4" Grid.Row="0"
                                                                             HorizontalAlignment="Right"
                                                                             Command="{Binding Path=DataContext.CloseGroupCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}}"
                                                                             CommandParameter="{Binding Path=(CollectionViewGroup.Name)}"

--- a/Source/NETworkManager/Views/PingMonitorView.xaml
+++ b/Source/NETworkManager/Views/PingMonitorView.xaml
@@ -58,6 +58,9 @@
                            Visibility="{Binding IsErrorMessageDisplayed, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                 <Rectangle Grid.Column="0" Grid.Row="0"
                            Width="24" Height="24"
+                           ToolTip="{Binding StatusTimeToolTip}"
+                           ToolTipService.InitialShowDelay="0"
+                           ToolTipService.ShowDuration="600000"
                            Visibility="{Binding IsErrorMessageDisplayed, Converter={StaticResource BooleanReverseToVisibilityCollapsedConverter}}">
                     <Rectangle.Resources>
                         <VisualBrush x:Key="VisualConnected" Stretch="Uniform"
@@ -69,6 +72,9 @@
                     </Rectangle.Resources>
                     <Rectangle.Style>
                         <Style TargetType="{x:Type Rectangle}">
+                            <Style.Resources>
+                                <Style TargetType="{x:Type ToolTip}" BasedOn="{StaticResource DefaultToolTip}" />
+                            </Style.Resources>
                             <Setter Property="OpacityMask" Value="{StaticResource VisualPending}" />
                             <Setter Property="Fill" Value="{DynamicResource MahApps.Brushes.Gray3}" />
                             <Style.Triggers>
@@ -105,11 +111,13 @@
                            Style="{StaticResource DefaultTextBlock}"
                            Foreground="{StaticResource MahApps.Brushes.Gray5}">
                     <TextBlock.Text>
-                        <MultiBinding StringFormat="{} {0} / {1} / {2} %">
-                            <Binding Path="Transmitted" />
+                        <MultiBinding StringFormat="{}{0}: {1} · {2}: {3} · {4}: {5}%">
+                            <Binding Source="{x:Static localization:Strings.Received}" />
+                            <Binding Path="Received" />
+                            <Binding Source="{x:Static localization:Strings.Lost}" />
                             <Binding Path="Lost" />
+                            <Binding Source="{x:Static localization:Strings.PacketLoss}" />
                             <Binding Path="PacketLoss" />
-                            <Binding Path="TimeMs" />
                         </MultiBinding>
                     </TextBlock.Text>
                 </TextBlock>
@@ -184,114 +192,60 @@
                 </Button>
             </Grid>
         </Expander.Header>
-        <Grid Margin="10">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition MinWidth="350" MaxWidth="600" />
-                <ColumnDefinition Width="10" />
-                <ColumnDefinition MinWidth="200" Width="*" />
-            </Grid.ColumnDefinitions>
-            <Grid Grid.Column="0" Grid.Row="0">
-                <Grid.Resources>
-                    <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource CenterTextBlock}">
-                        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Gray5}" />
-                    </Style>
-                    <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource TextBlockAsTextBox}">
-                        <Setter Property="ContextMenu" Value="{StaticResource CopyContextMenu}" />
-                        <Setter Property="TextWrapping" Value="NoWrap" />
-                    </Style>
-                </Grid.Resources>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="10" />
-                    <ColumnDefinition Width="3*" />
-                    <ColumnDefinition Width="20" />
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="10" />
-                    <ColumnDefinition Width="1*" />
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="5" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="5" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="5" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-                <TextBlock Grid.Column="0" Grid.Row="0" Text="{x:Static localization:Strings.Hostname}" />
-                <TextBox Grid.Column="2" Grid.Row="0" Text="{Binding Hostname, Mode=OneWay}" />
-                <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static localization:Strings.IPAddress}" />
-                <TextBox Grid.Column="2" Grid.Row="2" Text="{Binding IPAddress, Mode=OneWay}" />
-                <TextBlock Grid.Column="0" Grid.Row="4" Text="{x:Static localization:Strings.StatusChange}" />
-                <TextBox Grid.Column="2" Grid.Row="4" Text="{Binding StatusTime, Mode=OneWay, StringFormat={}{0:HH:mm:ss}}" />
-                <TextBlock Grid.Column="4" Grid.Row="0" Text="{x:Static localization:Strings.Received}" />
-                <TextBox Grid.Column="6" Grid.Row="0" Text="{Binding Received, Mode=OneWay}" />
-                <TextBlock Grid.Column="4" Grid.Row="2" Text="{x:Static localization:Strings.Lost}" />
-                <TextBox Grid.Column="6" Grid.Row="2" Text="{Binding Lost, Mode=OneWay}" />
-                <TextBlock Grid.Column="4" Grid.Row="4" Text="{x:Static localization:Strings.PacketLoss}" />
-                <TextBox Grid.Column="6" Grid.Row="4">
-                    <TextBox.Text>
-                        <MultiBinding Mode="OneWay" StringFormat="{}{0} %">
-                            <Binding Path="PacketLoss" />
-                        </MultiBinding>
-                    </TextBox.Text>
-                </TextBox>
-            </Grid>
-            <Grid Grid.Column="2" Margin="0,0,0,0">
-                <lvc:CartesianChart Background="Transparent"
-                                    Series="{Binding Series}"
-                                    XAxes="{Binding PingXAxes}"
-                                    YAxes="{Binding PingYAxes}"
-                                    DrawMarginFrame="{x:Null}"
-                                    EasingFunction="{x:Null}"
-                                    ZoomMode="PanX, ZoomX, NoFit"
-                                    ContextMenuOpening="Chart_ContextMenuOpening"
-                                    RenderOptions.BitmapScalingMode="NearestNeighbor">
-                    <lvc:CartesianChart.Tooltip>
-                        <controls:LiveChartsPingTimeTooltip />
-                    </lvc:CartesianChart.Tooltip>
-                </lvc:CartesianChart>
-                <Button HorizontalAlignment="Right"
-                        VerticalAlignment="Top"
-                        Margin="0,5,5,0"
-                        Command="{Binding GoLiveCommand}"
-                        Style="{StaticResource CleanButton}"
-                        Visibility="{Binding IsLiveMode, Converter={StaticResource BooleanReverseToVisibilityCollapsedConverter}}">
-                    <StackPanel Orientation="Horizontal">
-                        <Rectangle Width="16" Height="16"
-                                   VerticalAlignment="Center">
-                            <Rectangle.OpacityMask>
-                                <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=AccessPoint}" />
-                            </Rectangle.OpacityMask>
-                            <Rectangle.Style>
-                                <Style TargetType="{x:Type Rectangle}">
-                                    <Setter Property="Fill" Value="{DynamicResource MahApps.Brushes.Gray3}" />
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Button}}, Path=IsMouseOver}" Value="True">
-                                            <Setter Property="Fill" Value="{DynamicResource MahApps.Brushes.Gray5}" />
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </Rectangle.Style>
-                        </Rectangle>
-                        <TextBlock Margin="4,0,0,0"
-                                   Text="{x:Static localization:Strings.Live}"
-                                   FontSize="14"
-                                   VerticalAlignment="Center">
-                            <TextBlock.Style>
-                                <Style TargetType="{x:Type TextBlock}">
-                                    <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Gray3}" />
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Button}}, Path=IsMouseOver}" Value="True">
-                                            <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Gray5}" />
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </TextBlock.Style>
-                        </TextBlock>
-                    </StackPanel>
-                </Button>
-            </Grid>
+        <Grid Margin="10" MinHeight="150">
+            <lvc:CartesianChart Background="Transparent"
+                                Series="{Binding Series}"
+                                XAxes="{Binding PingXAxes}"
+                                YAxes="{Binding PingYAxes}"
+                                DrawMarginFrame="{x:Null}"
+                                EasingFunction="{x:Null}"
+                                ZoomMode="PanX, ZoomX, NoFit"
+                                ContextMenuOpening="Chart_ContextMenuOpening"
+                                RenderOptions.BitmapScalingMode="NearestNeighbor">
+                <lvc:CartesianChart.Tooltip>
+                    <controls:LiveChartsPingTimeTooltip />
+                </lvc:CartesianChart.Tooltip>
+            </lvc:CartesianChart>
+            <Button HorizontalAlignment="Right"
+                    VerticalAlignment="Top"
+                    Margin="0,5,5,0"
+                    Command="{Binding GoLiveCommand}"
+                    Style="{StaticResource CleanButton}"
+                    Visibility="{Binding IsLiveMode, Converter={StaticResource BooleanReverseToVisibilityCollapsedConverter}}">
+                <StackPanel Orientation="Horizontal">
+                    <Rectangle Width="16" Height="16"
+                               VerticalAlignment="Center">
+                        <Rectangle.OpacityMask>
+                            <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=AccessPoint}" />
+                        </Rectangle.OpacityMask>
+                        <Rectangle.Style>
+                            <Style TargetType="{x:Type Rectangle}">
+                                <Setter Property="Fill" Value="{DynamicResource MahApps.Brushes.Gray3}" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Button}}, Path=IsMouseOver}" Value="True">
+                                        <Setter Property="Fill" Value="{DynamicResource MahApps.Brushes.Gray5}" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Rectangle.Style>
+                    </Rectangle>
+                    <TextBlock Margin="4,0,0,0"
+                               Text="{x:Static localization:Strings.Live}"
+                               FontSize="14"
+                               VerticalAlignment="Center">
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}">
+                                <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Gray3}" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Button}}, Path=IsMouseOver}" Value="True">
+                                        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Gray5}" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </StackPanel>
+            </Button>
         </Grid>
     </Expander>
 </UserControl>

--- a/Source/NETworkManager/Views/PingMonitorView.xaml
+++ b/Source/NETworkManager/Views/PingMonitorView.xaml
@@ -21,6 +21,39 @@
               Margin="0,0,0,10">
         <Expander.ContextMenu>
             <ContextMenu Style="{StaticResource DefaultContextMenu}" MinWidth="150">
+                <MenuItem Header="{x:Static localization:Strings.CopyDots}">
+                    <MenuItem.Icon>
+                        <Rectangle Width="16" Height="16" Fill="{DynamicResource MahApps.Brushes.Gray3}">
+                            <Rectangle.OpacityMask>
+                                <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=ContentCopy}" />
+                            </Rectangle.OpacityMask>
+                        </Rectangle>
+                    </MenuItem.Icon>
+                    <MenuItem Header="{x:Static localization:Strings.Hostname}"
+                              Command="{Binding CopyDataToClipboardCommand}"
+                              CommandParameter="{Binding Hostname}"
+                              Style="{StaticResource ResourceKey=CopyMenuItem}" />
+                    <MenuItem Header="{x:Static localization:Strings.IPAddress}"
+                              Command="{Binding CopyDataToClipboardCommand}"
+                              CommandParameter="{Binding IPAddress}"
+                              Style="{StaticResource ResourceKey=CopyMenuItem}" />
+                    <MenuItem Header="{x:Static localization:Strings.StatusChange}"
+                              Command="{Binding CopyDataToClipboardCommand}"
+                              CommandParameter="{Binding StatusTime, StringFormat={}{0:HH:mm:ss}}"
+                              Style="{StaticResource ResourceKey=CopyMenuItem}" />
+                    <MenuItem Header="{x:Static localization:Strings.Received}"
+                              Command="{Binding CopyDataToClipboardCommand}"
+                              CommandParameter="{Binding Received}"
+                              Style="{StaticResource ResourceKey=CopyMenuItem}" />
+                    <MenuItem Header="{x:Static localization:Strings.Lost}"
+                              Command="{Binding CopyDataToClipboardCommand}"
+                              CommandParameter="{Binding Lost}"
+                              Style="{StaticResource ResourceKey=CopyMenuItem}" />
+                    <MenuItem Header="{x:Static localization:Strings.PacketLoss}"
+                              Command="{Binding CopyDataToClipboardCommand}"
+                              CommandParameter="{Binding PacketLoss, StringFormat={}{0} %}"
+                              Style="{StaticResource ResourceKey=CopyMenuItem}" />
+                </MenuItem>
                 <MenuItem Header="{x:Static localization:Strings.ExportDots}"
                           Command="{Binding ExportCommand}">
                     <MenuItem.Icon>

--- a/Source/NETworkManager/Views/PingMonitorView.xaml.cs
+++ b/Source/NETworkManager/Views/PingMonitorView.xaml.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Net;
 using System.Windows.Controls;
+using NETworkManager.Models.Network;
 using NETworkManager.ViewModels;
 
 namespace NETworkManager.Views;
 
-public partial class PingMonitorView
+public partial class PingMonitorView : IPingMonitorHostStatus
 {
     private readonly PingMonitorViewModel _viewModel;
 
@@ -27,10 +28,17 @@ public partial class PingMonitorView
 
     /// <summary>
     /// The underlying view model, exposed so <see cref="ViewModels.PingMonitorHostViewModel"/> can
-    /// observe per-host status (<see cref="PingMonitorViewModel.IsReachable"/>,
-    /// <see cref="PingMonitorViewModel.IsRunning"/>) for the group up/down summary.
+    /// subscribe to <see cref="PingMonitorViewModel.PropertyChanged"/> for the group up/down
+    /// summary. Prefer <see cref="IsReachable"/>/<see cref="IsRunning"/> (via
+    /// <see cref="IPingMonitorHostStatus"/>) to just read the current status.
     /// </summary>
     public PingMonitorViewModel ViewModel => _viewModel;
+
+    /// <inheritdoc />
+    public bool IsReachable => _viewModel.IsReachable;
+
+    /// <inheritdoc />
+    public bool IsRunning => _viewModel.IsRunning;
 
     public void Start()
     {

--- a/Source/NETworkManager/Views/PingMonitorView.xaml.cs
+++ b/Source/NETworkManager/Views/PingMonitorView.xaml.cs
@@ -25,6 +25,13 @@ public partial class PingMonitorView
 
     public string Group => _viewModel.Group;
 
+    /// <summary>
+    /// The underlying view model, exposed so <see cref="ViewModels.PingMonitorHostViewModel"/> can
+    /// observe per-host status (<see cref="PingMonitorViewModel.IsReachable"/>,
+    /// <see cref="PingMonitorViewModel.IsRunning"/>) for the group up/down summary.
+    /// </summary>
+    public PingMonitorViewModel ViewModel => _viewModel;
+
     public void Start()
     {
         _viewModel.Start();

--- a/Source/NETworkManager/Views/PortScannerView.xaml
+++ b/Source/NETworkManager/Views/PortScannerView.xaml
@@ -23,6 +23,7 @@
         <converters:StringNullOrEmptyToStringConverter x:Key="StringNullOrEmptyToStringConverter" />
         <converters:PortStateToStringConverter x:Key="PortStateToStringConverter" />
         <converters:PortOpenStyleConverter x:Key="PortOpenStyleConverter" />
+        <converters:IntNotZeroToVisibilityCollapsedConverter x:Key="IntNotZeroToVisibilityCollapsedConverter" />
     </UserControl.Resources>
     <Grid Margin="10">
         <Grid.RowDefinitions>
@@ -227,6 +228,34 @@
                        Style="{DynamicResource StatusMessageTextBlock}" Margin="0,10,0,0" />
         </Grid>
         <TextBlock Grid.Row="2" Style="{StaticResource HeaderTextBlock}" Text="{x:Static localization:Strings.Result}" />
+        <StackPanel Grid.Row="2"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Center"
+                    Visibility="{Binding Path=PortsToScan, Converter={StaticResource IntNotZeroToVisibilityCollapsedConverter}}">
+            <TextBlock Style="{StaticResource DefaultTextBlock}"
+                       Foreground="{DynamicResource MahApps.Brushes.Gray5}">
+                <TextBlock.Text>
+                    <MultiBinding StringFormat="{}{0} {1}">
+                        <Binding Path="PortsOpen" />
+                        <Binding Source="{x:Static localization:Strings.Open}" />
+                    </MultiBinding>
+                </TextBlock.Text>
+            </TextBlock>
+            <TextBlock Text="·"
+                       Style="{StaticResource DefaultTextBlock}"
+                       Foreground="{DynamicResource MahApps.Brushes.Gray5}"
+                       Margin="6,0,6,0" />
+            <TextBlock Style="{StaticResource DefaultTextBlock}"
+                       Foreground="{DynamicResource MahApps.Brushes.Gray5}">
+                <TextBlock.Text>
+                    <MultiBinding StringFormat="{}{0} {1}">
+                        <Binding Path="PortsClosed" />
+                        <Binding Source="{x:Static localization:Strings.Closed}" />
+                    </MultiBinding>
+                </TextBlock.Text>
+            </TextBlock>
+        </StackPanel>
         <controls:MultiSelectDataGrid x:Name="DataGridResults"
                                       Grid.Row="3" ItemsSource="{Binding Path=ResultsView}"
                                       SelectedItem="{Binding Path=SelectedResult}"

--- a/Website/docs/application/ping-monitor.md
+++ b/Website/docs/application/ping-monitor.md
@@ -56,11 +56,10 @@ When you zoom or pan, the chart leaves live mode and stops scrolling. A **Live**
 
 Right-click a monitored host (anywhere except the chart) to open the context menu:
 
-| Action | Description |
-|--------|-------------|
-| **Export...** | Exports the results of the host to a file |
-
-Right-clicking an individual field (hostname, IP address, ...) instead lets you **Copy** its value to the clipboard.
+| Action        | Description                                      |
+| ------------- | ------------------------------------------------- |
+| **Copy**      | Copies the selected information to the clipboard |
+| **Export...** | Exports the results of the host to a file        |
 
 ### Notifications
 

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -35,28 +35,29 @@ Release date: **xx.xx.2026**
 
 **IP Scanner**
 
-- Added a live count of hosts up/down next to the **Result** header. Stays visible after the scan finishes. [#3565](https://github.com/BornToBeRoot/NETworkManager/issues/3565)
+- Added a live count of hosts up/down next to the **Result** header. Stays visible after the scan finishes. [#3572](https://github.com/BornToBeRoot/NETworkManager/pull/3572)
 - Host input now accepts newline-separated hosts (one per line, e.g. a column pasted from Excel), converted automatically to the semicolon-separated form. Thanks to [@dearmb](https://github.com/dearmb) [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
 - Host input now supports shorthand IPv4 ranges like `192.168.0.1-100`, in addition to the existing `192.168.0.0-192.168.0.100` and `192.168.[0-100].1` range formats. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
 - Added `135` (RPC) and `9100` (raw printing) to the default **Ports** list used to detect if a host is reachable. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
 - Reduced the default **Max. concurrent port threads** from `5` to `4`. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
 - Reduced the default **Max. concurrent host threads** from `256` to `64`, a more conservative default that puts less simultaneous load on the scanned network. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
 
-**Ping Monitor**
-
-- Added a live count of hosts up/down (and paused, if any) per group, next to the group's close button. [#3565](https://github.com/BornToBeRoot/NETworkManager/issues/3565)
-- Host input now accepts newline-separated hosts (one per line, e.g. a column pasted from Excel), converted automatically to the semicolon-separated form. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
-- Host input now supports shorthand IPv4 ranges like `192.168.0.1-100`, in addition to the existing `192.168.0.0-192.168.0.100` and `192.168.[0-100].1` range formats. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
-
 **Port Scanner**
 
 - Added a port status icon column to the results, matching the port icon used in the IP Scanner's extended port info, to indicate at a glance whether a port is open (green) or closed (red). [#3558](https://github.com/BornToBeRoot/NETworkManager/issues/3558)
-- Added a live count of ports open/closed next to the **Result** header. Stays visible after the scan finishes. [#3565](https://github.com/BornToBeRoot/NETworkManager/issues/3565)
+- Added a live count of ports open/closed next to the **Result** header. Stays visible after the scan finishes. [#3572](https://github.com/BornToBeRoot/NETworkManager/pull/3572)
 - Host and Ports input fields now accept newline-separated entries (one per line, e.g. a column pasted from Excel), converted automatically to the semicolon-separated form. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
 - Host input now supports shorthand IPv4 ranges like `192.168.0.1-100`, in addition to the existing `192.168.0.0-192.168.0.100` and `192.168.[0-100].1` range formats. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
 - Reduced the default **Max. concurrent host threads** from `5` to `4`. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
 - Reduced the default **Max. concurrent port threads** from `256` to `64`, a more conservative default that puts less simultaneous load on the scanned host. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
 - Added a new **Well-known ports** (`1-1024`) default port profile. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
+
+**Ping Monitor**
+
+- Added a live count of hosts up/down (and paused, if any) per group, next to the group's close button. [#3572](https://github.com/BornToBeRoot/NETworkManager/pull/3572)
+- Reworked each monitored host's card: the collapsed quick info now shows labeled values (`Received: X · Lost: Y · Packet loss: Z%`) instead of unlabeled numbers, the expanded view shows only the latency chart (with more room, since Hostname/IP address are already visible in the header) and the last status change time moved to a tooltip on the connectivity icon. The **Status change** field was also renamed to **Last status change**. [#3572](https://github.com/BornToBeRoot/NETworkManager/pull/3572)
+- Host input now accepts newline-separated hosts (one per line, e.g. a column pasted from Excel), converted automatically to the semicolon-separated form. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
+- Host input now supports shorthand IPv4 ranges like `192.168.0.1-100`, in addition to the existing `192.168.0.0-192.168.0.100` and `192.168.[0-100].1` range formats. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
 
 ## Bug Fixes
 

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -35,6 +35,7 @@ Release date: **xx.xx.2026**
 
 **IP Scanner**
 
+- Added a live count of hosts up/down next to the **Result** header. Stays visible after the scan finishes. [#3565](https://github.com/BornToBeRoot/NETworkManager/issues/3565)
 - Host input now accepts newline-separated hosts (one per line, e.g. a column pasted from Excel), converted automatically to the semicolon-separated form. Thanks to [@dearmb](https://github.com/dearmb) [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
 - Host input now supports shorthand IPv4 ranges like `192.168.0.1-100`, in addition to the existing `192.168.0.0-192.168.0.100` and `192.168.[0-100].1` range formats. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
 - Added `135` (RPC) and `9100` (raw printing) to the default **Ports** list used to detect if a host is reachable. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)
@@ -43,12 +44,14 @@ Release date: **xx.xx.2026**
 
 **Ping Monitor**
 
+- Added a live count of hosts up/down (and paused, if any) per group, next to the group's close button. [#3565](https://github.com/BornToBeRoot/NETworkManager/issues/3565)
 - Host input now accepts newline-separated hosts (one per line, e.g. a column pasted from Excel), converted automatically to the semicolon-separated form. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
 - Host input now supports shorthand IPv4 ranges like `192.168.0.1-100`, in addition to the existing `192.168.0.0-192.168.0.100` and `192.168.[0-100].1` range formats. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
 
 **Port Scanner**
 
 - Added a port status icon column to the results, matching the port icon used in the IP Scanner's extended port info, to indicate at a glance whether a port is open (green) or closed (red). [#3558](https://github.com/BornToBeRoot/NETworkManager/issues/3558)
+- Added a live count of ports open/closed next to the **Result** header. Stays visible after the scan finishes. [#3565](https://github.com/BornToBeRoot/NETworkManager/issues/3565)
 - Host and Ports input fields now accept newline-separated entries (one per line, e.g. a column pasted from Excel), converted automatically to the semicolon-separated form. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
 - Host input now supports shorthand IPv4 ranges like `192.168.0.1-100`, in addition to the existing `192.168.0.0-192.168.0.100` and `192.168.[0-100].1` range formats. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
 - Reduced the default **Max. concurrent host threads** from `5` to `4`. [#3564](https://github.com/BornToBeRoot/NETworkManager/pull/3564)


### PR DESCRIPTION
## Changes proposed in this pull request

- Add count up/down, open/closed 
- re-work ping monitor view

## Related issue(s)

- Fixes #3565

</details>

## To-Do

- [x] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs) to reflect this changes
- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
