### PR TITLE
Feature: Add start & pause button per group in ping monitor

### DIFF
--- a/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
+++ b/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
@@ -1909,6 +1909,15 @@ namespace NETworkManager.Localization.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Group actions.
+        /// </summary>
+        public static string GroupActions {
+            get {
+                return ResourceManager.GetString("GroupActions", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Pause group.
         /// </summary>
         public static string PauseGroup {

--- a/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
+++ b/Source/NETworkManager.Localization/Resources/Strings.Designer.cs
@@ -1898,7 +1898,25 @@ namespace NETworkManager.Localization.Resources {
                 return ResourceManager.GetString("CloseGroup", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Start group.
+        /// </summary>
+        public static string StartGroup {
+            get {
+                return ResourceManager.GetString("StartGroup", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Pause group.
+        /// </summary>
+        public static string PauseGroup {
+            get {
+                return ResourceManager.GetString("PauseGroup", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Closing in {0} seconds....
         /// </summary>

--- a/Source/NETworkManager.Localization/Resources/Strings.resx
+++ b/Source/NETworkManager.Localization/Resources/Strings.resx
@@ -3895,6 +3895,9 @@ Try again in a few seconds.</value>
   <data name="StartGroup" xml:space="preserve">
     <value>Start group</value>
   </data>
+  <data name="GroupActions" xml:space="preserve">
+    <value>Group actions</value>
+  </data>
   <data name="PauseGroup" xml:space="preserve">
     <value>Pause group</value>
   </data>

--- a/Source/NETworkManager.Localization/Resources/Strings.resx
+++ b/Source/NETworkManager.Localization/Resources/Strings.resx
@@ -3892,6 +3892,12 @@ Try again in a few seconds.</value>
   <data name="CloseGroup" xml:space="preserve">
     <value>Close group</value>
   </data>
+  <data name="StartGroup" xml:space="preserve">
+    <value>Start group</value>
+  </data>
+  <data name="PauseGroup" xml:space="preserve">
+    <value>Pause group</value>
+  </data>
   <data name="RunCommandDotsWithHotKey" xml:space="preserve">
     <value>Run command... (Ctrl+Shift+P)</value>
   </data>

--- a/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
+++ b/Source/NETworkManager/ViewModels/PingMonitorHostViewModel.cs
@@ -239,6 +239,28 @@ public class PingMonitorHostViewModel : ProfileHostViewModelBase
         RemoveGroup(group.ToString());
     }
 
+    /// <summary>
+    ///     Gets the command to start every host in a group that is not currently running.
+    /// </summary>
+    public ICommand StartGroupCommand => new RelayCommand(StartGroupAction);
+
+    private void StartGroupAction(object group)
+    {
+        foreach (var host in Hosts.Where(host => host.Group.Equals(group.ToString()) && !host.IsRunning))
+            host.Start();
+    }
+
+    /// <summary>
+    ///     Gets the command to pause every host in a group that is currently running.
+    /// </summary>
+    public ICommand PauseGroupCommand => new RelayCommand(PauseGroupAction);
+
+    private void PauseGroupAction(object group)
+    {
+        foreach (var host in Hosts.Where(host => host.Group.Equals(group.ToString()) && host.IsRunning))
+            host.Stop();
+    }
+
     #endregion
 
     #region Methods

--- a/Source/NETworkManager/Views/PingMonitorHostView.xaml
+++ b/Source/NETworkManager/Views/PingMonitorHostView.xaml
@@ -26,6 +26,10 @@
         <converters:IntZeroToVisibilityCollapsedConverter x:Key="IntZeroToVisibilityCollapsedConverter" />
         <converters:StringNullOrEmptyToBoolConverter x:Key="StringNullOrEmptyToBoolConverter" />
         <converters:PingMonitorGroupSummaryConverter x:Key="PingMonitorGroupSummaryConverter" />
+        <!-- Data-bound to the panel itself, so the group's context menu (rendered in a detached
+             popup, outside the normal DataContext-inheritance chain) can still reach the
+             PingMonitorHostViewModel's Start/Pause/CloseGroupCommand. -->
+        <wpfHelpers:BindingProxy x:Key="BindingProxy" Data="{Binding}" />
         <DataTemplate x:Key="PingMonitorProfileItemTemplate" DataType="{x:Type profiles:ProfileInfo}">
             <Grid Background="Transparent">
                 <Grid.ToolTip>
@@ -208,9 +212,7 @@
                                                         <Expander IsExpanded="True"
                                                                   Style="{StaticResource ResourceKey=DefaultExpander}">
                                                             <Expander.Header>
-                                                                <Grid x:Name="GroupHeaderGrid"
-                                                                      MouseEnter="GroupHeader_MouseEnter"
-                                                                      MouseLeave="GroupHeader_MouseLeave">
+                                                                <Grid>
                                                                     <Grid.ColumnDefinitions>
                                                                         <ColumnDefinition Width="*" />
                                                                         <ColumnDefinition Width="10" />
@@ -294,15 +296,13 @@
                                                                             </TextBlock.Visibility>
                                                                         </TextBlock>
                                                                     </StackPanel>
-                                                                    <ToggleButton x:Name="GroupActionsToggle"
-                                                                                  Grid.Column="4" Grid.Row="0"
-                                                                                  HorizontalAlignment="Right"
-                                                                                  Style="{StaticResource ResourceKey=CleanToggleButton}"
-                                                                                  ToolTip="{x:Static Member=localization:Strings.GroupActions}"
-                                                                                  Checked="GroupActionsToggle_Checked"
-                                                                                  Unchecked="GroupActionsToggle_Unchecked"
-                                                                                  Unloaded="GroupActionsToggle_Unloaded"
-                                                                                  Visibility="{Binding Path=IsChecked, RelativeSource={RelativeSource Mode=Self}, Converter={StaticResource ResourceKey=BooleanReverseToVisibilityCollapsedConverter}}">
+                                                                    <Button x:Name="GroupActionsButton"
+                                                                            Grid.Column="4" Grid.Row="0"
+                                                                            HorizontalAlignment="Right"
+                                                                            Tag="{Binding Path=(CollectionViewGroup.Name)}"
+                                                                            Click="GroupActionsButton_Click"
+                                                                            Style="{StaticResource ResourceKey=CleanButton}"
+                                                                            ToolTip="{x:Static Member=localization:Strings.GroupActions}">
                                                                         <Rectangle Width="16" Height="16">
                                                                             <Rectangle.OpacityMask>
                                                                                 <VisualBrush Stretch="Uniform"
@@ -315,7 +315,7 @@
                                                                                         Value="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}" />
                                                                                     <Style.Triggers>
                                                                                         <DataTrigger
-                                                                                            Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ToggleButton}}, Path=IsMouseOver}"
+                                                                                            Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=Button}}, Path=IsMouseOver}"
                                                                                             Value="True">
                                                                                             <Setter Property="Fill"
                                                                                                 Value="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}" />
@@ -324,101 +324,51 @@
                                                                                 </Style>
                                                                             </Rectangle.Style>
                                                                         </Rectangle>
-                                                                    </ToggleButton>
-                                                                    <Grid Grid.Column="4" Grid.Row="0"
-                                                                          Visibility="{Binding Path=IsChecked, ElementName=GroupActionsToggle, Converter={StaticResource ResourceKey=BooleanToVisibilityCollapsedConverter}}">
-                                                                        <Grid.ColumnDefinitions>
-                                                                            <ColumnDefinition Width="Auto" />
-                                                                            <ColumnDefinition Width="10" />
-                                                                            <ColumnDefinition Width="Auto" />
-                                                                            <ColumnDefinition Width="10" />
-                                                                            <ColumnDefinition Width="Auto" />
-                                                                        </Grid.ColumnDefinitions>
-                                                                        <Button Grid.Column="0" Grid.Row="0"
-                                                                                HorizontalAlignment="Right"
-                                                                                Command="{Binding Path=DataContext.StartGroupCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}}"
-                                                                                CommandParameter="{Binding Path=(CollectionViewGroup.Name)}"
-                                                                                Style="{StaticResource ResourceKey=CleanButton}"
-                                                                                ToolTip="{x:Static Member=localization:Strings.StartGroup}">
-                                                                            <Rectangle Width="16" Height="16">
-                                                                                <Rectangle.OpacityMask>
-                                                                                    <VisualBrush Stretch="Uniform"
-                                                                                        Visual="{iconPacks:Material Kind=Play}" />
-                                                                                </Rectangle.OpacityMask>
-                                                                                <Rectangle.Style>
-                                                                                    <Style
-                                                                                        TargetType="{x:Type TypeName=Rectangle}">
-                                                                                        <Setter Property="Fill"
-                                                                                            Value="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}" />
-                                                                                        <Style.Triggers>
-                                                                                            <DataTrigger
-                                                                                                Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=Button}}, Path=IsMouseOver}"
-                                                                                                Value="True">
-                                                                                                <Setter Property="Fill"
-                                                                                                    Value="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}" />
-                                                                                            </DataTrigger>
-                                                                                        </Style.Triggers>
-                                                                                    </Style>
-                                                                                </Rectangle.Style>
-                                                                            </Rectangle>
-                                                                        </Button>
-                                                                        <Button Grid.Column="2" Grid.Row="0"
-                                                                                HorizontalAlignment="Right"
-                                                                                Command="{Binding Path=DataContext.PauseGroupCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}}"
-                                                                                CommandParameter="{Binding Path=(CollectionViewGroup.Name)}"
-                                                                                Style="{StaticResource ResourceKey=CleanButton}"
-                                                                                ToolTip="{x:Static Member=localization:Strings.PauseGroup}">
-                                                                            <Rectangle Width="16" Height="16">
-                                                                                <Rectangle.OpacityMask>
-                                                                                    <VisualBrush Stretch="Uniform"
-                                                                                        Visual="{iconPacks:Material Kind=Pause}" />
-                                                                                </Rectangle.OpacityMask>
-                                                                                <Rectangle.Style>
-                                                                                    <Style
-                                                                                        TargetType="{x:Type TypeName=Rectangle}">
-                                                                                        <Setter Property="Fill"
-                                                                                            Value="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}" />
-                                                                                        <Style.Triggers>
-                                                                                            <DataTrigger
-                                                                                                Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=Button}}, Path=IsMouseOver}"
-                                                                                                Value="True">
-                                                                                                <Setter Property="Fill"
-                                                                                                    Value="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}" />
-                                                                                            </DataTrigger>
-                                                                                        </Style.Triggers>
-                                                                                    </Style>
-                                                                                </Rectangle.Style>
-                                                                            </Rectangle>
-                                                                        </Button>
-                                                                        <Button Grid.Column="4" Grid.Row="0"
-                                                                                HorizontalAlignment="Right"
-                                                                                Command="{Binding Path=DataContext.CloseGroupCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}}"
-                                                                                CommandParameter="{Binding Path=(CollectionViewGroup.Name)}"
-                                                                                Style="{StaticResource ResourceKey=CleanButton}"
-                                                                                ToolTip="{x:Static Member=localization:Strings.CloseGroup}">
-                                                                            <Rectangle Width="16" Height="16">
-                                                                                <Rectangle.OpacityMask>
-                                                                                    <VisualBrush Stretch="Fill"
-                                                                                        Visual="{iconPacks:Material Kind=WindowClose}" />
-                                                                                </Rectangle.OpacityMask>
-                                                                                <Rectangle.Style>
-                                                                                    <Style
-                                                                                        TargetType="{x:Type TypeName=Rectangle}">
-                                                                                        <Setter Property="Fill"
-                                                                                            Value="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}" />
-                                                                                        <Style.Triggers>
-                                                                                            <DataTrigger
-                                                                                                Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=Button}}, Path=IsMouseOver}"
-                                                                                                Value="True">
-                                                                                                <Setter Property="Fill"
-                                                                                                    Value="Red" />
-                                                                                            </DataTrigger>
-                                                                                        </Style.Triggers>
-                                                                                    </Style>
-                                                                                </Rectangle.Style>
-                                                                            </Rectangle>
-                                                                        </Button>
-                                                                    </Grid>
+                                                                        <Button.ContextMenu>
+                                                                            <ContextMenu Style="{StaticResource ResourceKey=DefaultContextMenu}">
+                                                                                <MenuItem Header="{x:Static Member=localization:Strings.StartGroup}"
+                                                                                          Command="{Binding Path=Data.StartGroupCommand, Source={StaticResource ResourceKey=BindingProxy}}"
+                                                                                          CommandParameter="{Binding Path=PlacementTarget.Tag, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ContextMenu}}}">
+                                                                                    <MenuItem.Icon>
+                                                                                        <Rectangle Width="16" Height="16"
+                                                                                                   Fill="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}">
+                                                                                            <Rectangle.OpacityMask>
+                                                                                                <VisualBrush Stretch="Uniform"
+                                                                                                        Visual="{iconPacks:Material Kind=Play}" />
+                                                                                            </Rectangle.OpacityMask>
+                                                                                        </Rectangle>
+                                                                                    </MenuItem.Icon>
+                                                                                </MenuItem>
+                                                                                <MenuItem Header="{x:Static Member=localization:Strings.PauseGroup}"
+                                                                                          Command="{Binding Path=Data.PauseGroupCommand, Source={StaticResource ResourceKey=BindingProxy}}"
+                                                                                          CommandParameter="{Binding Path=PlacementTarget.Tag, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ContextMenu}}}">
+                                                                                    <MenuItem.Icon>
+                                                                                        <Rectangle Width="16" Height="16"
+                                                                                                   Fill="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}">
+                                                                                            <Rectangle.OpacityMask>
+                                                                                                <VisualBrush Stretch="Uniform"
+                                                                                                        Visual="{iconPacks:Material Kind=Pause}" />
+                                                                                            </Rectangle.OpacityMask>
+                                                                                        </Rectangle>
+                                                                                    </MenuItem.Icon>
+                                                                                </MenuItem>
+                                                                                <Separator />
+                                                                                <MenuItem Header="{x:Static Member=localization:Strings.CloseGroup}"
+                                                                                          Command="{Binding Path=Data.CloseGroupCommand, Source={StaticResource ResourceKey=BindingProxy}}"
+                                                                                          CommandParameter="{Binding Path=PlacementTarget.Tag, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ContextMenu}}}">
+                                                                                    <MenuItem.Icon>
+                                                                                        <Rectangle Width="16" Height="16"
+                                                                                                   Fill="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}">
+                                                                                            <Rectangle.OpacityMask>
+                                                                                                <VisualBrush Stretch="Fill"
+                                                                                                        Visual="{iconPacks:Material Kind=WindowClose}" />
+                                                                                            </Rectangle.OpacityMask>
+                                                                                        </Rectangle>
+                                                                                    </MenuItem.Icon>
+                                                                                </MenuItem>
+                                                                            </ContextMenu>
+                                                                        </Button.ContextMenu>
+                                                                    </Button>
                                                                 </Grid>
                                                             </Expander.Header>
                                                             <ItemsPresenter />

--- a/Source/NETworkManager/Views/PingMonitorHostView.xaml
+++ b/Source/NETworkManager/Views/PingMonitorHostView.xaml
@@ -208,7 +208,8 @@
                                                         <Expander IsExpanded="True"
                                                                   Style="{StaticResource ResourceKey=DefaultExpander}">
                                                             <Expander.Header>
-                                                                <Grid MouseEnter="GroupHeader_MouseEnter"
+                                                                <Grid x:Name="GroupHeaderGrid"
+                                                                      MouseEnter="GroupHeader_MouseEnter"
                                                                       MouseLeave="GroupHeader_MouseLeave">
                                                                     <Grid.ColumnDefinitions>
                                                                         <ColumnDefinition Width="*" />
@@ -300,6 +301,7 @@
                                                                                   ToolTip="{x:Static Member=localization:Strings.GroupActions}"
                                                                                   Checked="GroupActionsToggle_Checked"
                                                                                   Unchecked="GroupActionsToggle_Unchecked"
+                                                                                  Unloaded="GroupActionsToggle_Unloaded"
                                                                                   Visibility="{Binding Path=IsChecked, RelativeSource={RelativeSource Mode=Self}, Converter={StaticResource ResourceKey=BooleanReverseToVisibilityCollapsedConverter}}">
                                                                         <Rectangle Width="16" Height="16">
                                                                             <Rectangle.OpacityMask>

--- a/Source/NETworkManager/Views/PingMonitorHostView.xaml
+++ b/Source/NETworkManager/Views/PingMonitorHostView.xaml
@@ -196,8 +196,8 @@
                     <ScrollViewer Grid.Column="0" Grid.Row="2"
                                   HorizontalScrollBarVisibility="Auto">
                         <ItemsControl ItemsSource="{Binding Path=HostsView}"
-                                  Visibility="{Binding Path=Hosts.Count, Converter={StaticResource ResourceKey=IntNotZeroToVisibilityCollapsedConverter}}"
-                                  Background="Transparent">
+                                      Visibility="{Binding Path=Hosts.Count, Converter={StaticResource ResourceKey=IntNotZeroToVisibilityCollapsedConverter}}"
+                                      Background="Transparent">
                             <ItemsControl.GroupStyle>
                                 <GroupStyle>
                                     <GroupStyle.ContainerStyle>
@@ -216,92 +216,191 @@
                                                                         <ColumnDefinition Width="10" />
                                                                         <ColumnDefinition Width="Auto" />
                                                                     </Grid.ColumnDefinitions>
+                                                                    <Rectangle Grid.Column="0" Grid.ColumnSpan="5"
+                                                                               Fill="Transparent" />
                                                                     <TextBlock Grid.Column="0" Grid.Row="0"
                                                                                Text="{Binding Path=(CollectionViewGroup.Name)}"
                                                                                Style="{DynamicResource ResourceKey=HeaderTextBlock}" />
                                                                     <StackPanel Grid.Column="2" Grid.Row="0"
-                                                                                Orientation="Horizontal"
-                                                                                VerticalAlignment="Center">
-                                                                        <TextBlock Style="{StaticResource ResourceKey=DefaultTextBlock}"
-                                                                                   Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}">
+                                                                            Orientation="Horizontal"
+                                                                            VerticalAlignment="Center">
+                                                                        <TextBlock
+                                                                            Style="{StaticResource ResourceKey=DefaultTextBlock}"
+                                                                            Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}">
                                                                             <TextBlock.Text>
-                                                                                <MultiBinding Converter="{StaticResource ResourceKey=PingMonitorGroupSummaryConverter}"
-                                                                                              ConverterParameter="Up">
+                                                                                <MultiBinding
+                                                                                    Converter="{StaticResource ResourceKey=PingMonitorGroupSummaryConverter}"
+                                                                                    ConverterParameter="Up">
                                                                                     <Binding />
-                                                                                    <Binding Path="DataContext.HostsChangeVersion"
-                                                                                             RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}" />
-                                                                                    <Binding Source="{x:Static Member=localization:Strings.Up}" />
+                                                                                    <Binding
+                                                                                        Path="DataContext.HostsChangeVersion"
+                                                                                        RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}" />
+                                                                                    <Binding
+                                                                                        Source="{x:Static Member=localization:Strings.Up}" />
                                                                                 </MultiBinding>
                                                                             </TextBlock.Text>
                                                                         </TextBlock>
                                                                         <TextBlock Text="·"
-                                                                                   Style="{StaticResource ResourceKey=DefaultTextBlock}"
-                                                                                   Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}"
-                                                                                   Margin="6,0,6,0" />
-                                                                        <TextBlock Style="{StaticResource ResourceKey=DefaultTextBlock}"
-                                                                                   Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}">
+                                                                                Style="{StaticResource ResourceKey=DefaultTextBlock}"
+                                                                                Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}"
+                                                                                Margin="6,0,6,0" />
+                                                                        <TextBlock
+                                                                            Style="{StaticResource ResourceKey=DefaultTextBlock}"
+                                                                            Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}">
                                                                             <TextBlock.Text>
-                                                                                <MultiBinding Converter="{StaticResource ResourceKey=PingMonitorGroupSummaryConverter}"
-                                                                                              ConverterParameter="Down">
+                                                                                <MultiBinding
+                                                                                    Converter="{StaticResource ResourceKey=PingMonitorGroupSummaryConverter}"
+                                                                                    ConverterParameter="Down">
                                                                                     <Binding />
-                                                                                    <Binding Path="DataContext.HostsChangeVersion"
-                                                                                             RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}" />
-                                                                                    <Binding Source="{x:Static Member=localization:Strings.Down}" />
+                                                                                    <Binding
+                                                                                        Path="DataContext.HostsChangeVersion"
+                                                                                        RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}" />
+                                                                                    <Binding
+                                                                                        Source="{x:Static Member=localization:Strings.Down}" />
                                                                                 </MultiBinding>
                                                                             </TextBlock.Text>
                                                                         </TextBlock>
                                                                         <TextBlock Text="·"
-                                                                                   Style="{StaticResource ResourceKey=DefaultTextBlock}"
-                                                                                   Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}"
-                                                                                   Margin="6,0,6,0"
-                                                                                   Visibility="{Binding ElementName=PausedText, Path=Visibility}" />
+                                                                                Style="{StaticResource ResourceKey=DefaultTextBlock}"
+                                                                                Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}"
+                                                                                Margin="6,0,6,0"
+                                                                                Visibility="{Binding ElementName=PausedText, Path=Visibility}" />
                                                                         <TextBlock x:Name="PausedText"
-                                                                                   Style="{StaticResource ResourceKey=DefaultTextBlock}"
-                                                                                   Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}">
+                                                                                Style="{StaticResource ResourceKey=DefaultTextBlock}"
+                                                                                Foreground="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}">
                                                                             <TextBlock.Text>
-                                                                                <MultiBinding Converter="{StaticResource ResourceKey=PingMonitorGroupSummaryConverter}"
-                                                                                              ConverterParameter="Paused">
+                                                                                <MultiBinding
+                                                                                    Converter="{StaticResource ResourceKey=PingMonitorGroupSummaryConverter}"
+                                                                                    ConverterParameter="Paused">
                                                                                     <Binding />
-                                                                                    <Binding Path="DataContext.HostsChangeVersion"
-                                                                                             RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}" />
-                                                                                    <Binding Source="{x:Static Member=localization:Strings.Paused}" />
+                                                                                    <Binding
+                                                                                        Path="DataContext.HostsChangeVersion"
+                                                                                        RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}" />
+                                                                                    <Binding
+                                                                                        Source="{x:Static Member=localization:Strings.Paused}" />
                                                                                 </MultiBinding>
                                                                             </TextBlock.Text>
                                                                             <TextBlock.Visibility>
-                                                                                <MultiBinding Converter="{StaticResource ResourceKey=PingMonitorGroupSummaryConverter}"
-                                                                                              ConverterParameter="PausedVisibility">
+                                                                                <MultiBinding
+                                                                                    Converter="{StaticResource ResourceKey=PingMonitorGroupSummaryConverter}"
+                                                                                    ConverterParameter="PausedVisibility">
                                                                                     <Binding />
-                                                                                    <Binding Path="DataContext.HostsChangeVersion"
-                                                                                             RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}" />
+                                                                                    <Binding
+                                                                                        Path="DataContext.HostsChangeVersion"
+                                                                                        RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}" />
                                                                                 </MultiBinding>
                                                                             </TextBlock.Visibility>
                                                                         </TextBlock>
                                                                     </StackPanel>
-                                                                    <Button Grid.Column="4" Grid.Row="0"
-                                                                            HorizontalAlignment="Right"
-                                                                            Command="{Binding Path=DataContext.CloseGroupCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}}"
-                                                                            CommandParameter="{Binding Path=(CollectionViewGroup.Name)}"
-                                                                            Style="{StaticResource ResourceKey=CleanButton}"
-                                                                            ToolTip="{x:Static Member=localization:Strings.CloseGroup}">
-                                                                        <Rectangle Width="16" Height="16">
-                                                                            <Rectangle.OpacityMask>
-                                                                                <VisualBrush Stretch="Fill"
-                                                                                    Visual="{iconPacks:Material Kind=WindowClose}" />
-                                                                            </Rectangle.OpacityMask>
-                                                                            <Rectangle.Style>
-                                                                                <Style TargetType="{x:Type TypeName=Rectangle}">
-                                                                                    <Setter Property="Fill" Value="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}" />
-                                                                                    <Style.Triggers>
-                                                                                        <DataTrigger
-                                                                                            Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=Button}}, Path=IsMouseOver}"
-                                                                                            Value="True">
-                                                                                            <Setter Property="Fill" Value="Red" />
-                                                                                        </DataTrigger>
-                                                                                    </Style.Triggers>
-                                                                                </Style>
-                                                                            </Rectangle.Style>
-                                                                        </Rectangle>
-                                                                    </Button>
+                                                                    <Rectangle Grid.Column="4" Grid.Row="0"
+                                                                               Width="16" Height="16"
+                                                                               Visibility="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=Grid}}, Converter={StaticResource ResourceKey=BooleanReverseToVisibilityCollapsedConverter}}">
+                                                                        <Rectangle.OpacityMask>
+                                                                            <VisualBrush Stretch="Uniform"
+                                                                                    Visual="{iconPacks:Material Kind=DotsVertical}" />
+                                                                        </Rectangle.OpacityMask>
+                                                                        <Rectangle.Style>
+                                                                            <Style
+                                                                                TargetType="{x:Type TypeName=Rectangle}">
+                                                                                <Setter Property="Fill"
+                                                                                    Value="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}" />
+                                                                            </Style>
+                                                                        </Rectangle.Style>
+                                                                    </Rectangle>
+                                                                    <Grid Grid.Column="4" Grid.Row="0"
+                                                                          Visibility="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=Grid}}, Converter={StaticResource ResourceKey=BooleanToVisibilityCollapsedConverter}}">
+                                                                        <Grid.ColumnDefinitions>
+                                                                            <ColumnDefinition Width="Auto" />
+                                                                            <ColumnDefinition Width="10" />
+                                                                            <ColumnDefinition Width="Auto" />
+                                                                            <ColumnDefinition Width="10" />
+                                                                            <ColumnDefinition Width="Auto" />
+                                                                        </Grid.ColumnDefinitions>
+                                                                        <Button Grid.Column="0" Grid.Row="0"
+                                                                                HorizontalAlignment="Right"
+                                                                                Command="{Binding Path=DataContext.StartGroupCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}}"
+                                                                                CommandParameter="{Binding Path=(CollectionViewGroup.Name)}"
+                                                                                Style="{StaticResource ResourceKey=CleanButton}"
+                                                                                ToolTip="{x:Static Member=localization:Strings.StartGroup}">
+                                                                            <Rectangle Width="16" Height="16">
+                                                                                <Rectangle.OpacityMask>
+                                                                                    <VisualBrush Stretch="Uniform"
+                                                                                        Visual="{iconPacks:Material Kind=Play}" />
+                                                                                </Rectangle.OpacityMask>
+                                                                                <Rectangle.Style>
+                                                                                    <Style
+                                                                                        TargetType="{x:Type TypeName=Rectangle}">
+                                                                                        <Setter Property="Fill"
+                                                                                            Value="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}" />
+                                                                                        <Style.Triggers>
+                                                                                            <DataTrigger
+                                                                                                Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=Button}}, Path=IsMouseOver}"
+                                                                                                Value="True">
+                                                                                                <Setter Property="Fill"
+                                                                                                    Value="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}" />
+                                                                                            </DataTrigger>
+                                                                                        </Style.Triggers>
+                                                                                    </Style>
+                                                                                </Rectangle.Style>
+                                                                            </Rectangle>
+                                                                        </Button>
+                                                                        <Button Grid.Column="2" Grid.Row="0"
+                                                                                HorizontalAlignment="Right"
+                                                                                Command="{Binding Path=DataContext.PauseGroupCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}}"
+                                                                                CommandParameter="{Binding Path=(CollectionViewGroup.Name)}"
+                                                                                Style="{StaticResource ResourceKey=CleanButton}"
+                                                                                ToolTip="{x:Static Member=localization:Strings.PauseGroup}">
+                                                                            <Rectangle Width="16" Height="16">
+                                                                                <Rectangle.OpacityMask>
+                                                                                    <VisualBrush Stretch="Uniform"
+                                                                                        Visual="{iconPacks:Material Kind=Pause}" />
+                                                                                </Rectangle.OpacityMask>
+                                                                                <Rectangle.Style>
+                                                                                    <Style
+                                                                                        TargetType="{x:Type TypeName=Rectangle}">
+                                                                                        <Setter Property="Fill"
+                                                                                            Value="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}" />
+                                                                                        <Style.Triggers>
+                                                                                            <DataTrigger
+                                                                                                Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=Button}}, Path=IsMouseOver}"
+                                                                                                Value="True">
+                                                                                                <Setter Property="Fill"
+                                                                                                    Value="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}" />
+                                                                                            </DataTrigger>
+                                                                                        </Style.Triggers>
+                                                                                    </Style>
+                                                                                </Rectangle.Style>
+                                                                            </Rectangle>
+                                                                        </Button>
+                                                                        <Button Grid.Column="4" Grid.Row="0"
+                                                                                HorizontalAlignment="Right"
+                                                                                Command="{Binding Path=DataContext.CloseGroupCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ItemsControl}}}"
+                                                                                CommandParameter="{Binding Path=(CollectionViewGroup.Name)}"
+                                                                                Style="{StaticResource ResourceKey=CleanButton}"
+                                                                                ToolTip="{x:Static Member=localization:Strings.CloseGroup}">
+                                                                            <Rectangle Width="16" Height="16">
+                                                                                <Rectangle.OpacityMask>
+                                                                                    <VisualBrush Stretch="Fill"
+                                                                                        Visual="{iconPacks:Material Kind=WindowClose}" />
+                                                                                </Rectangle.OpacityMask>
+                                                                                <Rectangle.Style>
+                                                                                    <Style
+                                                                                        TargetType="{x:Type TypeName=Rectangle}">
+                                                                                        <Setter Property="Fill"
+                                                                                            Value="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}" />
+                                                                                        <Style.Triggers>
+                                                                                            <DataTrigger
+                                                                                                Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=Button}}, Path=IsMouseOver}"
+                                                                                                Value="True">
+                                                                                                <Setter Property="Fill"
+                                                                                                    Value="Red" />
+                                                                                            </DataTrigger>
+                                                                                        </Style.Triggers>
+                                                                                    </Style>
+                                                                                </Rectangle.Style>
+                                                                            </Rectangle>
+                                                                        </Button>
+                                                                    </Grid>
                                                                 </Grid>
                                                             </Expander.Header>
                                                             <ItemsPresenter />
@@ -337,8 +436,8 @@
                       Focusable="False"
                       Style="{StaticResource ResourceKey=VerticalGridSplitter}" />
         <hostControls:ProfileExpanderPanel Grid.Column="2" Grid.Row="0"
-                                            ProfileItemTemplate="{StaticResource ResourceKey=PingMonitorProfileItemTemplate}"
-                                            ProfileContextMenuExtraItems="{StaticResource ResourceKey=PingMonitorProfileContextMenuExtraItems}"
-                                            RunProfileCommand="{Binding Path=PingProfileCommand}" />
+                                           ProfileItemTemplate="{StaticResource ResourceKey=PingMonitorProfileItemTemplate}"
+                                           ProfileContextMenuExtraItems="{StaticResource ResourceKey=PingMonitorProfileContextMenuExtraItems}"
+                                           RunProfileCommand="{Binding Path=PingProfileCommand}" />
     </Grid>
 </UserControl>

--- a/Source/NETworkManager/Views/PingMonitorHostView.xaml
+++ b/Source/NETworkManager/Views/PingMonitorHostView.xaml
@@ -208,7 +208,8 @@
                                                         <Expander IsExpanded="True"
                                                                   Style="{StaticResource ResourceKey=DefaultExpander}">
                                                             <Expander.Header>
-                                                                <Grid>
+                                                                <Grid MouseEnter="GroupHeader_MouseEnter"
+                                                                      MouseLeave="GroupHeader_MouseLeave">
                                                                     <Grid.ColumnDefinitions>
                                                                         <ColumnDefinition Width="*" />
                                                                         <ColumnDefinition Width="10" />
@@ -292,23 +293,38 @@
                                                                             </TextBlock.Visibility>
                                                                         </TextBlock>
                                                                     </StackPanel>
-                                                                    <Rectangle Grid.Column="4" Grid.Row="0"
-                                                                               Width="16" Height="16"
-                                                                               Visibility="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=Grid}}, Converter={StaticResource ResourceKey=BooleanReverseToVisibilityCollapsedConverter}}">
-                                                                        <Rectangle.OpacityMask>
-                                                                            <VisualBrush Stretch="Uniform"
-                                                                                    Visual="{iconPacks:Material Kind=DotsVertical}" />
-                                                                        </Rectangle.OpacityMask>
-                                                                        <Rectangle.Style>
-                                                                            <Style
-                                                                                TargetType="{x:Type TypeName=Rectangle}">
-                                                                                <Setter Property="Fill"
-                                                                                    Value="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}" />
-                                                                            </Style>
-                                                                        </Rectangle.Style>
-                                                                    </Rectangle>
+                                                                    <ToggleButton x:Name="GroupActionsToggle"
+                                                                                  Grid.Column="4" Grid.Row="0"
+                                                                                  HorizontalAlignment="Right"
+                                                                                  Style="{StaticResource ResourceKey=CleanToggleButton}"
+                                                                                  ToolTip="{x:Static Member=localization:Strings.GroupActions}"
+                                                                                  Checked="GroupActionsToggle_Checked"
+                                                                                  Unchecked="GroupActionsToggle_Unchecked"
+                                                                                  Visibility="{Binding Path=IsChecked, RelativeSource={RelativeSource Mode=Self}, Converter={StaticResource ResourceKey=BooleanReverseToVisibilityCollapsedConverter}}">
+                                                                        <Rectangle Width="16" Height="16">
+                                                                            <Rectangle.OpacityMask>
+                                                                                <VisualBrush Stretch="Uniform"
+                                                                                        Visual="{iconPacks:Material Kind=DotsVertical}" />
+                                                                            </Rectangle.OpacityMask>
+                                                                            <Rectangle.Style>
+                                                                                <Style
+                                                                                    TargetType="{x:Type TypeName=Rectangle}">
+                                                                                    <Setter Property="Fill"
+                                                                                        Value="{DynamicResource ResourceKey=MahApps.Brushes.Gray3}" />
+                                                                                    <Style.Triggers>
+                                                                                        <DataTrigger
+                                                                                            Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=ToggleButton}}, Path=IsMouseOver}"
+                                                                                            Value="True">
+                                                                                            <Setter Property="Fill"
+                                                                                                Value="{DynamicResource ResourceKey=MahApps.Brushes.Gray5}" />
+                                                                                        </DataTrigger>
+                                                                                    </Style.Triggers>
+                                                                                </Style>
+                                                                            </Rectangle.Style>
+                                                                        </Rectangle>
+                                                                    </ToggleButton>
                                                                     <Grid Grid.Column="4" Grid.Row="0"
-                                                                          Visibility="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TypeName=Grid}}, Converter={StaticResource ResourceKey=BooleanToVisibilityCollapsedConverter}}">
+                                                                          Visibility="{Binding Path=IsChecked, ElementName=GroupActionsToggle, Converter={StaticResource ResourceKey=BooleanToVisibilityCollapsedConverter}}">
                                                                         <Grid.ColumnDefinitions>
                                                                             <ColumnDefinition Width="Auto" />
                                                                             <ColumnDefinition Width="10" />

--- a/Source/NETworkManager/Views/PingMonitorHostView.xaml.cs
+++ b/Source/NETworkManager/Views/PingMonitorHostView.xaml.cs
@@ -1,9 +1,21 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using System.Windows.Threading;
 using NETworkManager.ViewModels;
 
 namespace NETworkManager.Views;
 
 public partial class PingMonitorHostView
 {
+    /// <summary>
+    ///     Delay before a group's action buttons (Start/Pause/Close), revealed via mouse-over or by
+    ///     clicking/tapping the "..." toggle, are hidden again after the last interaction.
+    /// </summary>
+    private static readonly TimeSpan GroupActionsAutoCloseDelay = TimeSpan.FromSeconds(20);
+
     private readonly PingMonitorHostViewModel _viewModel = new();
 
     public PingMonitorHostView()
@@ -26,5 +38,79 @@ public partial class PingMonitorHostView
     public void OnViewVisible()
     {
         _viewModel.OnViewVisible();
+    }
+
+    /// <summary>
+    ///     Reveals the group's action buttons and cancels any pending auto-close, so hovering the
+    ///     header keeps them visible for as long as the mouse stays over it.
+    /// </summary>
+    private void GroupHeader_MouseEnter(object sender, MouseEventArgs e)
+    {
+        if (((Grid)sender).FindName("GroupActionsToggle") is not ToggleButton toggle)
+            return;
+
+        StopGroupActionsAutoCloseTimer(toggle);
+        toggle.IsChecked = true;
+    }
+
+    /// <summary>
+    ///     Starts the auto-close countdown once the mouse leaves the header, instead of hiding the
+    ///     action buttons immediately - this avoids them flickering away while moving the mouse
+    ///     from the header onto one of the buttons.
+    /// </summary>
+    private void GroupHeader_MouseLeave(object sender, MouseEventArgs e)
+    {
+        if (((Grid)sender).FindName("GroupActionsToggle") is not ToggleButton toggle)
+            return;
+
+        if (toggle.IsChecked == true)
+            StartGroupActionsAutoCloseTimer(toggle);
+    }
+
+    /// <summary>
+    ///     Starts the auto-close countdown when the toggle is checked by a click/tap rather than by
+    ///     hovering the header (<see cref="GroupHeader_MouseEnter"/> already handles the hover case,
+    ///     and cancels this if the mouse is still over the header).
+    /// </summary>
+    private void GroupActionsToggle_Checked(object sender, RoutedEventArgs e)
+    {
+        var toggle = (ToggleButton)sender;
+
+        if (!IsMouseOverGroupHeader(toggle))
+            StartGroupActionsAutoCloseTimer(toggle);
+    }
+
+    private void GroupActionsToggle_Unchecked(object sender, RoutedEventArgs e)
+    {
+        StopGroupActionsAutoCloseTimer((ToggleButton)sender);
+    }
+
+    private static bool IsMouseOverGroupHeader(ToggleButton toggle)
+    {
+        return toggle.Parent is Grid headerGrid && headerGrid.IsMouseOver;
+    }
+
+    private static void StartGroupActionsAutoCloseTimer(ToggleButton toggle)
+    {
+        StopGroupActionsAutoCloseTimer(toggle);
+
+        var timer = new DispatcherTimer { Interval = GroupActionsAutoCloseDelay };
+        timer.Tick += (_, _) =>
+        {
+            StopGroupActionsAutoCloseTimer(toggle);
+            toggle.IsChecked = false;
+        };
+
+        toggle.Tag = timer;
+        timer.Start();
+    }
+
+    private static void StopGroupActionsAutoCloseTimer(ToggleButton toggle)
+    {
+        if (toggle.Tag is not DispatcherTimer timer)
+            return;
+
+        timer.Stop();
+        toggle.Tag = null;
     }
 }

--- a/Source/NETworkManager/Views/PingMonitorHostView.xaml.cs
+++ b/Source/NETworkManager/Views/PingMonitorHostView.xaml.cs
@@ -1,21 +1,11 @@
-using System;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
-using System.Windows.Input;
-using System.Windows.Threading;
 using NETworkManager.ViewModels;
 
 namespace NETworkManager.Views;
 
 public partial class PingMonitorHostView
 {
-    /// <summary>
-    ///     Delay before a group's action buttons (Start/Pause/Close), revealed via mouse-over or by
-    ///     clicking/tapping the "..." toggle, are hidden again after the last interaction.
-    /// </summary>
-    private static readonly TimeSpan GroupActionsAutoCloseDelay = TimeSpan.FromSeconds(20);
-
     private readonly PingMonitorHostViewModel _viewModel = new();
 
     public PingMonitorHostView()
@@ -41,86 +31,15 @@ public partial class PingMonitorHostView
     }
 
     /// <summary>
-    ///     Reveals the group's action buttons and cancels any pending auto-close, so hovering the
-    ///     header keeps them visible for as long as the mouse stays over it.
+    ///     Opens the group actions context menu on a normal click (not just right-click), so it
+    ///     works the same way for mouse, touch and keyboard activation. PlacementTarget is set
+    ///     explicitly since it isn't populated automatically when opening the menu this way, and
+    ///     the menu items rely on it to reach the group name (see Button.Tag in the XAML).
     /// </summary>
-    private void GroupHeader_MouseEnter(object sender, MouseEventArgs e)
+    private void GroupActionsButton_Click(object sender, RoutedEventArgs e)
     {
-        if (((Grid)sender).FindName("GroupActionsToggle") is not ToggleButton toggle)
-            return;
-
-        StopGroupActionsAutoCloseTimer(toggle);
-        toggle.IsChecked = true;
-    }
-
-    /// <summary>
-    ///     Starts the auto-close countdown once the mouse leaves the header, instead of hiding the
-    ///     action buttons immediately - this avoids them flickering away while moving the mouse
-    ///     from the header onto one of the buttons.
-    /// </summary>
-    private void GroupHeader_MouseLeave(object sender, MouseEventArgs e)
-    {
-        if (((Grid)sender).FindName("GroupActionsToggle") is not ToggleButton toggle)
-            return;
-
-        if (toggle.IsChecked == true)
-            StartGroupActionsAutoCloseTimer(toggle);
-    }
-
-    /// <summary>
-    ///     Starts the auto-close countdown when the toggle is checked by a click/tap rather than by
-    ///     hovering the header (<see cref="GroupHeader_MouseEnter"/> already handles the hover case,
-    ///     and cancels this if the mouse is still over the header).
-    /// </summary>
-    private void GroupActionsToggle_Checked(object sender, RoutedEventArgs e)
-    {
-        var toggle = (ToggleButton)sender;
-
-        if (!IsMouseOverGroupHeader(toggle))
-            StartGroupActionsAutoCloseTimer(toggle);
-    }
-
-    private void GroupActionsToggle_Unchecked(object sender, RoutedEventArgs e)
-    {
-        StopGroupActionsAutoCloseTimer((ToggleButton)sender);
-    }
-
-    /// <summary>
-    ///     Stops any pending auto-close timer when the group (and its toggle) is torn down, e.g.
-    ///     because the group was closed - otherwise the timer would keep the detached toggle alive
-    ///     until it fires.
-    /// </summary>
-    private void GroupActionsToggle_Unloaded(object sender, RoutedEventArgs e)
-    {
-        StopGroupActionsAutoCloseTimer((ToggleButton)sender);
-    }
-
-    private static bool IsMouseOverGroupHeader(ToggleButton toggle)
-    {
-        return toggle.FindName("GroupHeaderGrid") is Grid headerGrid && headerGrid.IsMouseOver;
-    }
-
-    private static void StartGroupActionsAutoCloseTimer(ToggleButton toggle)
-    {
-        StopGroupActionsAutoCloseTimer(toggle);
-
-        var timer = new DispatcherTimer { Interval = GroupActionsAutoCloseDelay };
-        timer.Tick += (_, _) =>
-        {
-            StopGroupActionsAutoCloseTimer(toggle);
-            toggle.IsChecked = false;
-        };
-
-        toggle.Tag = timer;
-        timer.Start();
-    }
-
-    private static void StopGroupActionsAutoCloseTimer(ToggleButton toggle)
-    {
-        if (toggle.Tag is not DispatcherTimer timer)
-            return;
-
-        timer.Stop();
-        toggle.Tag = null;
+        var button = (Button)sender;
+        button.ContextMenu.PlacementTarget = button;
+        button.ContextMenu.IsOpen = true;
     }
 }

--- a/Source/NETworkManager/Views/PingMonitorHostView.xaml.cs
+++ b/Source/NETworkManager/Views/PingMonitorHostView.xaml.cs
@@ -85,9 +85,19 @@ public partial class PingMonitorHostView
         StopGroupActionsAutoCloseTimer((ToggleButton)sender);
     }
 
+    /// <summary>
+    ///     Stops any pending auto-close timer when the group (and its toggle) is torn down, e.g.
+    ///     because the group was closed - otherwise the timer would keep the detached toggle alive
+    ///     until it fires.
+    /// </summary>
+    private void GroupActionsToggle_Unloaded(object sender, RoutedEventArgs e)
+    {
+        StopGroupActionsAutoCloseTimer((ToggleButton)sender);
+    }
+
     private static bool IsMouseOverGroupHeader(ToggleButton toggle)
     {
-        return toggle.Parent is Grid headerGrid && headerGrid.IsMouseOver;
+        return toggle.FindName("GroupHeaderGrid") is Grid headerGrid && headerGrid.IsMouseOver;
     }
 
     private static void StartGroupActionsAutoCloseTimer(ToggleButton toggle)

--- a/Website/docs/application/ping-monitor.md
+++ b/Website/docs/application/ping-monitor.md
@@ -52,6 +52,18 @@ You can interact with the chart to inspect past results:
 
 When you zoom or pan, the chart leaves live mode and stops scrolling. A **Live** button then appears in the top-right corner of the chart — click it to return to live mode and resume auto-scrolling.
 
+### Groups
+
+Hosts are grouped by their profile group (or **Hosts** if none is set). Each group header shows a live count of hosts that are up, down and paused (**Paused** is only shown while at least one host in the group is paused).
+
+Hover over a group header to reveal its action buttons:
+
+| Action | Description |
+|--------|-------------|
+| **Start** | Starts every host in the group that isn't currently running |
+| **Pause** | Pauses every host in the group that's currently running |
+| **Close** | Stops and removes every host in the group |
+
 ### Context menu
 
 Right-click a monitored host (anywhere except the chart) to open the context menu:

--- a/Website/docs/application/ping-monitor.md
+++ b/Website/docs/application/ping-monitor.md
@@ -56,7 +56,7 @@ When you zoom or pan, the chart leaves live mode and stops scrolling. A **Live**
 
 Hosts are grouped by their profile group (or **Hosts** if none is set). Each group header shows a live count of hosts that are up, down and paused (**Paused** is only shown while at least one host in the group is paused).
 
-Hover over a group header to reveal its action buttons. Without a mouse (touch or keyboard), click/tap the **⋮** icon on the right instead - the buttons then stay visible for 20 seconds, or as long as you keep hovering.
+Click/tap the **⋮** icon on the right of a group header to open its action menu:
 
 | Action | Description |
 |--------|-------------|

--- a/Website/docs/application/ping-monitor.md
+++ b/Website/docs/application/ping-monitor.md
@@ -56,7 +56,7 @@ When you zoom or pan, the chart leaves live mode and stops scrolling. A **Live**
 
 Hosts are grouped by their profile group (or **Hosts** if none is set). Each group header shows a live count of hosts that are up, down and paused (**Paused** is only shown while at least one host in the group is paused).
 
-Hover over a group header to reveal its action buttons:
+Hover over a group header to reveal its action buttons. Without a mouse (touch or keyboard), click/tap the **⋮** icon on the right instead - the buttons then stay visible for 20 seconds, or as long as you keep hovering.
 
 | Action | Description |
 |--------|-------------|

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -55,6 +55,7 @@ Release date: **xx.xx.2026**
 **Ping Monitor**
 
 - Added a live count of hosts up/down (and paused, if any) per group, next to the group's close button. [#3572](https://github.com/BornToBeRoot/NETworkManager/pull/3572)
+- Added **Start** and **Pause** buttons to each group header (shown next to the close button on mouse-over), to start every paused host in the group or pause every running one at once. [#XXXX](https://github.com/BornToBeRoot/NETworkManager/pull/XXXX)
 - Reworked each monitored host's card: the collapsed quick info now shows labeled values (`Received: X · Lost: Y · Packet loss: Z%`) instead of unlabeled numbers, the expanded view shows only the latency chart (with more room, since Hostname/IP address are already visible in the header) and the last status change time moved to a tooltip on the connectivity icon. The **Status change** field was also renamed to **Last status change**. [#3572](https://github.com/BornToBeRoot/NETworkManager/pull/3572)
 - Host input now accepts newline-separated hosts (one per line, e.g. a column pasted from Excel), converted automatically to the semicolon-separated form. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
 - Host input now supports shorthand IPv4 ranges like `192.168.0.1-100`, in addition to the existing `192.168.0.0-192.168.0.100` and `192.168.[0-100].1` range formats. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -55,7 +55,7 @@ Release date: **xx.xx.2026**
 **Ping Monitor**
 
 - Added a live count of hosts up/down (and paused, if any) per group, next to the group's close button. [#3572](https://github.com/BornToBeRoot/NETworkManager/pull/3572)
-- Added **Start** and **Pause** buttons to each group header (shown next to the close button on mouse-over), to start every paused host in the group or pause every running one at once. [#3575](https://github.com/BornToBeRoot/NETworkManager/pull/3575)
+- Added **Start** and **Pause** buttons to each group header, to start every paused host in the group or pause every running one at once. They're shown next to the close button on mouse-over, or by clicking/tapping the **⋮** icon (for touch and keyboard use). [#3575](https://github.com/BornToBeRoot/NETworkManager/pull/3575)
 - Reworked each monitored host's card: the collapsed quick info now shows labeled values (`Received: X · Lost: Y · Packet loss: Z%`) instead of unlabeled numbers, the expanded view shows only the latency chart (with more room, since Hostname/IP address are already visible in the header) and the last status change time moved to a tooltip on the connectivity icon. The **Status change** field was also renamed to **Last status change**. [#3572](https://github.com/BornToBeRoot/NETworkManager/pull/3572)
 - Host input now accepts newline-separated hosts (one per line, e.g. a column pasted from Excel), converted automatically to the semicolon-separated form. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
 - Host input now supports shorthand IPv4 ranges like `192.168.0.1-100`, in addition to the existing `192.168.0.0-192.168.0.100` and `192.168.[0-100].1` range formats. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -55,7 +55,7 @@ Release date: **xx.xx.2026**
 **Ping Monitor**
 
 - Added a live count of hosts up/down (and paused, if any) per group, next to the group's close button. [#3572](https://github.com/BornToBeRoot/NETworkManager/pull/3572)
-- Added **Start** and **Pause** buttons to each group header (shown next to the close button on mouse-over), to start every paused host in the group or pause every running one at once. [#XXXX](https://github.com/BornToBeRoot/NETworkManager/pull/XXXX)
+- Added **Start** and **Pause** buttons to each group header (shown next to the close button on mouse-over), to start every paused host in the group or pause every running one at once. [#3575](https://github.com/BornToBeRoot/NETworkManager/pull/3575)
 - Reworked each monitored host's card: the collapsed quick info now shows labeled values (`Received: X · Lost: Y · Packet loss: Z%`) instead of unlabeled numbers, the expanded view shows only the latency chart (with more room, since Hostname/IP address are already visible in the header) and the last status change time moved to a tooltip on the connectivity icon. The **Status change** field was also renamed to **Last status change**. [#3572](https://github.com/BornToBeRoot/NETworkManager/pull/3572)
 - Host input now accepts newline-separated hosts (one per line, e.g. a column pasted from Excel), converted automatically to the semicolon-separated form. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
 - Host input now supports shorthand IPv4 ranges like `192.168.0.1-100`, in addition to the existing `192.168.0.0-192.168.0.100` and `192.168.[0-100].1` range formats. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)

--- a/Website/docs/changelog/next-release.md
+++ b/Website/docs/changelog/next-release.md
@@ -54,8 +54,8 @@ Release date: **xx.xx.2026**
 
 **Ping Monitor**
 
-- Added a live count of hosts up/down (and paused, if any) per group, next to the group's close button. [#3572](https://github.com/BornToBeRoot/NETworkManager/pull/3572)
-- Added **Start** and **Pause** buttons to each group header, to start every paused host in the group or pause every running one at once. They're shown next to the close button on mouse-over, or by clicking/tapping the **⋮** icon (for touch and keyboard use). [#3575](https://github.com/BornToBeRoot/NETworkManager/pull/3575)
+- Added a live count of hosts up/down (and paused, if any) to each group header. [#3572](https://github.com/BornToBeRoot/NETworkManager/pull/3572)
+- Added **Start** and **Pause** actions to each group header (next to the existing **Close**), to start every paused host in the group or pause every running one at once. Click/tap the **⋮** icon to open the group's action menu. [#3575](https://github.com/BornToBeRoot/NETworkManager/pull/3575)
 - Reworked each monitored host's card: the collapsed quick info now shows labeled values (`Received: X · Lost: Y · Packet loss: Z%`) instead of unlabeled numbers, the expanded view shows only the latency chart (with more room, since Hostname/IP address are already visible in the header) and the last status change time moved to a tooltip on the connectivity icon. The **Status change** field was also renamed to **Last status change**. [#3572](https://github.com/BornToBeRoot/NETworkManager/pull/3572)
 - Host input now accepts newline-separated hosts (one per line, e.g. a column pasted from Excel), converted automatically to the semicolon-separated form. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)
 - Host input now supports shorthand IPv4 ranges like `192.168.0.1-100`, in addition to the existing `192.168.0.0-192.168.0.100` and `192.168.[0-100].1` range formats. [#3568](https://github.com/BornToBeRoot/NETworkManager/pull/3568)


### PR DESCRIPTION
## Changes proposed in this pull request

- Add start & pause button per group in ping monitor
- Button will be visible on mouse over

## Related issue(s)

- Fixes #3507

## To-Do

- [x] Update [documentation](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs) to reflect this changes
- [x] Update [changelog](https://github.com/BornToBeRoot/NETworkManager/tree/main/Website/docs/changelog) to reflect this changes

## Contributing

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributing guidelines](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/BornToBeRoot/NETworkManager/blob/main/CODE_OF_CONDUCT.md).
- [x] I have have added my name, username or email to the [contributors](https://github.com/BornToBeRoot/NETworkManager/blob/main/CONTRIBUTORS.md) list or don't want to.
- [x] The code or resource is compatible with the [GNU General Public License v3.0](https://github.com/BornToBeRoot/NETworkManager/blob/main/LICENSE).
